### PR TITLE
Enable 1-step workflow with Epsilon GC

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ $ docker run --rm -v /repos/leyden/build/linux-x64/images/jdk:/jdk -v $(pwd):/te
 Error occurred during initialization of VM
 Unable to use shared archive.
 ```
-### Only G1GC, SerialGC and ParallelGC are Supported
+### Only G1GC, SerialGC, ParallelGC, EpsilonGC are Supported
 
 Currently, if you use any other garbage collector in combination with `-XX:CacheDataStore`, the VM will
 exit with an error.
@@ -241,7 +241,7 @@ exit with an error.
 $ java -XX:+UseZGC -XX:CacheDataStore=foo --version
 Error occurred during initialization of VM
 Cannot create the CacheDataStore: UseCompressedClassPointers must be enabled, and collector
-must be G1, Parallel, or Serial
+must be G1, Parallel, Serial, or Epsilon
 ```
 
 

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -150,7 +150,7 @@ public:
       if (_disable_writing) {
         return false;
       }
-      return (UseG1GC || UseParallelGC || UseSerialGC) && UseCompressedClassPointers;
+      return (UseG1GC || UseParallelGC || UseSerialGC || UseEpsilonGC) && UseCompressedClassPointers;
     )
     NOT_CDS_JAVA_HEAP(return false;)
   }

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -273,7 +273,7 @@ void MetaspaceShared::initialize_for_static_dump() {
   assert(CDSConfig::is_dumping_static_archive(), "sanity");
 
   if (CDSConfig::is_dumping_preimage_static_archive() || CDSConfig::is_dumping_final_static_archive()) {
-    if (!((UseG1GC || UseParallelGC || UseSerialGC) && UseCompressedClassPointers)) {
+    if (!((UseG1GC || UseParallelGC || UseSerialGC || UseEpsilonGC) && UseCompressedClassPointers)) {
       vm_exit_during_initialization("Cannot create the CacheDataStore",
                                     "UseCompressedClassPointers must be enabled, and collector must be G1, Parallel, or Serial");
     }

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -275,7 +275,7 @@ void MetaspaceShared::initialize_for_static_dump() {
   if (CDSConfig::is_dumping_preimage_static_archive() || CDSConfig::is_dumping_final_static_archive()) {
     if (!((UseG1GC || UseParallelGC || UseSerialGC || UseEpsilonGC) && UseCompressedClassPointers)) {
       vm_exit_during_initialization("Cannot create the CacheDataStore",
-                                    "UseCompressedClassPointers must be enabled, and collector must be G1, Parallel, or Serial");
+                                    "UseCompressedClassPointers must be enabled, and collector must be G1, Parallel, Serial, or Epsilon");
     }
   }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/leyden/LeydenGCFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/leyden/LeydenGCFlags.java
@@ -44,7 +44,7 @@ import jdk.test.lib.StringArrayUtils;
 public class LeydenGCFlags {
     static final String appJar = ClassFileInstaller.getJarPath("app.jar");
     static final String mainClass = "HelloApp";
-    static final String ERROR_GC_SUPPORTED = "Cannot create the CacheDataStore: UseCompressedClassPointers must be enabled, and collector must be G1, Parallel, or Serial";
+    static final String ERROR_GC_SUPPORTED = "Cannot create the CacheDataStore: UseCompressedClassPointers must be enabled, and collector must be G1, Parallel, Serial, or Epsilon";
     static final String ERROR_GC_MISMATCH = "CDS archive has aot-linked classes. It cannot be used because GC used during dump time (.*) is not the same as runtime (.*)";
     static final String ERROR_COOP_MISMATCH = "Disable Startup Code Cache: 'HelloApp.cds.code' was created with CompressedOops::shift.. = .* vs current .*";
 


### PR DESCRIPTION
It is a bit awkward to allow archive dump with Epsilon, since we probably dump quite a bit of cruft in the archive without the GC. But I think it is still useful for controlled Epsilon uses.

I checked this works well:

```
#!/bin/bash

rm -fv app.cds*
for I in `seq 1 10`; do
  build/linux-x86_64-server-fastdebug/images/jdk/bin/java -XX:CacheDataStore=app.cds -Xmx256m -Xms256m -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -cp hellostream.jar HelloStream;
done
```

Additional testing:
 - [x] Ad-hoc testing (see above)
 - [x] Linux x86_64 server fastdebug, `runtime/cds/appcds`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/leyden.git pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/12.diff">https://git.openjdk.org/leyden/pull/12.diff</a>

</details>
