### PR TITLE
Mark Leyden tests that require artifacts with "external-dep"

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/applications/HelidonQuickStartSE.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/applications/HelidonQuickStartSE.java
@@ -33,6 +33,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test id=static
+ * @key external-dep
  * @requires vm.cds
  * @summary run HelidonQuickStartSE with the classic static archive workflow
  * @library /test/lib
@@ -41,6 +42,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test id=dynamic
+ * @key external-dep
  * @requires vm.cds
  * @summary run HelidonQuickStartSE with the classic dynamic archive workflow
  * @library /test/lib
@@ -49,6 +51,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test id=leyden
+ * @key external-dep
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @summary un HelidonQuickStartSE with the Leyden workflow
@@ -58,6 +61,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test id=leyden_old
+ * @key external-dep
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @summary un HelidonQuickStartSE with the "OLD" Leyden workflow

--- a/test/hotspot/jtreg/runtime/cds/appcds/applications/MicronautFirstApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/applications/MicronautFirstApp.java
@@ -33,6 +33,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test id=static
+ * @key external-dep
  * @requires vm.cds
  * @summary run MicronautFirstApp with the classic static archive workflow
  * @library /test/lib
@@ -41,6 +42,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test id=dynamic
+ * @key external-dep
  * @requires vm.cds
  * @summary run MicronautFirstApp with the classic dynamic archive workflow
  * @library /test/lib
@@ -49,6 +51,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test id=leyden
+ * @key external-dep
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @summary un MicronautFirstApp with the Leyden workflow
@@ -58,6 +61,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test id=leyden_old
+ * @key external-dep
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @summary un MicronautFirstApp with the "OLD" Leyden workflow

--- a/test/hotspot/jtreg/runtime/cds/appcds/applications/QuarkusGettingStarted.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/applications/QuarkusGettingStarted.java
@@ -33,6 +33,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test id=static
+ * @key external-dep
  * @requires vm.cds
  * @summary run QuarkusGettingStarted with the classic static archive workflow
  * @library /test/lib
@@ -41,6 +42,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test id=dynamic
+ * @key external-dep
  * @requires vm.cds
  * @summary run QuarkusGettingStarted with the classic dynamic archive workflow
  * @library /test/lib
@@ -49,6 +51,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test id=leyden
+ * @key external-dep
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @summary un QuarkusGettingStarted with the Leyden workflow
@@ -58,6 +61,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test id=leyden_old
+ * @key external-dep
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @summary un QuarkusGettingStarted with the "OLD" Leyden workflow

--- a/test/hotspot/jtreg/runtime/cds/appcds/applications/SpringPetClinic.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/applications/SpringPetClinic.java
@@ -25,6 +25,7 @@
 
 /*
  * @test id=static
+ * @key external-dep
  * @requires vm.cds
  * @summary run Spring Pet Clinic demo with the classic static archive workflow
  * @library /test/lib
@@ -33,6 +34,7 @@
 
 /*
  * @test id=dynamic
+ * @key external-dep
  * @requires vm.cds
  * @summary run Spring Pet Clinic demo with the classic dynamic archive workflow
  * @library /test/lib
@@ -41,6 +43,7 @@
 
 /*
  * @test id=leyden
+ * @key external-dep
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @summary run Spring Pet Clinic demo with leyden-premain "new workflow"
@@ -50,6 +53,7 @@
 
 /*
  * @test id=leyden_old
+ * @key external-dep
  * @requires vm.cds
  * @requires vm.cds.write.archived.java.heap
  * @summary run Spring Pet Clinic demo with leyden-premain


### PR DESCRIPTION
[JDK-8323717](https://bugs.openjdk.org/browse/JDK-8323717) added a new keyword that marks tests that require external artifacts. This allows skipping the tests that would definitely fail without artifact resolution. This PR marks the new Leyden tests.

Tested with:

```
$ JTREG_KEYWORDS='!external-dep' CONF=linux-x86_64-server-fastdebug make test TEST=runtime/cds/appcds

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg/runtime/cds/appcds         288   288     0     0   
==============================
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/leyden.git pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/14.diff">https://git.openjdk.org/leyden/pull/14.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/14#issuecomment-2332307015)