### PR TITLE
Load coops base shift from AOTRuntimeConstants in AOT code

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -5172,7 +5172,7 @@ operand indOffX2P(iRegL reg, immLOffset off)
 
 operand indirectN(iRegN reg)
 %{
-  predicate(CompressedOops::shift() == 0);
+  predicate(CompressedOops::shift() == 0 && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(DecodeN reg);
   op_cost(0);
@@ -5187,7 +5187,7 @@ operand indirectN(iRegN reg)
 
 operand indIndexScaledI2LN(iRegN reg, iRegI ireg, immIScale scale)
 %{
-  predicate(CompressedOops::shift() == 0 && size_fits_all_mem_uses(n->as_AddP(), n->in(AddPNode::Offset)->in(2)->get_int()));
+  predicate(CompressedOops::shift() == 0 && size_fits_all_mem_uses(n->as_AddP(), n->in(AddPNode::Offset)->in(2)->get_int()) && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (DecodeN reg) (LShiftL (ConvI2L ireg) scale));
   op_cost(0);
@@ -5202,7 +5202,7 @@ operand indIndexScaledI2LN(iRegN reg, iRegI ireg, immIScale scale)
 
 operand indIndexScaledN(iRegN reg, iRegL lreg, immIScale scale)
 %{
-  predicate(CompressedOops::shift() == 0 && size_fits_all_mem_uses(n->as_AddP(), n->in(AddPNode::Offset)->in(2)->get_int()));
+  predicate(CompressedOops::shift() == 0 && size_fits_all_mem_uses(n->as_AddP(), n->in(AddPNode::Offset)->in(2)->get_int()) && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (DecodeN reg) (LShiftL lreg scale));
   op_cost(0);
@@ -5217,7 +5217,7 @@ operand indIndexScaledN(iRegN reg, iRegL lreg, immIScale scale)
 
 operand indIndexI2LN(iRegN reg, iRegI ireg)
 %{
-  predicate(CompressedOops::shift() == 0);
+  predicate(CompressedOops::shift() == 0  && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (DecodeN reg) (ConvI2L ireg));
   op_cost(0);
@@ -5232,7 +5232,7 @@ operand indIndexI2LN(iRegN reg, iRegI ireg)
 
 operand indIndexN(iRegN reg, iRegL lreg)
 %{
-  predicate(CompressedOops::shift() == 0);
+  predicate(CompressedOops::shift() == 0 && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (DecodeN reg) lreg);
   op_cost(0);
@@ -5247,7 +5247,7 @@ operand indIndexN(iRegN reg, iRegL lreg)
 
 operand indOffIN(iRegN reg, immIOffset off)
 %{
-  predicate(CompressedOops::shift() == 0);
+  predicate(CompressedOops::shift() == 0 && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (DecodeN reg) off);
   op_cost(0);
@@ -5262,7 +5262,7 @@ operand indOffIN(iRegN reg, immIOffset off)
 
 operand indOffLN(iRegN reg, immLOffset off)
 %{
-  predicate(CompressedOops::shift() == 0);
+  predicate(CompressedOops::shift() == 0 && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (DecodeN reg) off);
   op_cost(0);
@@ -7790,7 +7790,7 @@ instruct convP2I(iRegINoSp dst, iRegP src) %{
 // in case of 32bit oops (heap < 4Gb).
 instruct convN2I(iRegINoSp dst, iRegN src)
 %{
-  predicate(CompressedOops::shift() == 0);
+  predicate(CompressedOops::shift() == 0 && !SCCache::is_on_for_write());
   match(Set dst (ConvL2I (CastP2X (DecodeN src))));
 
   ins_cost(INSN_COST);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5120,14 +5120,8 @@ void  MacroAssembler::decode_heap_oop_not_null(Register dst, Register src) {
 }
 
 static Register pick_different_tmp(Register dst, Register src) {
-  Register tmp = r0;
-  if (tmp == src || tmp == dst) {
-    tmp = r1;
-    if (tmp == src || tmp == dst) {
-      tmp = r2;
-    }
-  }
-  return tmp;
+  auto tmps = RegSet::of(r0, r1, r2) - RegSet::of(src, dst);
+  return *tmps.begin();
 }
 
 void MacroAssembler::encode_heap_oop_for_aot(Register dst, Register src) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -920,6 +920,13 @@ public:
   void encode_heap_oop_not_null(Register dst, Register src);
   void decode_heap_oop_not_null(Register dst, Register src);
 
+private:
+  void encode_heap_oop_for_aot(Register dst, Register src);
+  void decode_heap_oop_for_aot(Register dst, Register src);
+  void encode_heap_oop_not_null_for_aot(Register dst, Register src);
+  void decode_heap_oop_not_null_for_aot(Register dst, Register src);
+
+public:
   void set_narrow_oop(Register dst, jobject obj);
 
   void encode_klass_not_null(Register r);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5774,12 +5774,40 @@ void MacroAssembler::verify_heapbase(const char* msg) {
 }
 #endif
 
+void MacroAssembler::encode_heap_oop_for_aot(Register r) {
+  assert(SCCache::is_on_for_write(), "should be for AOT code");
+  Register oop = r;
+  if (r == rcx) {
+    push(rscratch1);
+    movq(rscratch1, r);
+    oop = rscratch1;
+  } else {
+    push(rcx);
+  }
+  testq(oop, oop);
+  movptr(rcx, ExternalAddress(AOTRuntimeConstants::coops_base_address()));
+  cmovq(Assembler::equal, oop, rcx);
+  subq(oop, rcx);
+  movptr(rcx, ExternalAddress(AOTRuntimeConstants::coops_shift_address()));
+  shrq(oop);
+  if (r == rcx) {
+    mov(r, rscratch1);
+    pop(rscratch1);
+  } else {
+    pop(rcx);
+  }
+}
+
 // Algorithm must match oop.inline.hpp encode_heap_oop.
 void MacroAssembler::encode_heap_oop(Register r) {
 #ifdef ASSERT
   verify_heapbase("MacroAssembler::encode_heap_oop: heap base corrupted?");
 #endif
   verify_oop_msg(r, "broken oop in encode_heap_oop");
+  if (SCCache::is_on_for_write()) {
+    encode_heap_oop_for_aot(r);
+    return;
+  }
   if (CompressedOops::base() == nullptr) {
     if (CompressedOops::shift() != 0) {
       assert (LogMinObjAlignmentInBytes == CompressedOops::shift(), "decode alg wrong");
@@ -5791,6 +5819,28 @@ void MacroAssembler::encode_heap_oop(Register r) {
   cmovq(Assembler::equal, r, r12_heapbase);
   subq(r, r12_heapbase);
   shrq(r, LogMinObjAlignmentInBytes);
+}
+
+void MacroAssembler::encode_heap_oop_not_null_for_aot(Register r) {
+  assert(SCCache::is_on_for_write(), "should be for AOT code");
+  Register oop = r;
+  if (r == rcx) {
+    push(rscratch1);
+    movq(rscratch1, r);
+    oop = rscratch1;
+  } else {
+    push(rcx);
+  }
+  movptr(rcx, ExternalAddress(AOTRuntimeConstants::coops_base_address()));
+  subq(oop, rcx);
+  movptr(rcx, ExternalAddress(AOTRuntimeConstants::coops_shift_address()));
+  shrq(oop);
+  if (r == rcx) {
+    mov(r, rscratch1);
+    pop(rscratch1);
+  } else {
+    pop(rcx);
+  }
 }
 
 void MacroAssembler::encode_heap_oop_not_null(Register r) {
@@ -5805,6 +5855,10 @@ void MacroAssembler::encode_heap_oop_not_null(Register r) {
   }
 #endif
   verify_oop_msg(r, "broken oop in encode_heap_oop_not_null");
+  if (SCCache::is_on_for_write()) {
+    encode_heap_oop_not_null_for_aot(r);
+    return;
+  }
   if (CompressedOops::base() != nullptr) {
     subq(r, r12_heapbase);
   }
@@ -5829,6 +5883,10 @@ void MacroAssembler::encode_heap_oop_not_null(Register dst, Register src) {
   if (dst != src) {
     movq(dst, src);
   }
+  if (SCCache::is_on_for_write()) {
+    encode_heap_oop_not_null_for_aot(dst);
+    return;
+  }
   if (CompressedOops::base() != nullptr) {
     subq(dst, r12_heapbase);
   }
@@ -5838,10 +5896,39 @@ void MacroAssembler::encode_heap_oop_not_null(Register dst, Register src) {
   }
 }
 
-void  MacroAssembler::decode_heap_oop(Register r) {
+void MacroAssembler::decode_heap_oop_for_aot(Register r) {
+  assert(SCCache::is_on_for_write(), "should be for AOT code");
+  Label done;
+  Register narrowOop = r;
+  if (r == rcx) {
+    push(rscratch1);
+    movq(rscratch1, r);
+    narrowOop = rscratch1;
+  } else {
+    push(rcx);
+  }
+  movptr(rcx, ExternalAddress(AOTRuntimeConstants::coops_shift_address()));
+  shlq(narrowOop);
+  jccb(Assembler::equal, done);
+  movptr(rcx, ExternalAddress(AOTRuntimeConstants::coops_base_address()));
+  addq(narrowOop, rcx);
+  bind(done);
+  if (r == rcx) {
+    movq(r, rscratch1);
+    pop(rscratch1);
+  } else {
+    pop(rcx);
+  }
+}
+
+void MacroAssembler::decode_heap_oop(Register r) {
 #ifdef ASSERT
   verify_heapbase("MacroAssembler::decode_heap_oop: heap base corrupted?");
 #endif
+  if (SCCache::is_on_for_write()) {
+    decode_heap_oop_for_aot(r);
+    return;
+  }
   if (CompressedOops::base() == nullptr) {
     if (CompressedOops::shift() != 0) {
       assert (LogMinObjAlignmentInBytes == CompressedOops::shift(), "decode alg wrong");
@@ -5857,13 +5944,39 @@ void  MacroAssembler::decode_heap_oop(Register r) {
   verify_oop_msg(r, "broken oop in decode_heap_oop");
 }
 
-void  MacroAssembler::decode_heap_oop_not_null(Register r) {
+void MacroAssembler::decode_heap_oop_not_null_for_aot(Register r) {
+  assert(SCCache::is_on_for_write(), "should be for AOT code");
+  Register narrowOop = r;
+  if (r == rcx) {
+    push(rscratch1);
+    movq(rscratch1, r);
+    narrowOop = rscratch1;
+  } else {
+    push(rcx);
+  }
+  movptr(rcx, ExternalAddress(AOTRuntimeConstants::coops_shift_address()));
+  shlq(narrowOop);
+  movptr(rcx, ExternalAddress(AOTRuntimeConstants::coops_base_address()));
+  addq(narrowOop, rcx);
+  if (r == rcx) {
+    movq(r, rscratch1);
+    pop(rscratch1);
+  } else {
+    pop(rcx);
+  }
+}
+
+void MacroAssembler::decode_heap_oop_not_null(Register r) {
   // Note: it will change flags
   assert (UseCompressedOops, "should only be used for compressed headers");
   assert (Universe::heap() != nullptr, "java heap should be initialized");
   // Cannot assert, unverified entry point counts instructions (see .ad file)
   // vtableStubs also counts instructions in pd_code_size_limit.
   // Also do not verify_oop as this is called by verify_oop.
+  if (SCCache::is_on_for_write()) {
+    decode_heap_oop_not_null_for_aot(r);
+    return;
+  }
   if (CompressedOops::shift() != 0) {
     assert(LogMinObjAlignmentInBytes == CompressedOops::shift(), "decode alg wrong");
     shlq(r, LogMinObjAlignmentInBytes);
@@ -5882,6 +5995,13 @@ void  MacroAssembler::decode_heap_oop_not_null(Register dst, Register src) {
   // Cannot assert, unverified entry point counts instructions (see .ad file)
   // vtableStubs also counts instructions in pd_code_size_limit.
   // Also do not verify_oop as this is called by verify_oop.
+  if (SCCache::is_on_for_write()) {
+    if (dst != src) {
+      movq(dst, src);
+    }
+    decode_heap_oop_not_null_for_aot(dst);
+    return;
+  }
   if (CompressedOops::shift() != 0) {
     assert(LogMinObjAlignmentInBytes == CompressedOops::shift(), "decode alg wrong");
     if (LogMinObjAlignmentInBytes == Address::times_8) {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -398,6 +398,11 @@ class MacroAssembler: public Assembler {
   void encode_heap_oop_not_null(Register dst, Register src);
   void decode_heap_oop_not_null(Register dst, Register src);
 
+  void encode_heap_oop_for_aot(Register r);
+  void decode_heap_oop_for_aot(Register r);
+  void encode_heap_oop_not_null_for_aot(Register r);
+  void decode_heap_oop_not_null_for_aot(Register r);
+
   void set_narrow_oop(Register dst, jobject obj);
   void set_narrow_oop(Address dst, jobject obj);
   void cmp_narrow_oop(Register dst, jobject obj);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -421,6 +421,7 @@ reg_class int_rdi_reg(RDI);
 source_hpp %{
 
 #include "peephole_x86_64.hpp"
+#include <code/SCCache.hpp>
 
 %}
 
@@ -3080,7 +3081,7 @@ operand indPosIndexScaleOffset(any_RegP reg, immL32 off, rRegI idx, immI2 scale)
 // Note: x86 architecture doesn't support "scale * index + offset" without a base
 // we can't free r12 even with CompressedOops::base() == nullptr.
 operand indCompressedOopOffset(rRegN reg, immL32 off) %{
-  predicate(UseCompressedOops && (CompressedOops::shift() == Address::times_8));
+  predicate(UseCompressedOops && (CompressedOops::shift() == Address::times_8) && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (DecodeN reg) off);
 
@@ -3097,7 +3098,7 @@ operand indCompressedOopOffset(rRegN reg, immL32 off) %{
 // Indirect Memory Operand
 operand indirectNarrow(rRegN reg)
 %{
-  predicate(CompressedOops::shift() == 0);
+  predicate(CompressedOops::shift() == 0 && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(DecodeN reg);
 
@@ -3113,7 +3114,7 @@ operand indirectNarrow(rRegN reg)
 // Indirect Memory Plus Short Offset Operand
 operand indOffset8Narrow(rRegN reg, immL8 off)
 %{
-  predicate(CompressedOops::shift() == 0);
+  predicate(CompressedOops::shift() == 0 && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (DecodeN reg) off);
 
@@ -3129,7 +3130,7 @@ operand indOffset8Narrow(rRegN reg, immL8 off)
 // Indirect Memory Plus Long Offset Operand
 operand indOffset32Narrow(rRegN reg, immL32 off)
 %{
-  predicate(CompressedOops::shift() == 0);
+  predicate(CompressedOops::shift() == 0 && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (DecodeN reg) off);
 
@@ -3145,7 +3146,7 @@ operand indOffset32Narrow(rRegN reg, immL32 off)
 // Indirect Memory Plus Index Register Plus Offset Operand
 operand indIndexOffsetNarrow(rRegN reg, rRegL lreg, immL32 off)
 %{
-  predicate(CompressedOops::shift() == 0);
+  predicate(CompressedOops::shift() == 0 && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (AddP (DecodeN reg) lreg) off);
 
@@ -3162,7 +3163,7 @@ operand indIndexOffsetNarrow(rRegN reg, rRegL lreg, immL32 off)
 // Indirect Memory Plus Index Register Plus Offset Operand
 operand indIndexNarrow(rRegN reg, rRegL lreg)
 %{
-  predicate(CompressedOops::shift() == 0);
+  predicate(CompressedOops::shift() == 0 && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (DecodeN reg) lreg);
 
@@ -3179,7 +3180,7 @@ operand indIndexNarrow(rRegN reg, rRegL lreg)
 // Indirect Memory Times Scale Plus Index Register
 operand indIndexScaleNarrow(rRegN reg, rRegL lreg, immI2 scale)
 %{
-  predicate(CompressedOops::shift() == 0);
+  predicate(CompressedOops::shift() == 0 && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (DecodeN reg) (LShiftL lreg scale));
 
@@ -3196,7 +3197,7 @@ operand indIndexScaleNarrow(rRegN reg, rRegL lreg, immI2 scale)
 // Indirect Memory Times Scale Plus Index Register Plus Offset Operand
 operand indIndexScaleOffsetNarrow(rRegN reg, immL32 off, rRegL lreg, immI2 scale)
 %{
-  predicate(CompressedOops::shift() == 0);
+  predicate(CompressedOops::shift() == 0 && !SCCache::is_on_for_write());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (AddP (DecodeN reg) (LShiftL lreg scale)) off);
 
@@ -3214,7 +3215,7 @@ operand indIndexScaleOffsetNarrow(rRegN reg, immL32 off, rRegL lreg, immI2 scale
 operand indPosIndexOffsetNarrow(rRegN reg, immL32 off, rRegI idx)
 %{
   constraint(ALLOC_IN_RC(ptr_reg));
-  predicate(CompressedOops::shift() == 0 && n->in(2)->in(3)->as_Type()->type()->is_long()->_lo >= 0);
+  predicate(CompressedOops::shift() == 0 && n->in(2)->in(3)->as_Type()->type()->is_long()->_lo >= 0 && !SCCache::is_on_for_write());
   match(AddP (AddP (DecodeN reg) (ConvI2L idx)) off);
 
   op_cost(10);
@@ -3231,7 +3232,7 @@ operand indPosIndexOffsetNarrow(rRegN reg, immL32 off, rRegI idx)
 operand indPosIndexScaleOffsetNarrow(rRegN reg, immL32 off, rRegI idx, immI2 scale)
 %{
   constraint(ALLOC_IN_RC(ptr_reg));
-  predicate(CompressedOops::shift() == 0 && n->in(2)->in(3)->in(1)->as_Type()->type()->is_long()->_lo >= 0);
+  predicate(CompressedOops::shift() == 0 && n->in(2)->in(3)->in(1)->as_Type()->type()->is_long()->_lo >= 0 && !SCCache::is_on_for_write());
   match(AddP (AddP (DecodeN reg) (LShiftL (ConvI2L idx) scale)) off);
 
   op_cost(10);
@@ -5995,7 +5996,7 @@ instruct convP2I(rRegI dst, rRegP src)
 // in case of 32bit oops (heap < 4Gb).
 instruct convN2I(rRegI dst, rRegN src)
 %{
-  predicate(CompressedOops::shift() == 0);
+  predicate(CompressedOops::shift() == 0 && !SCCache::is_on_for_write());
   match(Set dst (ConvL2I (CastP2X (DecodeN src))));
 
   format %{ "movl    $dst, $src\t# compressed ptr -> int" %}

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -452,6 +452,7 @@ bool CDSConfig::check_vm_args_consistency(bool patch_mod_javabase, bool mode_fla
   check_flag_aliases();
 
   if (CacheDataStore != nullptr) {
+#if 0
     // Leyden temp work-around:
     //
     // By default, when using CacheDataStore, use the HeapBasedNarrowOop mode so that
@@ -466,6 +467,7 @@ bool CDSConfig::check_vm_args_consistency(bool patch_mod_javabase, bool mode_fla
     // because it is unable to load the AOT code cache.
 #ifdef _LP64
     FLAG_SET_ERGO_IF_DEFAULT(UseCompatibleCompressedOops, true);
+#endif
 #endif
 
     // Leyden temp: make sure the user knows if CDS archive somehow fails to load.

--- a/src/hotspot/share/code/SCCache.cpp
+++ b/src/hotspot/share/code/SCCache.cpp
@@ -676,11 +676,13 @@ bool SCConfig::verify(const char* cache_path) const {
     log_warning(scc, init)("Disable Startup Code Cache: '%s' was created with RestrictContended = %s", cache_path, RestrictContended ? "false" : "true");
     return false;
   }
+#ifdef _LP64
   if (UseCompatibleCompressedOops && (_compressedOopShift != (uint)CompressedOops::shift())) {
     log_warning(scc, init)("Disable Startup Code Cache: '%s' was created with CompressedOops::shift() = %d vs current %d and UseCompatibleCompressedOops=%s", cache_path, _compressedOopShift, CompressedOops::shift(),
                            UseCompatibleCompressedOops ? "true" : "false");
     return false;
   }
+#endif
   if (_compressedKlassShift != (uint)CompressedKlassPointers::shift()) {
     log_warning(scc, init)("Disable Startup Code Cache: '%s' was created with CompressedKlassPointers::shift() = %d vs current %d", cache_path, _compressedKlassShift, CompressedKlassPointers::shift());
     return false;

--- a/src/hotspot/share/code/SCCache.cpp
+++ b/src/hotspot/share/code/SCCache.cpp
@@ -676,8 +676,9 @@ bool SCConfig::verify(const char* cache_path) const {
     log_warning(scc, init)("Disable Startup Code Cache: '%s' was created with RestrictContended = %s", cache_path, RestrictContended ? "false" : "true");
     return false;
   }
-  if (_compressedOopShift != (uint)CompressedOops::shift()) {
-    log_warning(scc, init)("Disable Startup Code Cache: '%s' was created with CompressedOops::shift() = %d vs current %d", cache_path, _compressedOopShift, CompressedOops::shift());
+  if (UseCompatibleCompressedOops && (_compressedOopShift != (uint)CompressedOops::shift())) {
+    log_warning(scc, init)("Disable Startup Code Cache: '%s' was created with CompressedOops::shift() = %d vs current %d and UseCompatibleCompressedOops=%s", cache_path, _compressedOopShift, CompressedOops::shift(),
+                           UseCompatibleCompressedOops ? "true" : "false");
     return false;
   }
   if (_compressedKlassShift != (uint)CompressedKlassPointers::shift()) {
@@ -4180,6 +4181,10 @@ void AOTRuntimeConstants::initialize_from_runtime() {
     _aot_runtime_constants._grain_shift = ctbs->grain_shift();
     _aot_runtime_constants._card_shift = ctbs->card_shift();
   }
+  if (UseCompressedOops) {
+    _aot_runtime_constants._coops_base = CompressedOops::base();
+    _aot_runtime_constants._coops_shift = CompressedOops::shift();
+  }
 }
 
 AOTRuntimeConstants AOTRuntimeConstants::_aot_runtime_constants;
@@ -4187,6 +4192,8 @@ AOTRuntimeConstants AOTRuntimeConstants::_aot_runtime_constants;
 address AOTRuntimeConstants::_field_addresses_list[] = {
   grain_shift_address(),
   card_shift_address(),
+  coops_base_address(),
+  coops_shift_address(),
   nullptr
 };
 

--- a/src/hotspot/share/code/SCCache.cpp
+++ b/src/hotspot/share/code/SCCache.cpp
@@ -678,8 +678,7 @@ bool SCConfig::verify(const char* cache_path) const {
   }
 #ifdef _LP64
   if (UseCompatibleCompressedOops && (_compressedOopShift != (uint)CompressedOops::shift())) {
-    log_warning(scc, init)("Disable Startup Code Cache: '%s' was created with CompressedOops::shift() = %d vs current %d and UseCompatibleCompressedOops=%s", cache_path, _compressedOopShift, CompressedOops::shift(),
-                           UseCompatibleCompressedOops ? "true" : "false");
+    log_warning(scc, init)("Disable Startup Code Cache: '%s' was created with CompressedOops::shift() = %d vs current %d and UseCompatibleCompressedOops=true", cache_path, _compressedOopShift, CompressedOops::shift());
     return false;
   }
 #endif

--- a/src/hotspot/share/code/SCCache.hpp
+++ b/src/hotspot/share/code/SCCache.hpp
@@ -616,10 +616,10 @@ public:
 // code cache internal runtime constants area used by AOT code
 class AOTRuntimeConstants {
  friend class SCCache;
-  uint _grain_shift;
-  uint _card_shift;
   address _coops_base;
   uint _coops_shift;
+  uint _grain_shift;
+  uint _card_shift;
 
   static address _field_addresses_list[];
   static AOTRuntimeConstants _aot_runtime_constants;

--- a/src/hotspot/share/code/SCCache.hpp
+++ b/src/hotspot/share/code/SCCache.hpp
@@ -618,6 +618,9 @@ class AOTRuntimeConstants {
  friend class SCCache;
   uint _grain_shift;
   uint _card_shift;
+  address _coops_base;
+  uint _coops_shift;
+
   static address _field_addresses_list[];
   static AOTRuntimeConstants _aot_runtime_constants;
   // private constructor for unique singleton
@@ -632,6 +635,9 @@ class AOTRuntimeConstants {
   }
   static address grain_shift_address() { return (address)&_aot_runtime_constants._grain_shift; }
   static address card_shift_address() { return (address)&_aot_runtime_constants._card_shift; }
+  static address coops_base_address() { return (address)&_aot_runtime_constants._coops_base; }
+  static address coops_shift_address() { return (address)&_aot_runtime_constants._coops_shift; }
+
   static address* field_addresses_list() {
     return _field_addresses_list;
   }


### PR DESCRIPTION
This PR modifies AOT compiled method code to load compressed oops base and shift constants via the AOTRuntimeConstants area rather than encode them as immediates. It also unlatches the currently forced setting of UseCompatibleCompressedOops, allowing the heap to be allocated wherever it will fit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.org/leyden.git pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/20.diff">https://git.openjdk.org/leyden/pull/20.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/20#issuecomment-2343781609)