### PR TITLE
Avoid delayed profiling when MethodTrainingData is not available

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -1424,7 +1424,8 @@ CompLevel CompilationPolicy::common(const methodHandle& method, CompLevel cur_le
   if (force_comp_at_level_simple(method)) {
     next_level = CompLevel_simple;
   } else {
-    if (MethodTrainingData::have_data()) {
+    MethodTrainingData* mtd = MethodTrainingData::find(method);
+    if (MethodTrainingData::have_data() && mtd != nullptr) {
       next_level = trained_transition(method, cur_level, THREAD);
       if (cur_level == next_level) {
         // If the trained transition logic returns the same level check the standard transition function


### PR DESCRIPTION
If there is no `MethodTrainingData` associate with a method, its full profile compilation can get delayed.

In `CompilationPolicy::common` [0] the call to `trained_transition` will return same level as the current level if MethodTrainingData is null. This prompts the subsequent call to `standard_transition` to be done with delay on, which prevents full profile compilation of the method. It can lead to delay in warm-up.

[0] https://github.com/openjdk/leyden/blob/1b6bbf7c7dff4b41b5aa03bf3f000898133cd629/src/hotspot/share/compiler/compilationPolicy.cpp#L1425-L1430

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.org/leyden.git pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/4.diff">https://git.openjdk.org/leyden/pull/4.diff</a>

</details>
