### PR TITLE
Prefer to take AOT method from the SC queue faster

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -907,6 +907,12 @@ CompileTask* CompilationPolicy::select_task(CompileQueue* compile_queue, JavaThr
       continue;
     }
     Method* method = task->method();
+    if (task->is_scc()) {
+      // AOT task, it should load fast, take it, and go.
+      max_task = task;
+      max_method = method;
+      break;
+    }
     methodHandle mh(THREAD, method);
     if (task->can_become_stale() && is_stale(t, TieredCompileTaskTimeout, mh) && !is_old(mh)) {
       if (PrintTieredEvents) {

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -1188,10 +1188,7 @@ bool CompilationPolicy::compare_methods(Method* x, Method* y) {
 }
 
 bool CompilationPolicy::compare_tasks(CompileTask* x, CompileTask* y) {
-  if (x->is_scc() && !y->is_scc()) {
-    // x has cached code
-    return true;
-  }
+  assert(!x->is_scc() && !y->is_scc(), "SC tasks are not expected here");
   if (x->compile_reason() != y->compile_reason() && y->compile_reason() == CompileTask::Reason_MustBeCompiled) {
     return true;
   }

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -906,13 +906,12 @@ CompileTask* CompilationPolicy::select_task(CompileQueue* compile_queue, JavaThr
       task = next_task;
       continue;
     }
-    Method* method = task->method();
     if (task->is_scc()) {
-      // AOT task, it should load fast, take it, and go.
-      max_task = task;
-      max_method = method;
-      break;
+      // SCC tasks are on separate queue, and they should load fast. There is no need to walk
+      // the rest of the queue, just take the task and go.
+      return task;
     }
+    Method* method = task->method();
     methodHandle mh(THREAD, method);
     if (task->can_become_stale() && is_stale(t, TieredCompileTaskTimeout, mh) && !is_old(mh)) {
       if (PrintTieredEvents) {


### PR DESCRIPTION
Probably WIP. Humor me for a second: why could not / should not we take the AOT task for "compilation" (installation, really) right away like this? I suspect when SC queues are overwhelmed with N elements, we keep walking the entire SC queue for no particular reason?

This improves javac benchmark considerably (look at both wall time and user time):

```
# BEFORE
Benchmark 1: build/linux-x86_64-server-release/images/jdk/bin/java -XX:CacheDataStore=app.cds -Xmx256m -Xms256m -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -cp JavacBenchApp.jar JavacBenchApp 50
  Time (mean ± σ):     348.3 ms ±   2.8 ms    [User: 949.0 ms, System: 101.4 ms]
  Range (min … max):   344.0 ms … 355.3 ms    100 runs

# AFTER
Benchmark 1: build/linux-x86_64-server-release/images/jdk/bin/java -XX:CacheDataStore=app.cds -Xmx256m -Xms256m -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -cp JavacBenchApp.jar JavacBenchApp 50
  Time (mean ± σ):     312.2 ms ±   2.6 ms    [User: 577.8 ms, System: 95.4 ms]
  Range (min … max):   307.1 ms … 318.5 ms    100 runs
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.org/leyden.git pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/17.diff">https://git.openjdk.org/leyden/pull/17.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/17#issuecomment-2334719677)