### PR TITLE
Rework rich PrintCompilation logs

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2661,6 +2661,8 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
     }
   }
 
+  task->mark_finished(os::elapsed_counter());
+
   if (tdata != nullptr) {
     tdata->record_compilation_end(task);
   }
@@ -2714,6 +2716,11 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
   // only after the setting of the bits. See also 14012000 above.
   method->clear_queued_for_compilation();
   method->set_pending_queue_processed(false);
+
+  if (PrintCompilation) {
+    ResourceMark rm;
+    task->print_tty();
+  }
 }
 
 /**

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -122,6 +122,7 @@ void CompileTask::initialize(int compile_id,
   _time_created = os::elapsed_counter();
   _time_queued = 0;
   _time_started = 0;
+  _time_finished = 0;
   _compile_reason = compile_reason;
   _nm_content_size = 0;
   _nm_insts_size = 0;
@@ -248,24 +249,37 @@ void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, i
                              bool is_osr_method, int osr_bci, bool is_blocking, bool is_scc, bool is_preload,
                              const char* compiler_name,
                              const char* msg, bool short_form, bool cr,
-                             jlong time_created, jlong time_queued, jlong time_started) {
+                             jlong time_created, jlong time_queued, jlong time_started, jlong time_finished) {
   if (!short_form) {
-    // Print current time
-    stringStream ss;
-    ss.print("%c" UINT64_FORMAT, (time_started != 0 ? 'F' : 'S'), (uint64_t)tty->time_stamp().milliseconds());
-    st->print("%7s ", ss.freeze());
-    if (time_created != 0) {
-      // Print time in queue and time being processed by compiler thread
-      jlong now = os::elapsed_counter();
-      st->print("C%d ", (int) TimeHelper::counter_to_millis((time_queued != 0 ? time_queued : now) - time_created));
-      if (time_queued != 0) {
-        st->print("Q%d ", (int) TimeHelper::counter_to_millis((time_started != 0 ? time_started : now) - time_queued));
-        if (time_started != 0) {
-          st->print("S%d ", (int) TimeHelper::counter_to_millis(now - time_started));
-        }
-      }
+    {
+      stringStream ss;
+      ss.print(UINT64_FORMAT, (uint64_t) tty->time_stamp().milliseconds());
+      st->print("%7s ", ss.freeze());
     }
+    { // Time after creation
+      stringStream ss;
+      if (time_created != 0 && time_queued != 0) {
+        ss.print("C%.1f", TimeHelper::counter_to_millis(time_queued - time_created));
+      }
+      st->print("%7s ", ss.freeze());
+    }
+    { // Time in queue
+      stringStream ss;
+      if (time_queued != 0 && time_started != 0) {
+        ss.print("Q%.1f", TimeHelper::counter_to_millis(time_started - time_queued));
+      }
+      st->print("%7s ", ss.freeze());
+    }
+    { // Time in work
+      stringStream ss;
+      if (time_started != 0 && time_finished != 0) {
+        ss.print("W%.1f", TimeHelper::counter_to_millis(time_finished - time_started));
+      }
+      st->print("%7s ", ss.freeze());
+    }
+    st->print("  ");
   }
+
   // print compiler name if requested
   if (CIPrintCompilerName) {
     st->print("%s:", compiler_name);
@@ -339,7 +353,7 @@ void CompileTask::print_inline_indent(int inline_level, outputStream* st) {
 void CompileTask::print(outputStream* st, const char* msg, bool short_form, bool cr) {
   bool is_osr_method = osr_bci() != InvocationEntryBci;
   print_impl(st, is_unloaded() ? nullptr : method(), compile_id(), comp_level(), is_osr_method, osr_bci(), is_blocking(), is_scc(), preload(),
-             compiler()->name(), msg, short_form, cr, _time_created, _time_queued, _time_started);
+             compiler()->name(), msg, short_form, cr, _time_created, _time_queued, _time_started, _time_finished);
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -256,10 +256,10 @@ void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, i
       ss.print(UINT64_FORMAT, (uint64_t) tty->time_stamp().milliseconds());
       st->print("%7s ", ss.freeze());
     }
-    { // Time after creation
+    { // Time waiting to be put on queue
       stringStream ss;
       if (time_created != 0 && time_queued != 0) {
-        ss.print("C%.1f", TimeHelper::counter_to_millis(time_queued - time_created));
+        ss.print("W%.1f", TimeHelper::counter_to_millis(time_queued - time_created));
       }
       st->print("%7s ", ss.freeze());
     }
@@ -270,10 +270,10 @@ void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, i
       }
       st->print("%7s ", ss.freeze());
     }
-    { // Time in work
+    { // Time in compilation
       stringStream ss;
       if (time_started != 0 && time_finished != 0) {
-        ss.print("W%.1f", TimeHelper::counter_to_millis(time_finished - time_started));
+        ss.print("C%.1f", TimeHelper::counter_to_millis(time_finished - time_started));
       }
       st->print("%7s ", ss.freeze());
     }

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -121,9 +121,10 @@ class CompileTask : public CHeapObj<mtCompiler> {
   CompileTask*         _prev;
   bool                 _is_free;
   // Fields used for logging why the compilation was initiated:
-  jlong                _time_created; // time when task was enqueued
+  jlong                _time_created; // time when task was created
   jlong                _time_queued;  // time when task was enqueued
   jlong                _time_started; // time when compilation started
+  jlong                _time_finished; // time when compilation finished
   Method*              _hot_method;   // which method actually triggered this task
   jobject              _hot_method_holder;
   int                  _hot_count;    // information about its invocation counter
@@ -213,6 +214,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
   void         mark_success()                    { _is_success = true; }
   void         mark_queued(jlong time)           { _time_queued = time; }
   void         mark_started(jlong time)          { _time_started = time; }
+  void         mark_finished(jlong time)         { _time_finished = time; }
 
   int          comp_level()                      { return _comp_level;}
   void         set_comp_level(int comp_level)    { _comp_level = comp_level;}
@@ -251,7 +253,7 @@ private:
                                       bool is_scc = false, bool is_preload = false,
                                       const char* compiler_name = nullptr,
                                       const char* msg = nullptr, bool short_form = false, bool cr = true,
-                                      jlong time_created = 0, jlong time_queued = 0, jlong time_started = 0);
+                                      jlong time_created = 0, jlong time_queued = 0, jlong time_started = 0, jlong time_finished = 0);
 
 public:
   void         print(outputStream* st = tty, const char* msg = nullptr, bool short_form = false, bool cr = true);


### PR DESCRIPTION
I have been studying javac benchmark behavior, and current `PrintCompilation` logs are very useful to figure out how much time is spent in creation, queueing, work time for each task. Current logs are quite a bit confusing, though:
 - The columns are misindented
 - The precision is too low to capture short events: most of the times are zero
 - Output seems to rely on "now" timestamp, which depends on _when_ we print
 
This PR reworks the logs to be more straightforward.

Example before:

```
   S296 C0 Q229 3531      A  2       com.sun.tools.javac.parser.JavacParser::typeName (37 bytes)
   S296 C0 Q245 2030      A  2       com.sun.tools.javac.tree.TreeInfo::innermostType (102 bytes)
   S296 C0 Q0 4169         3       com.sun.tools.javac.comp.Flow$AliveAnalyzer$$Lambda/0x800000105::accept (12 bytes)
   S296 C0 Q245 2042      A  2       com.sun.tools.javac.tree.JCTree$JCPrimitiveTypeTree::accept (9 bytes)
   S296 C0 Q0 4170         3       com.sun.tools.javac.comp.Flow$AssignAnalyzer$$Lambda/0x800000108::accept (12 bytes)
   S296 C0 Q0 4171         3       com.sun.tools.javac.comp.Flow$FlowAnalyzer$$Lambda/0x80000010a::accept (12 bytes)
   S296 C0 Q245 2098      A  2       com.sun.tools.javac.code.Symbol$RecordComponent::getOriginalAnnos (24 bytes)
   S296 C0 Q244 2348      A  2       com.sun.tools.javac.tree.TreeCopier::visitPrimitiveType (24 bytes)
   S296 C0 Q244 2349      A  2       com.sun.tools.javac.tree.TreeCopier::visitPrimitiveType (7 bytes)
```

Example after:

```
    386    W0.0  Q313.7    C0.2   3524   !  A  2       com.sun.tools.javac.parser.JavacParser::literal (655 bytes)
    386                           3858         3       java.util.stream.MatchOps$$Lambda/0x800000030::<init> (15 bytes)   made not entrant
    386    W0.1                   2416      A  1       com.sun.tools.javac.comp.Infer$CheckInst::boundsToCheck (5 bytes)
    386    W0.0    Q0.1    C0.2   4155         4       java.util.stream.MatchOps$$Lambda/0x800000030::<init> (15 bytes)
    386    W0.1  Q332.7    C0.0   2416      A  1       com.sun.tools.javac.comp.Infer$CheckInst::boundsToCheck (5 bytes)
    386    W0.2                   2902      A  2       com.sun.tools.javac.code.ClassFinder::classFileNotFound (13 bytes)
    386    W0.2  Q327.9    C0.0   2902      A  2       com.sun.tools.javac.code.ClassFinder::classFileNotFound (13 bytes)
    386    W0.0                   3527      A  2       com.sun.tools.javac.parser.JavacParser::parseExpression (6 bytes)
    386    W0.0  Q314.2    C0.0   3527      A  2       com.sun.tools.javac.parser.JavacParser::parseExpression (6 bytes)
    386                           3859         3       java.util.stream.MatchOps$$Lambda/0x800000030::get (12 bytes)   made not entrant
    386    W0.1                   2196      A  1       com.sun.tools.javac.comp.InferenceContext::inferenceVars (5 bytes)
    386    W0.0    Q0.0    C0.6   4154         4       java.util.stream.MatchOps$$Lambda/0x800000030::get (12 bytes)
```

Note this effectively prints the task twice: one in the "usual" place we do it (near task creation), and one at the end, when we know all counters are populated and trustworthy.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.org/leyden.git pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/16.diff">https://git.openjdk.org/leyden/pull/16.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/16#issuecomment-2334642415)