### PR TITLE
8324975: Add a timer to track thread cpu time

### DIFF
--- a/src/hotspot/share/compiler/abstractCompiler.hpp
+++ b/src/hotspot/share/compiler/abstractCompiler.hpp
@@ -44,7 +44,7 @@ class CompilerStatistics {
     uint _count;         // number of compilations
     Data() : _bytes(0), _count(0) {}
     void update(elapsedTimer time, int bytes) {
-      _time.add(time);
+      _time.add(&time);
       _bytes += bytes;
       _count++;
     }

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2793,7 +2793,7 @@ void CompileBroker::collect_statistics(CompilerThread* thread, elapsedTimer time
 
   // account all time, including bailouts and failures in this counter;
   // C1 and C2 counters are counting both successful and unsuccessful compiles
-  _t_total_compilation.add(time);
+  _t_total_compilation.add(&time);
 
   if (!success) {
     _total_bailout_count++;
@@ -2802,7 +2802,7 @@ void CompileBroker::collect_statistics(CompilerThread* thread, elapsedTimer time
       _perf_last_failed_type->set_value(counters->compile_type());
       _perf_total_bailout_count->inc();
     }
-    _t_bailedout_compilation.add(time);
+    _t_bailedout_compilation.add(&time);
 
     if (CITime || log_is_enabled(Info, init)) {
       CompilerStatistics* stats = nullptr;
@@ -2821,7 +2821,7 @@ void CompileBroker::collect_statistics(CompilerThread* thread, elapsedTimer time
       _perf_total_invalidated_count->inc();
     }
     _total_invalidated_count++;
-    _t_invalidated_compilation.add(time);
+    _t_invalidated_compilation.add(&time);
 
     if (CITime || log_is_enabled(Info, init)) {
       CompilerStatistics* stats = nullptr;
@@ -2844,10 +2844,10 @@ void CompileBroker::collect_statistics(CompilerThread* thread, elapsedTimer time
     if (CITime || log_is_enabled(Info, init)) {
       int bytes_compiled = method->code_size() + task->num_inlined_bytecodes();
       if (is_osr) {
-        _t_osr_compilation.add(time);
+        _t_osr_compilation.add(&time);
         _sum_osr_bytes_compiled += bytes_compiled;
       } else {
-        _t_standard_compilation.add(time);
+        _t_standard_compilation.add(&time);
         _sum_standard_bytes_compiled += method->code_size() + task->num_inlined_bytecodes();
       }
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -4280,6 +4280,7 @@ JVM_END
 
 #define INIT_COUNTER(name) \
     NEWPERFTICKCOUNTER(_perf_##name##_timer, SUN_RT, #name "_time"); \
+    NEWPERFTHREADTICKCOUNTER(_perf_##name##_thread_timer, SUN_RT, #name "_thread_time"); \
     NEWPERFEVENTCOUNTER(_perf_##name##_count, SUN_RT, #name "_count"); \
 
 void perf_jvm_init() {
@@ -4299,8 +4300,8 @@ void perf_jvm_init() {
 #define PRINT_COUNTER(name) {\
   jlong count = _perf_##name##_count->get_value(); \
   if (count > 0) { \
-    st->print_cr("  %-40s = %4ldms (%5ld events)", #name, \
-                 Management::ticks_to_ms(_perf_##name##_timer->get_value()), count); \
+    st->print_cr("  %-40s = %4ldms (elapsed) %4ldms (thread time) (%5ld events)", #name, \
+                 Management::ticks_to_ms(_perf_##name##_timer->get_value()), Management::ticks_to_ms(_perf_##name##_thread_timer->get_value()), count); \
   }}
 
 void perf_jvm_print_on(outputStream* st) {

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -472,11 +472,12 @@ extern "C" {                                                         \
 
 #define JVM_ENTRY_PROF(result_type, name, header)                    \
   PerfCounter* _perf_##name##_timer = nullptr;                       \
+  PerfCounter* _perf_##name##_thread_timer = nullptr;                \
   PerfCounter* _perf_##name##_count = nullptr;                       \
 extern "C" {                                                         \
   result_type JNICALL header {                                       \
     JavaThread* thread=JavaThread::thread_from_jni_environment(env); \
-    PerfTraceTimedEvent perf_##name(_perf_##name##_timer, _perf_##name##_count, thread->profile_vm_calls()); \
+    PerfTraceTimedEvent perf_##name(_perf_##name##_timer, _perf_##name##_thread_timer, _perf_##name##_count, thread->profile_vm_calls()); \
     MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));        \
     ThreadInVMfromNative __tiv(thread);                              \
     debug_only(VMNativeEntryWrapper __vew;)                          \
@@ -485,11 +486,12 @@ extern "C" {                                                         \
 
 #define JVM_ENTRY_NO_ENV_PROF(result_type, name, header)             \
   PerfCounter* _perf_##name##_timer = nullptr;                       \
+  PerfCounter* _perf_##name##_thread_timer = nullptr;                \
   PerfCounter* _perf_##name##_count = nullptr;                       \
 extern "C" {                                                         \
   result_type JNICALL header {                                       \
     JavaThread* thread = JavaThread::current();                      \
-    PerfTraceTimedEvent perf_##name(_perf_##name##_timer, _perf_##name##_count, thread->profile_vm_calls()); \
+    PerfTraceTimedEvent perf_##name(_perf_##name##_timer, _perf_##name##_thread_timer, _perf_##name##_count, thread->profile_vm_calls()); \
     MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));        \
     ThreadInVMfromNative __tiv(thread);                              \
     debug_only(VMNativeEntryWrapper __vew;)                          \
@@ -498,10 +500,11 @@ extern "C" {                                                         \
 
 #define JVM_LEAF_PROF(result_type, name, header)                     \
   PerfCounter* _perf_##name##_timer = nullptr;                       \
+  PerfCounter* _perf_##name##_thread_timer = nullptr;                \
   PerfCounter* _perf_##name##_count = nullptr;                       \
 extern "C" {                                                         \
   result_type JNICALL header {                                       \
-    PerfTraceTimedEvent perf_##name(_perf_##name##_timer, _perf_##name##_count, \
+    PerfTraceTimedEvent perf_##name(_perf_##name##_timer, _perf_##name##_thread_timer, _perf_##name##_count, \
                                     ProfileVMCalls && Thread::current()->profile_vm_calls()); \
     VM_Exit::block_if_vm_exited();                                   \
     VM_LEAF_BASE(result_type, header)

--- a/src/hotspot/share/runtime/perfData.cpp
+++ b/src/hotspot/share/runtime/perfData.cpp
@@ -531,4 +531,8 @@ PerfTraceTime::~PerfTraceTime() {
   if (!UsePerfData || !_t.is_active()) return;
   _t.stop();
   _timerp->inc(_t.ticks());
+  if (_thread_timerp != nullptr) {
+    _thread_t.stop();
+    _thread_timerp->inc(_thread_t.ticks());
+  }
 }

--- a/src/hotspot/share/runtime/timer.cpp
+++ b/src/hotspot/share/runtime/timer.cpp
@@ -26,6 +26,7 @@
 #include "logging/log.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/os.hpp"
+#include "runtime/thread.hpp"
 #include "runtime/timer.hpp"
 #include "utilities/ostream.hpp"
 
@@ -48,43 +49,72 @@ jlong TimeHelper::micros_to_counter(jlong micros) {
   return micros * freq;
 }
 
-void elapsedTimer::add(elapsedTimer t) {
-  _counter += t._counter;
+void BaseTimer::add(BaseTimer* t) {
+  _counter += t->_counter;
 }
 
-void elapsedTimer::add_nanoseconds(jlong ns) {
+void BaseTimer::add_nanoseconds(jlong ns) {
   jlong freq = os::elapsed_frequency() / NANOUNITS;
   _counter += ns * freq;
 }
 
-void elapsedTimer::start() {
+void BaseTimer::start() {
   if (!_active) {
     _active = true;
-    _start_counter = os::elapsed_counter();
+    _start_counter = read_counter();
   }
 }
 
-void elapsedTimer::stop() {
+void BaseTimer::stop() {
   if (_active) {
-    _counter += os::elapsed_counter() - _start_counter;
+    _counter += read_counter() - _start_counter;
     _active = false;
   }
 }
 
-double elapsedTimer::seconds() const {
+double BaseTimer::seconds() const {
  return TimeHelper::counter_to_seconds(_counter);
 }
 
-jlong elapsedTimer::milliseconds() const {
+jlong BaseTimer::milliseconds() const {
   return (jlong)TimeHelper::counter_to_millis(_counter);
 }
 
-jlong elapsedTimer::active_ticks() const {
+jlong BaseTimer::active_ticks() const {
   if (!_active) {
     return ticks();
   }
-  jlong counter = _counter + os::elapsed_counter() - _start_counter;
+  jlong counter = _counter + read_counter() - _start_counter;
   return counter;
+}
+
+jlong elapsedTimer::read_counter() const {
+  return os::elapsed_counter();
+}
+
+ThreadTimer::ThreadTimer() {
+  _owner = Thread::current();
+}
+
+void ThreadTimer::start() {
+  assert(_owner != nullptr, "timer must be bound to a thread");
+  Thread* current = Thread::current();
+  assert(current == _owner, "timer can only be started by the thread that owns it");
+  BaseTimer::start();
+}
+
+void ThreadTimer::stop() {
+  assert(_owner != nullptr, "sanity check");
+  Thread* current = Thread::current();
+  assert(current == _owner, "timer can only be stopped by the thread that owns it");
+  if (_start_counter != -1) {
+    BaseTimer::stop();
+  }
+}
+
+jlong ThreadTimer::read_counter() const {
+  assert(_owner != nullptr, "sanity check");
+  return os::thread_cpu_time(_owner);
 }
 
 void TimeStamp::update_to(jlong ticks) {

--- a/src/hotspot/share/runtime/timer.hpp
+++ b/src/hotspot/share/runtime/timer.hpp
@@ -29,24 +29,47 @@
 
 // Timers for simple measurement.
 
-class elapsedTimer {
+class BaseTimer {
   friend class VMStructs;
- private:
+ protected:
   jlong _counter;
   jlong _start_counter;
   bool  _active;
+
+  virtual jlong read_counter() const = 0;
+
  public:
-  elapsedTimer()             { _active = false; reset(); }
-  void add(elapsedTimer t);
+  BaseTimer() {
+    _active = false;
+    reset();
+  }
+  void add(BaseTimer* t);
   void add_nanoseconds(jlong ns);
-  void start();
-  void stop();
+  virtual void start();
+  virtual void stop();
   void reset()               { _counter = 0; }
   double seconds() const;
   jlong milliseconds() const;
   jlong ticks() const        { return _counter; }
   jlong active_ticks() const;
   bool  is_active() const { return _active; }
+};
+
+class elapsedTimer: public BaseTimer {
+  friend class VMStructs;
+ public:
+  jlong read_counter() const override;
+};
+
+class ThreadTimer: public BaseTimer {
+ private:
+  Thread* _owner;
+ public:
+  ThreadTimer();
+  ThreadTimer(Thread* thread) : _owner(thread) {}
+  void start() override;
+  void stop() override;
+  jlong read_counter() const override;
 };
 
 // TimeStamp is used for recording when an event took place.

--- a/src/hotspot/share/runtime/timerTrace.cpp
+++ b/src/hotspot/share/runtime/timerTrace.cpp
@@ -73,7 +73,7 @@ TraceTime::~TraceTime() {
   }
   _t.stop();
   if (_accum != nullptr) {
-    _accum->add(_t);
+    _accum->add(&_t);
   }
   if (!_verbose) {
     return;


### PR DESCRIPTION
Added ThreadTimer to compute thread cpu time. Also updated perf counter that profile VM calls to use ThreadTimer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324975](https://bugs.openjdk.org/browse/JDK-8324975): Add a timer to track thread cpu time (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.org/leyden.git pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/6.diff">https://git.openjdk.org/leyden/pull/6.diff</a>

</details>
