### PR TITLE
8340559: [premain] java process crash with -XX:+PrintTrainingInfo

### DIFF
--- a/src/hotspot/share/oops/trainingData.cpp
+++ b/src/hotspot/share/oops/trainingData.cpp
@@ -176,10 +176,12 @@ MethodTrainingData* MethodTrainingData::make(const methodHandle& method,
 }
 
 void MethodTrainingData::print_on(outputStream* st, bool name_only) const {
-  _klass->print_on(st, true);
-  st->print(".");
-  name()->print_symbol_on(st);
-  signature()->print_symbol_on(st);
+  if (has_holder()) {
+    _klass->print_on(st, true);
+    st->print(".");
+    name()->print_symbol_on(st);
+    signature()->print_symbol_on(st);
+  }
   if (name_only) {
     return;
   }
@@ -409,8 +411,8 @@ KlassTrainingData* KlassTrainingData::make(InstanceKlass* holder, bool null_if_n
 }
 
 void KlassTrainingData::print_on(outputStream* st, bool name_only) const {
-  name()->print_symbol_on(st);
   if (has_holder()) {
+    name()->print_symbol_on(st);
     switch (holder()->init_state()) {
       case InstanceKlass::allocated:            st->print("[A]"); break;
       case InstanceKlass::loaded:               st->print("[D]"); break;


### PR DESCRIPTION
Java process crashes during training run with -XX:+PrintTrainingInfo as some of the _holder (i.e InstanceKlass and Method) objects are null in KlassTrainingData and MethodTrainingData.

repro command:
java -XX:+PrintTrainingInfo -XX:CacheDataStore=JavacBenchApp.cds -cp JavacBenchApp.jar JavacBenchApp 50

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8340559](https://bugs.openjdk.org/browse/JDK-8340559): [premain] java process crash with -XX:+PrintTrainingInfo (**Bug** - P4)


### Reviewers
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.org/leyden.git pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/23.diff">https://git.openjdk.org/leyden/pull/23.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/23#issuecomment-2364751470)