### PR TITLE
Increase PerfDataMemorySize from 32K to 64K to accommodate new perf data

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1756,7 +1756,7 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, PerfDisableSharedMem, false,                                \
           "Store performance data in standard memory")                      \
                                                                             \
-  product(int, PerfDataMemorySize, 32*K,                                    \
+  product(int, PerfDataMemorySize, 64*K,                                    \
           "Size of performance data memory region. Will be rounded "        \
           "up to a multiple of the native os page size.")                   \
           range(128, 32*64*K)                                               \


### PR DESCRIPTION
Lot of new data was added to perf memory as part of https://github.com/openjdk/leyden/commit/31b2e9c8610cd3ae6e6f1c9d6c7310ee80e03eb3. The current default size of 32K perf memory is no longer sufficient. This patch increases it to twice its current size to 64K.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.org/leyden.git pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/5.diff">https://git.openjdk.org/leyden/pull/5.diff</a>

</details>
