### PR TITLE
Method name AOTClassInitializer::has_non_default_static_fields  should be has_default_static_fields

### DIFF
--- a/src/hotspot/share/cds/aotClassInitializer.cpp
+++ b/src/hotspot/share/cds/aotClassInitializer.cpp
@@ -136,7 +136,7 @@ bool AOTClassInitializer::check_can_be_preinited(InstanceKlass* ik) {
       log_info(cds, init)("cannot initialize %s (has <clinit>)", ik->external_name());
       return false;
     }
-    if (ik->is_initialized() && !has_non_default_static_fields(ik)) {
+    if (ik->is_initialized() && !has_default_static_fields(ik)) {
       return false;
     }
   }
@@ -144,7 +144,7 @@ bool AOTClassInitializer::check_can_be_preinited(InstanceKlass* ik) {
   return true;
 }
 
-bool AOTClassInitializer::has_non_default_static_fields(InstanceKlass* ik) {
+bool AOTClassInitializer::has_default_static_fields(InstanceKlass* ik) {
   oop mirror = ik->java_mirror();
 
   for (JavaFieldStream fs(ik); !fs.done(); fs.next()) {
@@ -235,7 +235,7 @@ void AOTClassInitializer::maybe_preinit_class(InstanceKlass* ik, TRAPS) {
 //
 // Between the two phases, some Java code may have been executed to contaminate the
 // some initialized mirrors. So we call reset_preinit_check() at the beginning of the
-// [2] so that we will re-run has_non_default_static_fields() on all the classes.
+// [2] so that we will re-run has_default_static_fields() on all the classes.
 // As a result, phase [2] may archive fewer mirrors that were initialized in phase [1].
 void AOTClassInitializer::reset_preinit_check() {
   auto iterator = [&] (InstanceKlass* k, DumpTimeClassInfo& info) {

--- a/src/hotspot/share/cds/aotClassInitializer.hpp
+++ b/src/hotspot/share/cds/aotClassInitializer.hpp
@@ -31,7 +31,7 @@
 class InstanceKlass;
 
 class AOTClassInitializer : AllStatic {
-  static bool has_non_default_static_fields(InstanceKlass* ik);
+  static bool has_default_static_fields(InstanceKlass* ik);
   static bool is_forced_preinit_class(InstanceKlass* ik);
 
   static bool check_can_be_preinited(InstanceKlass* ik);


### PR DESCRIPTION
Trivial change to correct the method name to reflect its implementation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.org/leyden.git pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/22.diff">https://git.openjdk.org/leyden/pull/22.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/22#issuecomment-2357037614)