### PR TITLE
aot endtraining

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -1398,6 +1398,9 @@ void InterpreterMacroAssembler::_interp_verify_oop(Register reg, TosState state,
 
 void InterpreterMacroAssembler::verify_FPU(int stack_depth, TosState state) { ; }
 
+void InterpreterMacroAssembler::trigger_action_on_enter() {
+  call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::trigger_action_on_enter));
+}
 
 void InterpreterMacroAssembler::notify_method_entry() {
   // Whenever JVMTI is interp_only_mode, method entry/exit events are sent to

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -43,6 +43,7 @@
 #include "prims/jvmtiThreadState.hpp"
 #include "runtime/basicLock.hpp"
 #include "runtime/frame.inline.hpp"
+#include "runtime/globals_extension.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/safepointMechanism.hpp"
 #include "runtime/sharedRuntime.hpp"
@@ -1399,7 +1400,9 @@ void InterpreterMacroAssembler::_interp_verify_oop(Register reg, TosState state,
 void InterpreterMacroAssembler::verify_FPU(int stack_depth, TosState state) { ; }
 
 void InterpreterMacroAssembler::trigger_action_on_enter() {
-  call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::trigger_action_on_enter));
+  if (!FLAG_IS_DEFAULT(AOTCreateOnMethodEntry)) {
+    call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::trigger_action_on_enter));
+  }
 }
 
 void InterpreterMacroAssembler::notify_method_entry() {

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
@@ -303,6 +303,9 @@ class InterpreterMacroAssembler: public MacroAssembler {
 
   typedef enum { NotifyJVMTI, SkipNotifyJVMTI } NotifyMethodExitMode;
 
+  // support for AOT
+  void trigger_action_on_enter();
+
   // support for jvmti/dtrace
   void notify_method_entry();
   void notify_method_exit(TosState state, NotifyMethodExitMode mode);

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1257,8 +1257,6 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 #endif
   }
 
- __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::trigger_action_on_enter));
-
   // start execution
 #ifdef ASSERT
   {
@@ -1273,6 +1271,9 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     __ bind(L);
   }
 #endif
+
+  // AOT training run support
+  __ trigger_action_on_enter();
 
   // jvmti support
   __ notify_method_entry();
@@ -1723,8 +1724,9 @@ address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized) {
   }
 #endif
 
-  __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::trigger_action_on_enter));
-  
+  // AOT training run support
+  __ trigger_action_on_enter();
+
   // jvmti support
   __ notify_method_entry();
 

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1257,6 +1257,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 #endif
   }
 
+ __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::trigger_action_on_enter));
+
   // start execution
 #ifdef ASSERT
   {
@@ -1721,6 +1723,8 @@ address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized) {
   }
 #endif
 
