### PR TITLE
Reformat internal profiling stats

### DIFF
--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1556,9 +1556,9 @@ void Runtime1::init_counters() {
   if (_perf_##sub##_##name##_count != nullptr) {  \
     jlong count = _perf_##sub##_##name##_count->get_value(); \
     if (count > 0) { \
-      st->print_cr("  %-30s = " JLONG_FORMAT_W(4) " ms (elapsed) " JLONG_FORMAT_W(4) "ms (thread) (" JLONG_FORMAT_W(5) " events)", #sub "::" #name, \
-                   _perf_##sub##_##name##_timer->elapsed_counter_value_ms(), \
-                   _perf_##sub##_##name##_timer->thread_counter_value_ms(), \
+      st->print_cr("  %-50s = " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) (" JLONG_FORMAT_W(5) " events)", #sub "::" #name, \
+                   _perf_##sub##_##name##_timer->elapsed_counter_value_us(), \
+                   _perf_##sub##_##name##_timer->thread_counter_value_us( ), \
                    count); \
     }}}
 

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1558,7 +1558,7 @@ void Runtime1::init_counters() {
     if (count > 0) { \
       st->print_cr("  %-50s = " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) (" JLONG_FORMAT_W(5) " events)", #sub "::" #name, \
                    _perf_##sub##_##name##_timer->elapsed_counter_value_us(), \
-                   _perf_##sub##_##name##_timer->thread_counter_value_us( ), \
+                   _perf_##sub##_##name##_timer->thread_counter_value_us(), \
                    count); \
     }}}
 

--- a/src/hotspot/share/cds/aotLinkedClassBulkLoader.cpp
+++ b/src/hotspot/share/cds/aotLinkedClassBulkLoader.cpp
@@ -386,9 +386,9 @@ void AOTLinkedClassBulkLoader::print_counters() {
     LogStreamHandle(Info, init) log;
     if (log.is_enabled()) {
       log.print_cr("AOTLinkedClassBulkLoader:");
-      log.print_cr("  preload:           " JLONG_FORMAT "ms (elapsed) " JLONG_FORMAT " (thread) / " JLONG_FORMAT " events",
-                   _perf_class_preload_counters->elapsed_counter_value_ms(),
-                   _perf_class_preload_counters->thread_counter_value_ms(),
+      log.print_cr("  preload:           " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) " (thread) / " JLONG_FORMAT_W(5) " events",
+                   _perf_class_preload_counters->elapsed_counter_value_us(),
+                   _perf_class_preload_counters->thread_counter_value_us(),
                    _perf_classes_preloaded->get_value());
     }
   }

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -147,31 +147,31 @@ void ClassLoader::print_counters(outputStream *st) {
   // we print to the passed in outputStream as requested.
   if (log_is_enabled(Info, perf, class, link)) {
       st->print_cr("ClassLoader:");
-      st->print_cr(   "  clinit:               " JLONG_FORMAT "ms / " JLONG_FORMAT " events",
+      st->print_cr(   "  clinit:               " JLONG_FORMAT_W(6) "us / " JLONG_FORMAT " events",
                    ClassLoader::class_init_time_ms(), ClassLoader::class_init_count());
-      st->print_cr("  link methods:         " JLONG_FORMAT "ms / " JLONG_FORMAT " events",
-                   Management::ticks_to_ms(_perf_ik_link_methods_time->get_value())   , _perf_ik_link_methods_count->get_value());
-      st->print_cr("  method adapters:      " JLONG_FORMAT "ms / " JLONG_FORMAT " events",
-                   Management::ticks_to_ms(_perf_method_adapters_time->get_value())   , _perf_method_adapters_count->get_value());
+      st->print_cr("  link methods:         " JLONG_FORMAT_W(6) "us / " JLONG_FORMAT " events",
+                   Management::ticks_to_us(_perf_ik_link_methods_time->get_value())   , _perf_ik_link_methods_count->get_value());
+      st->print_cr("  method adapters:      " JLONG_FORMAT_W(6) "us / " JLONG_FORMAT " events",
+                   Management::ticks_to_us(_perf_method_adapters_time->get_value())   , _perf_method_adapters_count->get_value());
       if (CountBytecodes || CountBytecodesPerThread) {
         st->print_cr("; executed " JLONG_FORMAT " bytecodes", ClassLoader::class_init_bytecodes_count());
       }
       st->print_cr("  resolve...");
-      st->print_cr("    invokedynamic:   " JLONG_FORMAT "ms (elapsed) " JLONG_FORMAT "ms (thread) / " JLONG_FORMAT " events",
-                   _perf_resolve_indy_time->elapsed_counter_value_ms(),
-                   _perf_resolve_indy_time->thread_counter_value_ms(),
+      st->print_cr("    invokedynamic:   " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) / " JLONG_FORMAT_W(5) " events",
+                   _perf_resolve_indy_time->elapsed_counter_value_us(),
+                   _perf_resolve_indy_time->thread_counter_value_us(),
                    _perf_resolve_indy_count->get_value());
-      st->print_cr("    invokehandle:    " JLONG_FORMAT "ms (elapsed) " JLONG_FORMAT "ms (thread) / " JLONG_FORMAT " events",
-                   _perf_resolve_invokehandle_time->elapsed_counter_value_ms(),
-                   _perf_resolve_invokehandle_time->thread_counter_value_ms(),
+      st->print_cr("    invokehandle:    " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) / " JLONG_FORMAT_W(5) " events",
+                   _perf_resolve_invokehandle_time->elapsed_counter_value_us(),
+                   _perf_resolve_invokehandle_time->thread_counter_value_us(),
                    _perf_resolve_invokehandle_count->get_value());
-      st->print_cr("    CP_MethodHandle: " JLONG_FORMAT "ms (elapsed) " JLONG_FORMAT "ms (thread) / " JLONG_FORMAT " events",
-                   _perf_resolve_mh_time->elapsed_counter_value_ms(),
-                   _perf_resolve_mh_time->thread_counter_value_ms(),
+      st->print_cr("    CP_MethodHandle: " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) / " JLONG_FORMAT_W(5) " events",
+                   _perf_resolve_mh_time->elapsed_counter_value_us(),
+                   _perf_resolve_mh_time->thread_counter_value_us(),
                    _perf_resolve_mh_count->get_value());
-      st->print_cr("    CP_MethodType:   " JLONG_FORMAT "ms (elapsed) " JLONG_FORMAT "ms (thread) / " JLONG_FORMAT " events",
-                   _perf_resolve_mt_time->elapsed_counter_value_ms(),
-                   _perf_resolve_mt_time->thread_counter_value_ms(),
+      st->print_cr("    CP_MethodType:   " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) / " JLONG_FORMAT_W(5) " events",
+                   _perf_resolve_mt_time->elapsed_counter_value_us(),
+                   _perf_resolve_mt_time->thread_counter_value_us(),
                    _perf_resolve_mt_count->get_value());
   }
 }

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1802,10 +1802,10 @@ void InterpreterRuntime::init_counters() {
 #define PRINT_COUNTER(sub, name) { \
   jlong count = _perf_##sub##_##name##_count->get_value(); \
   if (count > 0) { \
-    st->print_cr("  %-50s = " JLONG_FORMAT_W(4) "ms (elapsed) " JLONG_FORMAT_W(4) "ms (thread) (" JLONG_FORMAT_W(5) " events)", \
+    st->print_cr("  %-50s = " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) (" JLONG_FORMAT_W(5) " events)", \
                  #sub "::" #name, \
-                 _perf_##sub##_##name##_timer->elapsed_counter_value_ms(), \
-                 _perf_##sub##_##name##_timer->thread_counter_value_ms(), \
+                 _perf_##sub##_##name##_timer->elapsed_counter_value_us(), \
+                 _perf_##sub##_##name##_timer->thread_counter_value_us(), \
                  count); \
   }}
 

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -2007,9 +2007,9 @@ void OptoRuntime::init_counters() {
 #define PRINT_COUNTER_TIME_AND_CNT(sub, name) { \
   jlong count = _perf_##sub##_##name##_count->get_value(); \
   if (count > 0) { \
-    st->print_cr("  %-30s = " JLONG_FORMAT_W(4) "ms (elapsed) " JLONG_FORMAT_W(4) "ms (thread) (" JLONG_FORMAT_W(5) " events)", #sub "::" #name, \
-                 _perf_##sub##_##name##_timer->elapsed_counter_value_ms(), \
-                 _perf_##sub##_##name##_timer->thread_counter_value_ms(), \
+    st->print_cr("  %-50s = " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) (" JLONG_FORMAT_W(5) " events)", #sub "::" #name, \
+                 _perf_##sub##_##name##_timer->elapsed_counter_value_us(), \
+                 _perf_##sub##_##name##_timer->thread_counter_value_us(), \
                  count); \
   }}
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -4231,10 +4231,10 @@ void perf_jvm_init() {
 #define PRINT_COUNTER(name) {\
   jlong count = _perf_##name##_count->get_value(); \
   if (count > 0) { \
-    st->print_cr("  %-40s = " JLONG_FORMAT_W(4) "ms (elapsed) " JLONG_FORMAT_W(4) "ms (thread) (" JLONG_FORMAT_W(5) " events)", \
+    st->print_cr("  %-40s = " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) (" JLONG_FORMAT_W(5) " events)", \
                  #name,                                                   \
-                 _perf_##name##_timer->elapsed_counter_value_ms(),        \
-                 _perf_##name##_timer->thread_counter_value_ms(), count); \
+                 _perf_##name##_timer->elapsed_counter_value_us(),        \
+                 _perf_##name##_timer->thread_counter_value_us(), count); \
   }}
 
 void perf_jvm_print_on(outputStream* st) {

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -1558,9 +1558,9 @@ void MethodHandles::init_counters() {
 #define PRINT_COUNTER(name) {\
   jlong count = _perf_##name##_count->get_value(); \
   if (count > 0) { \
-    st->print_cr("  %-40s = " JLONG_FORMAT_W(4) "ms (elapsed) " JLONG_FORMAT_W(4) "ms (thread) (" JLONG_FORMAT_W(5) " events)", #name, \
-                 _perf_##name##_timer->elapsed_counter_value_ms(), \
-                 _perf_##name##_timer->thread_counter_value_ms(), \
+    st->print_cr("  %-40s = " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) (" JLONG_FORMAT_W(5) " events)", #name, \
+                 _perf_##name##_timer->elapsed_counter_value_us(), \
+                 _perf_##name##_timer->thread_counter_value_us(), \
                  count); \
   }}
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -2973,9 +2973,9 @@ void Deoptimization::init_counters() {
 #define PRINT_COUNTER(sub, name) { \
   jlong count = _perf_##sub##_##name##_count->get_value(); \
   if (count > 0) { \
-    st->print_cr("  %-50s = " JLONG_FORMAT_W(4) "ms (elapsed) " JLONG_FORMAT_W(4) "ms (thread) (" JLONG_FORMAT_W(5) " events)", #sub "::" #name, \
-                 _perf_##sub##_##name##_timer->elapsed_counter_value_ms(), \
-                 _perf_##sub##_##name##_timer->thread_counter_value_ms(), \
+    st->print_cr("  %-50s = " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) (" JLONG_FORMAT_W(5) " events)", #sub "::" #name, \
+                 _perf_##sub##_##name##_timer->elapsed_counter_value_us(), \
+                 _perf_##sub##_##name##_timer->thread_counter_value_us(), \
                  count); \
   }}
 

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -453,10 +453,10 @@ int MutexLockerImpl::name2id(const char* name) {
 void MutexLockerImpl::print_counter_on(outputStream* st, const char* name, bool is_unique, int idx) {
   jlong count = _perf_lock_count[idx]->get_value();
   if (count > 0) {
-    st->print_cr("  %3d: %s%40s = " JLONG_FORMAT_W(5) "ms (" JLONG_FORMAT_W(5) "ms) / " JLONG_FORMAT_W(9) " events",
+    st->print_cr("  %3d: %s%40s = " JLONG_FORMAT_W(5) "us (" JLONG_FORMAT_W(5) "us) / " JLONG_FORMAT_W(9) " events",
                  idx, (is_unique ? " " : "M"), name,
-                 Management::ticks_to_ms(_perf_lock_hold_time[idx]->get_value()),
-                 Management::ticks_to_ms(_perf_lock_wait_time[idx]->get_value()),
+                 Management::ticks_to_us(_perf_lock_hold_time[idx]->get_value()),
+                 Management::ticks_to_us(_perf_lock_wait_time[idx]->get_value()),
                  count);
   }
 }
@@ -478,10 +478,10 @@ void MutexLockerImpl::print_counters_on(outputStream* st) {
     jlong total_wait_time = accumulate_lock_counters(_perf_lock_wait_time);
     jlong total_hold_time = accumulate_lock_counters(_perf_lock_hold_time);
 
-    st->print_cr("MutexLocker: Total: %d named locks (%d unique names); hold = " JLONG_FORMAT "ms (wait = " JLONG_FORMAT "ms) / " JLONG_FORMAT " events for thread \"main\"",
+    st->print_cr("MutexLocker: Total: %d named locks (%d unique names); hold = " JLONG_FORMAT "us (wait = " JLONG_FORMAT "us) / " JLONG_FORMAT " events for thread \"main\"",
                  _num_mutex, _num_names,
-                 Management::ticks_to_ms(total_hold_time),
-                 Management::ticks_to_ms(total_wait_time),
+                 Management::ticks_to_us(total_hold_time),
+                 Management::ticks_to_us(total_wait_time),
                  total_count);
     for (int i = 0; i < _num_names; i++) {
       print_counter_on(st, _names[i], _is_unique[i], i+1);

--- a/src/hotspot/share/runtime/perfData.hpp
+++ b/src/hotspot/share/runtime/perfData.hpp
@@ -643,6 +643,7 @@ public:
     return _elapsed_counter->get_value();
   }
   inline jlong elapsed_counter_value_ms() const;
+  inline jlong elapsed_counter_value_us() const;
 
   PerfCounter* thread_counter() const {
     return _thread_counter;
@@ -651,6 +652,7 @@ public:
     return _thread_counter->get_value();
   }
   inline jlong thread_counter_value_ms() const;
+  inline jlong thread_counter_value_us() const;
 
   void reset() {
     _elapsed_counter->reset();

--- a/src/hotspot/share/runtime/perfData.inline.hpp
+++ b/src/hotspot/share/runtime/perfData.inline.hpp
@@ -59,4 +59,12 @@ inline jlong PerfTickCounters::thread_counter_value_ms() const {
   return Management::ticks_to_ms(_thread_counter->get_value());
 }
 
+inline jlong PerfTickCounters::elapsed_counter_value_us() const {
+  return Management::ticks_to_us(_elapsed_counter->get_value());
+}
+
+inline jlong PerfTickCounters::thread_counter_value_us() const {
+  return Management::ticks_to_us(_thread_counter->get_value());
+}
+
 #endif // SHARE_RUNTIME_PERFDATA_INLINE_HPP

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -186,38 +186,38 @@ void SharedRuntime::generate_stubs() {
 void SharedRuntime::print_counters_on(outputStream* st) {
   st->print_cr("SharedRuntime:");
   if (UsePerfData) {
-    st->print_cr("  resolve_opt_virtual_call: " JLONG_FORMAT_W(5) "ms (elapsed) " JLONG_FORMAT_W(5) "ms (thread) / %5d events",
-                 _perf_resolve_opt_virtual_total_time->elapsed_counter_value_ms(),
-                 _perf_resolve_opt_virtual_total_time->thread_counter_value_ms(),
+    st->print_cr("  resolve_opt_virtual_call: " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) / %5d events",
+                 _perf_resolve_opt_virtual_total_time->elapsed_counter_value_us(),
+                 _perf_resolve_opt_virtual_total_time->thread_counter_value_us(),
                  _resolve_opt_virtual_ctr);
-    st->print_cr("  resolve_virtual_call:     " JLONG_FORMAT_W(5) "ms (elapsed) " JLONG_FORMAT_W(5) "ms (thread) / %5d events",
-                 _perf_resolve_virtual_total_time->elapsed_counter_value_ms(),
-                 _perf_resolve_virtual_total_time->thread_counter_value_ms(),
+    st->print_cr("  resolve_virtual_call:     " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) / %5d events",
+                 _perf_resolve_virtual_total_time->elapsed_counter_value_us(),
+                 _perf_resolve_virtual_total_time->thread_counter_value_us(),
                  _resolve_virtual_ctr);
-    st->print_cr("  resolve_static_call:      " JLONG_FORMAT_W(5) "ms (elapsed) " JLONG_FORMAT_W(5) "ms (thread) / %5d events",
-                 _perf_resolve_static_total_time->elapsed_counter_value_ms(),
-                 _perf_resolve_static_total_time->thread_counter_value_ms(),
+    st->print_cr("  resolve_static_call:      " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) / %5d events",
+                 _perf_resolve_static_total_time->elapsed_counter_value_us(),
+                 _perf_resolve_static_total_time->thread_counter_value_us(),
                  _resolve_static_ctr);
-    st->print_cr("  handle_wrong_method:      " JLONG_FORMAT_W(5) "ms (elapsed) " JLONG_FORMAT_W(5) "ms (thread) / %5d events",
-                 _perf_handle_wrong_method_total_time->elapsed_counter_value_ms(),
-                 _perf_handle_wrong_method_total_time->thread_counter_value_ms(),
+    st->print_cr("  handle_wrong_method:      " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) / %5d events",
+                 _perf_handle_wrong_method_total_time->elapsed_counter_value_us(),
+                 _perf_handle_wrong_method_total_time->thread_counter_value_us(),
                  _wrong_method_ctr);
-    st->print_cr("  ic_miss:                  " JLONG_FORMAT_W(5) "ms (elapsed) " JLONG_FORMAT_W(5) "ms (thread) / %5d events",
-                 _perf_ic_miss_total_time->elapsed_counter_value_ms(),
-                 _perf_ic_miss_total_time->thread_counter_value_ms(),
+    st->print_cr("  ic_miss:                  " JLONG_FORMAT_W(6) "us (elapsed) " JLONG_FORMAT_W(6) "us (thread) / %5d events",
+                 _perf_ic_miss_total_time->elapsed_counter_value_us(),
+                 _perf_ic_miss_total_time->thread_counter_value_us(),
                  _ic_miss_ctr);
 
-    jlong total_elapsed_time_ms = Management::ticks_to_ms(_perf_resolve_opt_virtual_total_time->elapsed_counter_value() +
+    jlong total_elapsed_time_us = Management::ticks_to_us(_perf_resolve_opt_virtual_total_time->elapsed_counter_value() +
                                                           _perf_resolve_virtual_total_time->elapsed_counter_value() +
                                                           _perf_resolve_static_total_time->elapsed_counter_value() +
                                                           _perf_handle_wrong_method_total_time->elapsed_counter_value() +
                                                           _perf_ic_miss_total_time->elapsed_counter_value());
-    jlong total_thread_time_ms = Management::ticks_to_ms(_perf_resolve_opt_virtual_total_time->thread_counter_value() +
+    jlong total_thread_time_us = Management::ticks_to_us(_perf_resolve_opt_virtual_total_time->thread_counter_value() +
                                                           _perf_resolve_virtual_total_time->thread_counter_value() +
                                                           _perf_resolve_static_total_time->thread_counter_value() +
                                                           _perf_handle_wrong_method_total_time->thread_counter_value() +
                                                           _perf_ic_miss_total_time->thread_counter_value());
-    st->print_cr("Total:                      " JLONG_FORMAT_W(5) "ms (elapsed) " JLONG_FORMAT_W(5) "ms (thread)", total_elapsed_time_ms, total_thread_time_ms);
+    st->print_cr("Total:                      " JLONG_FORMAT_W(5) "us (elapsed) " JLONG_FORMAT_W(5) "us (thread)", total_elapsed_time_us, total_thread_time_us);
   } else {
     st->print_cr("  no data (UsePerfData is turned off)");
   }

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -627,7 +627,7 @@ static jlong total_elapsed_time_in_ms() {
 #define PRINT_COUNTER(name) {\
   jlong count = _perf_##name##_count->get_value(); \
   if (count > 0) { \
-    st->print_cr("  %-40s = " JLONG_FORMAT_W(4) "ms (" JLONG_FORMAT_W(5) " events)", #name, _perf_##name##_timer->elapsed_counter_value_ms(), count); \
+    st->print_cr("  %-40s = " JLONG_FORMAT_W(6) "us (" JLONG_FORMAT_W(5) " events)", #name, _perf_##name##_timer->elapsed_counter_value_us(), count); \
   }}
 
 void VMThread::print_counters_on(outputStream* st) {

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -2094,6 +2094,12 @@ jlong Management::ticks_to_ms(jlong ticks) {
                  * (double)1000.0);
 }
 
+jlong Management::ticks_to_us(jlong ticks) {
+  assert(os::elapsed_frequency() > 0, "Must be non-zero");
+  return (jlong)(((double)ticks / (double)os::elapsed_frequency())
+                 * (double)1000000.0);
+}
+
 // Gets the amount of memory allocated on the Java heap since JVM launch.
 JVM_ENTRY(jlong, jmm_GetTotalThreadAllocatedMemory(JNIEnv *env))
     // A thread increments exited_allocated_bytes in ThreadService::remove_thread

--- a/src/hotspot/share/services/management.hpp
+++ b/src/hotspot/share/services/management.hpp
@@ -63,6 +63,7 @@ public:
   static void initialize(TRAPS);
 
   static jlong ticks_to_ms(jlong ticks) NOT_MANAGEMENT_RETURN_(0L);
+  static jlong ticks_to_us(jlong ticks) NOT_MANAGEMENT_RETURN_(0L);
   static jlong timestamp() NOT_MANAGEMENT_RETURN_(0L);
 
   static void* get_jmm_interface(int version);


### PR DESCRIPTION
For HelloWorld/javac workloads, the current output resolution in milliseconds is not enough, we better off printing microseconds. Plus, indenting is not agreeing in interpreter/C1/C2 outputs, fixed that as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.org/leyden.git pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/18.diff">https://git.openjdk.org/leyden/pull/18.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/18#issuecomment-2337824104)