### PR TITLE
ComputedConstantList: replace CAS+volatile get with CAE

### DIFF
--- a/src/java.base/share/classes/jdk/internal/constant/MethodHandleComputedConstant.java
+++ b/src/java.base/share/classes/jdk/internal/constant/MethodHandleComputedConstant.java
@@ -40,6 +40,8 @@ public final class MethodHandleComputedConstant<V>
     V evaluate(MethodHandle provider) {
         try {
             return (V) provider.invoke();
+        } catch (Error e) {
+            throw e;
         } catch (Throwable e) {
             throw new IllegalArgumentException(e);
         }

--- a/src/java.base/share/classes/jdk/internal/constant/OnDemandComputedConstantList.java
+++ b/src/java.base/share/classes/jdk/internal/constant/OnDemandComputedConstantList.java
@@ -50,14 +50,7 @@ public final class OnDemandComputedConstantList<V>
             return v;
         }
 
-        // Several candidates might be created ...
-        v = ListElementComputedConstant.create(index, provider);
-        // ... but only one will be selected
-        if (!casElement(index, v)) {
-            // Someone else created the selected element
-            v = elementVolatile(index);
-        }
-        return v;
+        return caeElement(index, ListElementComputedConstant.create(index, provider));
     }
 
     // Accessors
@@ -67,8 +60,13 @@ public final class OnDemandComputedConstantList<V>
         return (ComputedConstant<V>) Unsafe.getUnsafe().getReferenceVolatile(values, offset(index));
     }
 
-    private boolean casElement(int index, Object o) {
-        return Unsafe.getUnsafe().compareAndSetReference(values, offset(index), null, o);
+    private ComputedConstant<V> caeElement(int index, ComputedConstant<V> created) {
+        // try to store our newly-created CC
+        @SuppressWarnings("unchecked")
+        var witness = (ComputedConstant<V>) Unsafe.getUnsafe()
+                .compareAndExchangeReference(values, offset(index), null, created);
+        // will use the witness CC someone else created if it exists
+        return witness == null ? created : witness;
     }
 
     private static long offset(int index) {


### PR DESCRIPTION
1. MH's Errors like OutOfMemoryError should be propagated
2. List CC can use CAE instead of CAS+getVolatile

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/3/head:pull/3` \
`$ git checkout pull/3`

Update a local copy of the PR: \
`$ git checkout pull/3` \
`$ git pull https://git.openjdk.org/leyden.git pull/3/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3`

View PR using the GUI difftool: \
`$ git pr show -t 3`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/3.diff">https://git.openjdk.org/leyden/pull/3.diff</a>

</details>