+  __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::trigger_action_on_enter));
+  
   // jvmti support
   __ notify_method_entry();
 

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -2323,8 +2323,6 @@ void TemplateTable::resolve_cache_and_index_for_field(int byte_no,
 
   Label resolved, clinit_barrier_slow;
 
-  __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::trigger_action_before_call));
-
   Bytecodes::Code code = bytecode();
   switch (code) {
   case Bytecodes::_nofast_getfield: code = Bytecodes::_getfield; break;

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -2323,6 +2323,8 @@ void TemplateTable::resolve_cache_and_index_for_field(int byte_no,
 
   Label resolved, clinit_barrier_slow;
 
+  __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::trigger_action_before_call));
+
   Bytecodes::Code code = bytecode();
   switch (code) {
   case Bytecodes::_nofast_getfield: code = Bytecodes::_getfield; break;

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -42,7 +42,7 @@
 #include "jfr/jfrEvents.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/oop.inline.hpp"
-#include "runtime/globals_extensions.hpp"
+#include "runtime/globals_extension.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/bitMap.inline.hpp"

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -42,6 +42,7 @@
 #include "jfr/jfrEvents.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/oop.inline.hpp"
+#include "runtime/globals_extensions.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/bitMap.inline.hpp"
@@ -4062,6 +4063,11 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
                                : state()->local_at(0);
     sync_handler = new BlockBegin(SynchronizationEntryBCI);
     inline_sync_entry(lock, sync_handler);
+  }
+
+  if (!FLAG_IS_DEFAULT(AOTCreateOnMethodEntry)) {
+    Values* args = new Values(0);
+    append(new RuntimeCall(voidType, "trigger_action_from_c1", CAST_FROM_FN_PTR(address, SharedRuntime::trigger_action_from_c1), args));
   }
 
   if (compilation()->env()->dtrace_method_probes()) {

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -41,6 +41,7 @@
 #include "gc/shared/c1/barrierSetC1.hpp"
 #include "oops/klass.inline.hpp"
 #include "oops/methodCounters.hpp"
+#include "runtime/globals_extension.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "runtime/vm_version.hpp"
@@ -2662,6 +2663,14 @@ void LIRGenerator::do_Base(Base* x) {
     _instruction_for_operand.at_put_grow(dest->vreg_number(), local, nullptr);
 #endif
     java_index += type2size[t];
+  }
+
+  if (!FLAG_IS_DEFAULT(AOTCreateOnMethodEntry)) {
+    BasicTypeList signature;
+    signature.append(LP64_ONLY(T_LONG) NOT_LP64(T_INT));    // thread
+    LIR_OprList* args = new LIR_OprList();
+    args->append(getThreadPointer());
+    call_runtime(&signature, args, CAST_FROM_FN_PTR(address, SharedRuntime::trigger_action_from_c1), voidType, nullptr);
   }
 
   if (compilation()->env()->dtrace_method_probes()) {

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -328,6 +328,7 @@ const char* Runtime1::name_for_address(address entry) {
   FUNCTION_CASE(entry, SharedRuntime::lmul);
   FUNCTION_CASE(entry, SharedRuntime::lrem);
   FUNCTION_CASE(entry, SharedRuntime::lrem);
+  FUNCTION_CASE(entry, SharedRuntime::trigger_action_from_c1);
   FUNCTION_CASE(entry, SharedRuntime::dtrace_method_entry);
   FUNCTION_CASE(entry, SharedRuntime::dtrace_method_exit);
   FUNCTION_CASE(entry, is_instance_of);

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -518,6 +518,7 @@ public:
   bool is_native_method() const { return _method != nullptr && _method->is_native(); }
   bool is_java_method  () const { return _method != nullptr && !_method->is_native(); }
   bool is_osr_method   () const { return _entry_bci != InvocationEntryBci; }
+  bool is_trigger_method() const { return _method != nullptr && _method->is_trigger(); } 
 
   // Compiler task identification.  Note that all OSR methods
   // are numbered in an independent sequence if CICountOSR is true,

--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -58,6 +58,7 @@ class methodHandle;
   option(Break, "break", Bool) \
   option(BreakAtExecute, "BreakAtExecute", Bool) \
   option(BreakAtCompile, "BreakAtCompile", Bool) \
+  option(TriggerAtExecute, "TriggerAtExecute", Bool) \
   option(MemLimit, "MemLimit", Intx) \
   option(MemStat, "MemStat", Uintx) \
   option(PrintAssembly, "PrintAssembly", Bool) \
@@ -133,6 +134,9 @@ class CompilerOracle : AllStatic {
   static void print_parse_error(char* error_msg, char* original_line);
   static void print_command(CompileCommandEnum option, const char* name, enum OptionType type);
 
+  // Shared for parsing CompileOnly and AOTTrigger
+  static bool parse_for_command(char* line, CompileCommandEnum command, const char* error_prefix);
+
   // The core parser.
   static bool parse_from_input(inputStream::Input* input,
                                parse_from_line_fn_t* parse_from_line);
@@ -166,6 +170,9 @@ class CompilerOracle : AllStatic {
   // Tells whether to break when compiling method
   static bool should_break_at(const methodHandle& method);
 
+  // Tells whether to 'trigger' when executing method
+  static bool should_trigger_at(const methodHandle& method);
+
   // Tells whether there are any methods to print for print_method_statistics()
   static bool should_print_methods();
 
@@ -194,6 +201,7 @@ class CompilerOracle : AllStatic {
   static bool parse_from_line(char* line);
   static bool parse_from_line_quietly(char* line);
   static bool parse_compile_only(char* line);
+  static bool parse_aot_trigger(char* line);
 
   // Fast check if there is any option set that compile control needs to know about
   static bool has_any_command_set();

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -302,6 +302,9 @@
           range(0, 100)                                                     \
                                                                             \
   /* compiler directives */                                                 \
+  product(ccstrlist, AOTCreateOnMethodEntry, "",                            \
+          "List of methods (pkg/class.name) to trigger end of AOT "         \
+          "training run")                                                   \
                                                                             \
   product(ccstrlist, CompileOnly, "",                                       \
           "List of methods (pkg/class.name) to restrict compilation to")    \

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1162,7 +1162,7 @@ JRT_ENTRY(void, InterpreterRuntime::trigger_action_before_call(JavaThread* curre
   ResourceMark rm(current);
   methodHandle m (current, last_frame.method());
   if(m->is_trigger()) {
-    SharedRuntime::trigger_action("from interpreter before call");
+    SharedRuntime::trigger_action("from interpreter before call", CHECK);
   }
 }
 JRT_END
@@ -1173,7 +1173,7 @@ JRT_ENTRY(void, InterpreterRuntime::trigger_action_on_enter(JavaThread* current)
   ResourceMark rm(current);
   methodHandle m (current, last_frame.method());
   if(m->is_trigger()) {
-    SharedRuntime::trigger_action("from interpreter on enter");
+    SharedRuntime::trigger_action("from interpreter on enter", CHECK);
   }
 }
 JRT_END

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1159,7 +1159,6 @@ void InterpreterRuntime::cds_resolve_invokedynamic(int raw_index,
 // MNCMNC
 JRT_ENTRY(void, InterpreterRuntime::trigger_action_before_call(JavaThread* current)) {
   LastFrameAccessor last_frame(current);
-  // extract receiver from the outgoing argument list if necessary
   ResourceMark rm(current);
   methodHandle m (current, last_frame.method());
   if(m->is_trigger()) {
@@ -1171,7 +1170,6 @@ JRT_END
 // MNCMNC
 JRT_ENTRY(void, InterpreterRuntime::trigger_action_on_enter(JavaThread* current)) {
   LastFrameAccessor last_frame(current);
-  // extract receiver from the outgoing argument list if necessary
   ResourceMark rm(current);
   methodHandle m (current, last_frame.method());
   if(m->is_trigger()) {

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1156,6 +1156,30 @@ void InterpreterRuntime::cds_resolve_invokedynamic(int raw_index,
   pool->cache()->set_dynamic_call(info, raw_index);
 }
 
+// MNCMNC
+JRT_ENTRY(void, InterpreterRuntime::trigger_action_before_call(JavaThread* current)) {
+  LastFrameAccessor last_frame(current);
+  // extract receiver from the outgoing argument list if necessary
+  ResourceMark rm(current);
+  methodHandle m (current, last_frame.method());
+  if(m->is_trigger()) {
+    SharedRuntime::trigger_action("from interpreter before call");
+  }
+}
+JRT_END
+
+// MNCMNC
+JRT_ENTRY(void, InterpreterRuntime::trigger_action_on_enter(JavaThread* current)) {
+  LastFrameAccessor last_frame(current);
+  // extract receiver from the outgoing argument list if necessary
+  ResourceMark rm(current);
+  methodHandle m (current, last_frame.method());
+  if(m->is_trigger()) {
+    SharedRuntime::trigger_action("from interpreter on enter");
+  }
+}
+JRT_END
+
 // This function is the interface to the assembly code. It returns the resolved
 // cpCache entry.  This doesn't safepoint, but the helper routines safepoint.
 // This function will check for redefinition!

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -92,6 +92,9 @@ class InterpreterRuntime: AllStatic {
 
   static void resolve_from_cache(JavaThread* current, Bytecodes::Code bytecode);
 
+  static void trigger_action_before_call(JavaThread* current);
+  static void trigger_action_on_enter(JavaThread* current);
+
   // Used by AOTConstantPoolResolver
   static void resolve_get_put(Bytecodes::Code bytecode, int field_index,
                               methodHandle& m, constantPoolHandle& pool, bool initialize_holder, TRAPS);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1074,10 +1074,22 @@ void InstanceKlass::rewrite_class(TRAPS) {
 // executed more than once.
 void InstanceKlass::link_methods(TRAPS) {
   PerfTraceElapsedTime timer(ClassLoader::perf_ik_link_methods_time());
-
+  ResourceMark rm(THREAD);
+  
   int len = methods()->length();
   for (int i = len-1; i >= 0; i--) {
     methodHandle m(THREAD, methods()->at(i));
+  
+    // MNCMNC: if this is "outputMessage"
+    char* sig = m->signature()->as_C_string();
+    char* name = m->name()->as_C_string();
+    if (strcmp(name, "outputMessage") == 0) {
+      tty->print_cr("MNCMNC: found outputMessage");
+      if (strcmp(sig, "(Ljava/lang/String;)V") == 0) {
+        tty->print_cr("MNCMNC: found outputMessage sig");
+        m->set_is_trigger(true);
+      }
+    }
 
     // Set up method entry points for compiler and interpreter    .
     m->link_method(m, CHECK);

--- a/src/hotspot/share/oops/methodFlags.hpp
+++ b/src/hotspot/share/oops/methodFlags.hpp
@@ -59,7 +59,8 @@ class MethodFlags {
    status(has_loops_flag_init         , 1 << 14) /* The loop flag has been initialized */ \
    status(on_stack_flag               , 1 << 15) /* RedefineClasses support to keep Metadata from being cleaned */ \
    status(pending_queue_processed     , 1 << 16) \
-   /* end of list */
+  status(is_trigger                   , 1 << 16) /* Trigger action on execute (enter method) */ \
+  /* end of list */
 
 #define M_STATUS_ENUM_NAME(name, value)    _misc_##name = value,
   enum {

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -671,6 +671,9 @@ class GraphKit : public Phase {
   // Return a load of array element at idx.
   Node* load_array_element(Node* ary, Node* idx, const TypeAryPtr* arytype, bool set_ctrl);
 
+  //---------------- AOT support --------------------
+  void make_trigger_action();
+  
   //---------------- Dtrace support --------------------
   void make_dtrace_method_entry_exit(ciMethod* method, bool is_entry);
   void make_dtrace_method_entry(ciMethod* method) {

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -38,6 +38,7 @@
 #include "opto/rootnode.hpp"
 #include "opto/runtime.hpp"
 #include "opto/type.hpp"
+#include "runtime/globals_extension.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/safepointMechanism.hpp"
 #include "runtime/sharedRuntime.hpp"
@@ -1206,6 +1207,10 @@ void Parse::do_method_entry() {
   set_sp(0);                         // Java Stack Pointer
 
   NOT_PRODUCT( count_compiled_calls(true/*at_method_entry*/, false/*is_inline*/); )
+
+  if (!FLAG_IS_DEFAULT(AOTCreateOnMethodEntry)) {
+    make_trigger_action();
+  }
 
   if (C->env()->dtrace_method_probes()) {
     make_dtrace_method_entry(method());

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -34,6 +34,25 @@
 #include "opto/runtime.hpp"
 #include "runtime/sharedRuntime.hpp"
 
+// MNCMNC
+void GraphKit::make_trigger_action() {
+  const TypeFunc *call_type    = OptoRuntime::trigger_action_from_c2_Type();
+  address         call_address = CAST_FROM_FN_PTR(address, SharedRuntime::trigger_action_from_c2);
+  const char     *call_name    = "trigger_action_from_c2";
+
+  // Get base of thread-local storage area
+  Node* thread = _gvn.transform( new ThreadLocalNode() );
+
+  kill_dead_locals();
+
+  // For some reason, this call reads only raw memory.
+  const TypePtr* raw_adr_type = TypeRawPtr::BOTTOM;
+  make_runtime_call(RC_LEAF | RC_NARROW_MEM,
+                    call_type, call_address,
+                    call_name, raw_adr_type,
+                    thread);
+}
+
 //------------------------------make_dtrace_method_entry_exit ----------------
 // Dtrace -- record entry or exit of a method if compiled with dtrace support
 void GraphKit::make_dtrace_method_entry_exit(ciMethod* method, bool is_entry) {

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -1817,6 +1817,22 @@ const TypeFunc *OptoRuntime::class_id_load_barrier_Type() {
 #endif
 
 //-----------------------------------------------------------------------------
+// AOT
+const TypeFunc *OptoRuntime::trigger_action_from_c2_Type() {
+  // create input type (domain)
+  const Type **fields = TypeTuple::fields(1);
+  fields[TypeFunc::Parms+0] = TypeRawPtr::BOTTOM; // Thread-local storage
+  const TypeTuple *domain = TypeTuple::make(TypeFunc::Parms+1,fields);
+
+  // create result type (range)
+  fields = TypeTuple::fields(0);
+
+  const TypeTuple *range = TypeTuple::make(TypeFunc::Parms+0,fields);
+
+  return TypeFunc::make(domain,range);
+}
+
+//-----------------------------------------------------------------------------
 // Dtrace support.  entry and exit probes have the same signature
 const TypeFunc *OptoRuntime::dtrace_method_entry_exit_Type() {
   // create input type (domain)

--- a/src/hotspot/share/opto/runtime.hpp
+++ b/src/hotspot/share/opto/runtime.hpp
@@ -313,6 +313,9 @@ private:
   static const TypeFunc* notify_jvmti_vthread_Type();
 #endif
 
+  // AOT
+  static const TypeFunc* trigger_action_from_c2_Type();
+
   // Dtrace support
   static const TypeFunc* dtrace_method_entry_exit_Type();
   static const TypeFunc* dtrace_object_alloc_Type();

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1412,7 +1412,7 @@ void SharedRuntime::trigger_action_from_c1(JavaThread* current)
   }
 }
 
-RRT_LEAF(void, SharedRuntime::trigger_action_from_c2(JavaThread* current))
+JRT_LEAF(void, SharedRuntime::trigger_action_from_c2(JavaThread* current))
 {
   vframeStream vfst(current);//, true);
   if(!vfst.at_end()) {

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1397,10 +1397,31 @@ methodHandle SharedRuntime::find_callee_method(TRAPS) {
   return callee_method;
 }
 
+void SharedRuntime::trigger_action_from_c1(JavaThread* current)
+{
+  vframeStream vfst(current);//, true);
+  //assert(!vfst.at_end(), "Java frame must exist");
+  //Method m = vfst.method();
+
+  ResourceMark rm(current);
+  methodHandle caller(current, vfst.method());
+  //Symbol* name = caller->name();
+  //if (name != nullptr) {
+  //  tty->print_cr("method = %s", name->as_C_string());
+  //}
+  if(caller->is_trigger()) {
+    JRT_BLOCK
+      SharedRuntime::trigger_action("from c1", CHECK);
+    JRT_BLOCK_END
+  }
+}
+
 void SharedRuntime::trigger_action(const char* info, TRAPS)
 {
   tty->print_cr("SharedRuntime::trigger_action %s", info);
 
+  JavaThread* current = THREAD;
+  ResourceMark rm(current);
   Symbol* system_name  = vmSymbols::java_lang_System();
   Klass*  system_klass = SystemDictionary::resolve_or_fail(system_name, true /*throw error*/,  CHECK);
   JavaValue result(T_OBJECT);

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1397,9 +1397,23 @@ methodHandle SharedRuntime::find_callee_method(TRAPS) {
   return callee_method;
 }
 
-void SharedRuntime::trigger_action(const char* info)
+void SharedRuntime::trigger_action(const char* info, TRAPS)
 {
-    tty->print_cr("SharedRuntime::trigger_action %s", info);
+  tty->print_cr("SharedRuntime::trigger_action %s", info);
+
+  Symbol* system_name  = vmSymbols::java_lang_System();
+  Klass*  system_klass = SystemDictionary::resolve_or_fail(system_name, true /*throw error*/,  CHECK);
+  JavaValue result(T_OBJECT);
+  JavaCallArguments args;
+  args.push_int(0);
+  JavaCalls::call_static(&result,
+                         system_klass,
+                         vmSymbols::exit_method_name(),
+                         vmSymbols::int_void_signature(),
+                         &args, CHECK);
+  if (!HAS_PENDING_EXCEPTION) {
+    tty->print_cr("Came back from System.exit!");
+  }
 }
 
 // Resolves a call.
@@ -1455,9 +1469,9 @@ methodHandle SharedRuntime::resolve_helper(bool is_virtual, bool is_optimized, T
 
   // MNCMNC shouldnt trigger from here as this can even be a call to the interpreter
   // which would also call trigger_action
-  if (callee_method->is_trigger()) {
-    SharedRuntime::trigger_action("SharedRuntime");
-  }
+  //if (callee_method->is_trigger()) {
+  //  SharedRuntime::trigger_action("SharedRuntime");
+  //}
 
   if (invoke_code == Bytecodes::_invokestatic) {
     assert(callee_method->method_holder()->is_initialized() ||

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1397,6 +1397,11 @@ methodHandle SharedRuntime::find_callee_method(TRAPS) {
   return callee_method;
 }
 
+void SharedRuntime::trigger_action(const char* info)
+{
+    tty->print_cr("SharedRuntime::trigger_action %s", info);
+}
+
 // Resolves a call.
 methodHandle SharedRuntime::resolve_helper(bool is_virtual, bool is_optimized, TRAPS) {
   JavaThread* current = THREAD;
@@ -1447,6 +1452,12 @@ methodHandle SharedRuntime::resolve_helper(bool is_virtual, bool is_optimized, T
                   p2i(caller_frame.pc()), p2i(callee_method->code()));
   }
 #endif
+
+  // MNCMNC shouldnt trigger from here as this can even be a call to the interpreter
+  // which would also call trigger_action
+  if (callee_method->is_trigger()) {
+    SharedRuntime::trigger_action("SharedRuntime");
+  }
 
   if (invoke_code == Bytecodes::_invokestatic) {
     assert(callee_method->method_holder()->is_initialized() ||

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1400,21 +1400,33 @@ methodHandle SharedRuntime::find_callee_method(TRAPS) {
 void SharedRuntime::trigger_action_from_c1(JavaThread* current)
 {
   vframeStream vfst(current);//, true);
-  //assert(!vfst.at_end(), "Java frame must exist");
-  //Method m = vfst.method();
-
-  ResourceMark rm(current);
-  methodHandle caller(current, vfst.method());
-  //Symbol* name = caller->name();
-  //if (name != nullptr) {
-  //  tty->print_cr("method = %s", name->as_C_string());
-  //}
-  if(caller->is_trigger()) {
-    JRT_BLOCK
-      SharedRuntime::trigger_action("from c1", CHECK);
-    JRT_BLOCK_END
+  if(!vfst.at_end()) {
+    //assert(!vfst.at_end(), "Java frame must exist");
+    ResourceMark rm(current);
+    methodHandle caller(current, vfst.method());
+    if(caller->is_trigger()) {
+      JRT_BLOCK
+        SharedRuntime::trigger_action("from c1", CHECK);
+      JRT_BLOCK_END
+    }
   }
 }
+
+RRT_LEAF(void, SharedRuntime::trigger_action_from_c2(JavaThread* current))
+{
+  vframeStream vfst(current);//, true);
+  if(!vfst.at_end()) {
+    //assert(!vfst.at_end(), "Java frame must exist");
+    ResourceMark rm(current);
+    methodHandle caller(current, vfst.method());
+    if(caller->is_trigger()) {
+      JRT_BLOCK
+        SharedRuntime::trigger_action("from c2", CHECK);
+      JRT_BLOCK_END
+    }
+  }
+}
+JRT_END
 
 void SharedRuntime::trigger_action(const char* info, TRAPS)
 {

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -345,6 +345,9 @@ class SharedRuntime: AllStatic {
   // compiled code.
   static methodHandle resolve_helper(bool is_virtual, bool is_optimized, TRAPS);
 
+  // MNCMNC
+  static void trigger_action(const char* info);
+  
  private:
   // deopt blob
   static void generate_deopt_blob(void);

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -346,8 +346,8 @@ class SharedRuntime: AllStatic {
   static methodHandle resolve_helper(bool is_virtual, bool is_optimized, TRAPS);
 
   // MNCMNC
-  static void trigger_action(const char* info);
-  
+  static void trigger_action(const char* info, TRAPS);
+
  private:
   // deopt blob
   static void generate_deopt_blob(void);

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -346,6 +346,7 @@ class SharedRuntime: AllStatic {
   static methodHandle resolve_helper(bool is_virtual, bool is_optimized, TRAPS);
 
   // MNCMNC
+  static void trigger_action_from_c1(JavaThread* current);//TRAPS);
   static void trigger_action(const char* info, TRAPS);
 
  private:

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -347,6 +347,7 @@ class SharedRuntime: AllStatic {
 
   // MNCMNC
   static void trigger_action_from_c1(JavaThread* current);//TRAPS);
+  static void trigger_action_from_c2(JavaThread* current);//TRAPS);
   static void trigger_action(const char* info, TRAPS);
 
  private:

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -134,6 +134,7 @@ void DCmd::register_dcmds(){
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<CompileQueueDCmd>(full_export, true, false));
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<CodeListDCmd>(full_export, true, false));
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<CodeCacheDCmd>(full_export, true, false));
+  DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<AOTEndTrainingDCmd>(full_export, true, false));
 #ifdef LINUX
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<PerfMapDCmd>(full_export, true, false));
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<TrimCLibcHeapDCmd>(full_export, true, false));
@@ -989,6 +990,10 @@ public:
 void ClassesDCmd::execute(DCmdSource source, TRAPS) {
   VM_PrintClasses vmop(output(), _verbose.value());
   VMThread::execute(&vmop);
+}
+
+void AOTEndTrainingDCmd::execute(DCmdSource source, TRAPS) {
+  SharedRuntime::trigger_action("from diagnostic Command", CHECK);
 }
 
 #if INCLUDE_CDS

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -395,6 +395,24 @@ public:
   virtual void execute(DCmdSource source, TRAPS);
 };
 
+class AOTEndTrainingDCmd : public DCmd {
+public:
+  AOTEndTrainingDCmd(outputStream* output, bool heap) : DCmd(output, heap) { }
+    static const char* name() { return "AOT.end_training"; }
+    static const char* description() {
+      return "End AOT training and create the cache.";
+    }
+    static const char* impact() {
+      return "High: [insert reason here]";
+    }
+    static const JavaPermission permission() {
+    JavaPermission p = {"java.lang.management.ManagementPermission",
+                        "monitor", nullptr};
+      return p;
+    }
+    virtual void execute(DCmdSource source, TRAPS);
+};
+
 #if INCLUDE_CDS
 class DumpSharedArchiveDCmd: public DCmdWithParser {
 protected:


### PR DESCRIPTION
AOT training can be ended using either

1. -XX:AOTCreateOnMethodEntry=Hello.someMethod [same syntax as CompileOnly]
2. jcmd [pid] AOT.end_training

only supports arm64 (x64 to be added before PR)

note: this draft PR is or internal exposure while I address some runtime issues (and finalize naming)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.org/leyden.git pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/19.diff">https://git.openjdk.org/leyden/pull/19.diff</a>

</details>
