### PR TITLE
Workaround CacheDataStore use with source launcher

### DIFF
--- a/src/java.base/share/native/libjli/emessages.h
+++ b/src/java.base/share/native/libjli/emessages.h
@@ -77,6 +77,7 @@
 #define CFG_WARN3       "Warning: Missing VM type on line %d of `%s'"
 #define CFG_WARN4       "Warning: Missing server class VM on line %d of `%s'"
 #define CFG_WARN5       "Warning: Unknown VM type on line %d of `%s'"
+#define CFG_WARN6       "Warning: CacheDataStore cannot be used with default source launcher environment, disabling --add-modules=ALL-DEFAULT"
 
 #define CFG_ERROR1      "Error: Corrupt jvm.cfg file; cycle in alias list."
 #define CFG_ERROR2      "Error: Unable to resolve VM alias %s"

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1550,10 +1550,13 @@ ParseArguments(int *pargc, char ***pargv,
     }
 
     if (mode == LM_SOURCE) {
-        // Leyden: Supplying add-modules would break full module graph dumping,
-        // which will prevent CacheDataStore use. There is no other way to use
-        // CacheDataStore with source launcher at the moment. TODO: Figure this out.
-        if (!cacheDataStore) {
+        // Supplying add-modules would break full module graph dumping, which will
+        // prevent CacheDataStore use. There is no other way to use CacheDataStore
+        // with source launcher at the moment. Drop the add-modules, print warning
+        // message, and hope for the best. // TODO: Figure this out.
+        if (cacheDataStore) {
+          JLI_ReportErrorMessage(CFG_WARN6);
+        } else {
           AddOption("--add-modules=ALL-DEFAULT", NULL);
         }
         *pwhat = SOURCE_LAUNCHER_MAIN_ENTRY;

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -86,6 +86,7 @@ static jboolean _have_classpath = JNI_FALSE;
 static const char *_fVersion;
 static jboolean _wc_enabled = JNI_FALSE;
 static jboolean dumpSharedSpaces = JNI_FALSE; /* -Xshare:dump */
+static jboolean cacheDataStore = JNI_FALSE; /* -XX:CacheDataStore */
 
 /*
  * Entries for splash screen environment variables.
@@ -1522,6 +1523,9 @@ ParseArguments(int *pargc, char ***pargv,
             // Alias for -Xshare:dump
             dumpSharedSpaces = JNI_TRUE;
         }
+        if (JLI_StrCCmp(arg, "-XX:CacheDataStore") == 0) {
+            cacheDataStore = JNI_TRUE;
+        }
     }
 
     if (*pwhat == NULL && --argc >= 0) {
@@ -1546,7 +1550,12 @@ ParseArguments(int *pargc, char ***pargv,
     }
 
     if (mode == LM_SOURCE) {
-        AddOption("--add-modules=ALL-DEFAULT", NULL);
+        // Leyden: Supplying add-modules would break full module graph dumping,
+        // which will prevent CacheDataStore use. There is no other way to use
+        // CacheDataStore with source launcher at the moment. TODO: Figure this out.
+        if (!cacheDataStore) {
+          AddOption("--add-modules=ALL-DEFAULT", NULL);
+        }
         *pwhat = SOURCE_LAUNCHER_MAIN_ENTRY;
         // adjust (argc, argv) so that the name of the source file
         // is included in the args passed to the source launcher

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1555,9 +1555,9 @@ ParseArguments(int *pargc, char ***pargv,
         // with source launcher at the moment. Drop the add-modules, print warning
         // message, and hope for the best. // TODO: Figure this out.
         if (cacheDataStore) {
-          JLI_ReportErrorMessage(CFG_WARN6);
+            JLI_ReportErrorMessage(CFG_WARN6);
         } else {
-          AddOption("--add-modules=ALL-DEFAULT", NULL);
+            AddOption("--add-modules=ALL-DEFAULT", NULL);
         }
         *pwhat = SOURCE_LAUNCHER_MAIN_ENTRY;
         // adjust (argc, argv) so that the name of the source file


### PR DESCRIPTION
I was trying to test the simplest workload that involves javac, and that is source launcher. When I attempt to use source launcher with `-XX:CacheDataStore`, it fails with:

```
$ rm -f app.cds*; build/linux-x86_64-server-release/images/jdk/bin/java -XX:CacheDataStore=app.cds -Xmx256m -Xms256m -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC HelloStream.java
[0.001s][warning][cds] optimized module handling/full module graph: disabled due to incompatible property: jdk.module.addmods=ALL-DEFAULT
Error occurred during initialization of VM
CacheDataStore cannot be created because AOTClassLinking is enabled but full module graph is disabled
```

Source launcher adds `--add-modules=ALL-DEFAULT`:

```
$ man java
...
       In source-file mode, execution proceeds as follows:

...
       • The compiled classes are executed in  the  context  of  an  unnamed  module,  as  though  --add-mod‐
         ules=ALL-DEFAULT  is  in  effect.  This is in addition to any other --add-module options that may be
         have been specified on the command line.
```

I think we can work that around specifically for Leyden, and also leave a TODO breadcrumb in the code that we need to figure this out on CDS side. This PR does that workaround. With it, source launcher works with simple examples:

```
$ build/linux-x86_64-server-release/images/jdk/bin/java -XX:CacheDataStore=app.cds -Xmx256m -Xms256m -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC  HelloStream.java
Warning: CacheDataStore cannot be used with default source launcher environment, disabling --add-modules=ALL-DEFAULT
hello, world
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.org/leyden.git pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/15.diff">https://git.openjdk.org/leyden/pull/15.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/15#issuecomment-2333575097)