### PR TITLE
jcheck configuration for Leyden

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,10 +1,10 @@
 [general]
-project=jdk
+project=leyden
 jbs=JDK
 version=24
 
 [checks]
-error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists
+error=author,committer,reviewers,merge,executable,symlink,message,hg-tag,whitespace,problemlists
 warning=issuestitle,binary
 
 [repository]
@@ -23,14 +23,11 @@ ignore-tabs=.*\.gmk|Makefile
 message=Merge
 
 [checks "reviewers"]
-reviewers=1
+committers=1
 ignore=duke
 
 [checks "committer"]
 role=committer
-
-[checks "issues"]
-pattern=^([124-8][0-9]{6}): (\S.*)$
 
 [checks "problemlists"]
 dirs=test/jdk|test/langtools|test/lib-test|test/hotspot/jtreg|test/jaxp


### PR DESCRIPTION
Does things like we do in Lilliput: https://github.com/openjdk/lilliput/blob/master/.jcheck/conf

Namely:
 - Names the project. I *think* that would also mean the PR comments would be mirrored to mailing list, but I am not sure.
 - Drops the "issues" check and related config block, so PR can be open without relevant JBS issue.
 - Relaxes the integration checks to committers for the project (since we have no reviewers).

@iklam, you might need to merge it by hand to make it work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.org/leyden.git pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/11.diff">https://git.openjdk.org/leyden/pull/11.diff</a>

</details>
