### PR TITLE
fix throws information in ComputedConstant Javadoc

### DIFF
--- a/src/java.base/share/classes/java/lang/ComputedConstant.java
+++ b/src/java.base/share/classes/java/lang/ComputedConstant.java
@@ -291,7 +291,6 @@ public sealed interface ComputedConstant<V>
      * the binding completes (successfully or not).  Otherwise, this method is guaranteed to be lock-free.
      *
      * @param other to use if no value neither is bound nor can be bound (can be null)
-     * @throws NoSuchElementException if a value cannot be bound
      * @throws StackOverflowError     if a circular dependency is detected (i.e. the provider calls itself
      *                                directly or indirectly in the same thread).
      * @throws Error                  if the provider throws an Error


### PR DESCRIPTION
The [current Javadoc of ComputedConstant#orElse](https://github.com/openjdk/leyden/blob/184998a2b3b720a6718f0caa2a747f1c24604bdf/src/java.base/share/classes/java/lang/ComputedConstant.java#L294) mentions throwing a `NoSuchElementException` in case the element cannot be bound.
However, the Javadoc also mentions returning the passed value in that case.

If we take a look at the code for that in the `computed-constants` branch: https://github.com/openjdk/leyden/blob/b9219784cc277417dc112a7fbf652bdc021cf806/src/java.base/share/classes/jdk/internal/constant/AbstractComputedConstant.java#L127 
and 
https://github.com/openjdk/leyden/blob/b9219784cc277417dc112a7fbf652bdc021cf806/src/java.base/share/classes/jdk/internal/constant/AbstractComputedConstant.java#L161C27-L161C27
we can see that `rethrow` parameter is false and no `NoSuchElementException` is thrown: https://github.com/openjdk/leyden/blob/b9219784cc277417dc112a7fbf652bdc021cf806/src/java.base/share/classes/jdk/internal/constant/AbstractComputedConstant.java#L183-L186

I think the `@throws NoSuchElementException` should be removed from `ComputedConstant#orElse`:
https://github.com/openjdk/leyden/blob/b9219784cc277417dc112a7fbf652bdc021cf806/src/java.base/share/classes/java/lang/ComputedConstant.java#L294C19-L294C19


I also reported this here: https://mail.openjdk.org/pipermail/leyden-dev/2023-August/000248.html