### PR TITLE
Save and relocate stop msg strings in cached code on aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2703,8 +2703,11 @@ void MacroAssembler::resolve_global_jobject(Register value, Register tmp1, Regis
 
 void MacroAssembler::stop(const char* msg) {
   BLOCK_COMMENT(msg);
+  // load msg into r0 so we can access it from the signal handler
+  // ExternalAddress enables saving and restoring via the code cache
+  lea(c_rarg0, ExternalAddress((address) msg));
   dcps1(0xdeae);
-  emit_int64((uintptr_t)msg);
+  SCCache::add_C_string(msg);
 }
 
 void MacroAssembler::unimplemented(const char* what) {

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -266,10 +266,9 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
           stub = SharedRuntime::handle_unsafe_access(thread, next_pc);
         }
       } else if (sig == SIGILL && nativeInstruction_at(pc)->is_stop()) {
-        // Pull a pointer to the error message out of the instruction
-        // stream.
+        // A pointer to the message will have been placed in r0
         const uint64_t *detail_msg_ptr
-          = (uint64_t*)(pc + NativeInstruction::instruction_size);
+          = (uint64_t*)(uc->uc_mcontext.regs[0]);
         const char *detail_msg = (const char *)*detail_msg_ptr;
         const char *msg = "stop";
         if (TraceTraps) {

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -249,10 +249,9 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
           stub = SharedRuntime::handle_unsafe_access(thread, next_pc);
         }
       } else if (sig == SIGILL && nativeInstruction_at(pc)->is_stop()) {
-        // Pull a pointer to the error message out of the instruction
-        // stream.
+        // A pointer to the message will have been placed in r0
         const uint64_t *detail_msg_ptr
-          = (uint64_t*)(pc + NativeInstruction::instruction_size);
+          = (uint64_t*)(uc->uc_mcontext.regs[0]);
         const char *detail_msg = (const char *)*detail_msg_ptr;
         const char *msg = "stop";
         if (TraceTraps) {


### PR DESCRIPTION
On aarch64 MacroAssembler method stop() plants an illegal instruction and pokes the address of its msg string (C string) in the immediately following word. This is used by the Linux and bsd signal handlers to print an error message (Windows ignores this argument). When a generated stop() is saved to and restored from the SCCache the address may not be correctly relocated (specifically, this manifests with c1_Runtime1 stub names).

The strings should be added to the SCCache and loaded (relocatably) into c_rarg0 for the handlers to find, as happens with x86.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.org/leyden.git pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/7.diff">https://git.openjdk.org/leyden/pull/7.diff</a>

</details>
