### PR TITLE
FileMapInfo::write_bitmap_region bug after premain merge

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1634,7 +1634,7 @@ char* FileMapInfo::write_bitmap_region(CHeapBitMap* rw_ptrmap, CHeapBitMap* ro_p
   size_t removed_ro_leading_zeros = remove_bitmap_zeros(ro_ptrmap);
   header()->set_rw_ptrmap_start_pos(removed_rw_leading_zeros);
   header()->set_ro_ptrmap_start_pos(removed_ro_leading_zeros);
-  size_in_bytes = rw_ptrmap->size_in_bytes() + ro_ptrmap->size_in_bytes();
+  size_in_bytes = rw_ptrmap->size_in_bytes() + ro_ptrmap->size_in_bytes() + cc_ptrmap->size_in_bytes();
 
   if (heap_info->is_used()) {
     // Remove leading and trailing zeros


### PR DESCRIPTION
I think there is a bad merge in `FileMapInfo::write_bitmap_region`.

The symptom on `runtime/cds` tests suggests we have have the overflow on `bitmap` buffer array we have just allocated, which suggests we miscalculated the size for it:

```
#  Internal Error (/home/shade/trunks/shipilev-leyden/src/hotspot/share/nmt/mallocHeader.inline.hpp:107), pid=2332848, tid=2332849
#  fatal error: NMT corruption: Block at 0x000078422d0c3120: footer canary broken at 0x000078422d0f8618 (buffer overflow?)

Stack: [0x0000784232100000,0x0000784232200000],  sp=0x00007842321fcfe0,  free space=1011k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x145e785]  MallocHeader* MallocHeader::resolve_checked_impl<void*, MallocHeader*>(void*)+0x145  (mallocHeader.inline.hpp:107)
V  [libjvm.so+0x145d599]  MallocTracker::record_free_block(void*)+0x29  (mallocHeader.inline.hpp:113)
V  [libjvm.so+0x15dc42a]  os::free(void*)+0x6a  (memTracker.hpp:94)
V  [libjvm.so+0x64a487]  ArchiveBuilder::write_archive(FileMapInfo*, ArchiveHeapInfo*)+0x457  (archiveBuilder.cpp:1569)
V  [libjvm.so+0x14d3ece]  MetaspaceShared::write_static_archive(ArchiveBuilder*, FileMapInfo*, ArchiveHeapInfo*)+0x4e  (metaspaceShared.cpp:1016)
V  [libjvm.so+0x14d9066]  MetaspaceShared::preload_and_dump_impl(StaticArchiveBuilder&, JavaThread*)+0x5c6  (metaspaceShared.cpp:999)
V  [libjvm.so+0x14d9217]  MetaspaceShared::preload_and_dump(JavaThread*)+0x87  (metaspaceShared.cpp:792)
V  [libjvm.so+0x1a4cd3c]  Threads::create_vm(JavaVMInitArgs*, bool*)+0x122c  (threads.cpp:909)
V  [libjvm.so+0x1078e78]  JNI_CreateJavaVM+0x58  (jni.cpp:3594)
C  [libjli.so+0x4903]  JavaMain+0x93  (java.c:1494)
C  [libjli.so+0x7f0d]  ThreadJavaMain+0xd  (java_md.c:633)
```

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds` now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.org/leyden.git pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/24.diff">https://git.openjdk.org/leyden/pull/24.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/24#issuecomment-2378681914)