### PR TITLE
8348858: [leyden] Bump the default code buffer sizes to store more generated code

### DIFF
--- a/src/hotspot/share/code/SCCache.cpp
+++ b/src/hotspot/share/code/SCCache.cpp
@@ -3133,7 +3133,7 @@ SCCEntry* SCCache::write_nmethod(const methodHandle& method,
 //  }
   if (buffer->before_expand() != nullptr) {
     ResourceMark rm;
-    log_info(scc, nmethod)("%d (L%d): Skip nmethod with expanded buffer '%s'", comp_id, (int)comp_level, method->name_and_sig_as_C_string());
+    log_warning(scc, nmethod)("%d (L%d): Skip nmethod with expanded buffer '%s'", comp_id, (int)comp_level, method->name_and_sig_as_C_string());
     return nullptr;
   }
 #ifdef ASSERT

--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -537,6 +537,23 @@ void G1BarrierSetC2::late_barrier_analysis() const {
   compute_liveness_at_stubs();
 }
 
+int G1BarrierSetC2::estimate_stub_size() const {
+  Compile* const C = Compile::current();
+  BufferBlob* const blob = C->output()->scratch_buffer_blob();
+  GrowableArray<G1BarrierStubC2*>* const stubs = barrier_set_state()->stubs();
+  int size = 0;
+
+  for (int i = 0; i < stubs->length(); i++) {
+    CodeBuffer cb(blob->content_begin(), checked_cast<CodeBuffer::csize_t>((address)C->output()->scratch_locs_memory() - blob->content_begin()));
+    MacroAssembler masm(&cb);
+    stubs->at(i)->emit_code(masm);
+    size += cb.insts_size();
+  }
+
+  // Add slop to avoid expansion during emit_stubs.
+  return size + PhaseOutput::MAX_inst_size;
+}
+
 void G1BarrierSetC2::emit_stubs(CodeBuffer& cb) const {
   MacroAssembler masm(&cb);
   GrowableArray<G1BarrierStubC2*>* const stubs = barrier_set_state()->stubs();

--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -537,29 +537,12 @@ void G1BarrierSetC2::late_barrier_analysis() const {
   compute_liveness_at_stubs();
 }
 
-int G1BarrierSetC2::estimate_stub_size() const {
-  Compile* const C = Compile::current();
-  BufferBlob* const blob = C->output()->scratch_buffer_blob();
-  GrowableArray<G1BarrierStubC2*>* const stubs = barrier_set_state()->stubs();
-  int size = 0;
-
-  for (int i = 0; i < stubs->length(); i++) {
-    CodeBuffer cb(blob->content_begin(), checked_cast<CodeBuffer::csize_t>((address)C->output()->scratch_locs_memory() - blob->content_begin()));
-    MacroAssembler masm(&cb);
-    stubs->at(i)->emit_code(masm);
-    size += cb.insts_size();
-  }
-
-  // Add slop to avoid expansion during emit_stubs.
-  return size + PhaseOutput::MAX_inst_size;
-}
-
 void G1BarrierSetC2::emit_stubs(CodeBuffer& cb) const {
   MacroAssembler masm(&cb);
   GrowableArray<G1BarrierStubC2*>* const stubs = barrier_set_state()->stubs();
   for (int i = 0; i < stubs->length(); i++) {
     // Make sure there is enough space in the code buffer
-    if (cb.insts()->maybe_expand_to_ensure_remaining(PhaseOutput::MAX_inst_size) && cb.blob() == nullptr) {
+    if (cb.insts()->maybe_expand_to_ensure_remaining(PhaseOutput::MAX_inst_gcstub_size) && cb.blob() == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }

--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -542,7 +542,7 @@ void G1BarrierSetC2::emit_stubs(CodeBuffer& cb) const {
   GrowableArray<G1BarrierStubC2*>* const stubs = barrier_set_state()->stubs();
   for (int i = 0; i < stubs->length(); i++) {
     // Make sure there is enough space in the code buffer
-    if (cb.insts()->maybe_expand_to_ensure_remaining(PhaseOutput::MAX_inst_gcstub_size) && cb.blob() == nullptr) {
+    if (cb.insts()->maybe_expand_to_ensure_remaining(PhaseOutput::max_inst_gcstub_size()) && cb.blob() == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }

--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.hpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.hpp
@@ -118,6 +118,7 @@ public:
   virtual void* create_barrier_state(Arena* comp_arena) const;
   virtual void emit_stubs(CodeBuffer& cb) const;
   virtual void late_barrier_analysis() const;
+  virtual int estimate_stub_size() const;
 
 #ifndef PRODUCT
   virtual void dump_barrier_data(const MachNode* mach, outputStream* st) const;

--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.hpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.hpp
@@ -118,7 +118,6 @@ public:
   virtual void* create_barrier_state(Arena* comp_arena) const;
   virtual void emit_stubs(CodeBuffer& cb) const;
   virtual void late_barrier_analysis() const;
-  virtual int estimate_stub_size() const;
 
 #ifndef PRODUCT
   virtual void dump_barrier_data(const MachNode* mach, outputStream* st) const;

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -315,7 +315,7 @@ void ZBarrierSetC2::emit_stubs(CodeBuffer& cb) const {
 
   for (int i = 0; i < stubs->length(); i++) {
     // Make sure there is enough space in the code buffer
-    if (cb.insts()->maybe_expand_to_ensure_remaining(PhaseOutput::MAX_inst_size) && cb.blob() == nullptr) {
+    if (cb.insts()->maybe_expand_to_ensure_remaining(PhaseOutput::MAX_inst_gcstub_size) && cb.blob() == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -315,7 +315,7 @@ void ZBarrierSetC2::emit_stubs(CodeBuffer& cb) const {
 
   for (int i = 0; i < stubs->length(); i++) {
     // Make sure there is enough space in the code buffer
-    if (cb.insts()->maybe_expand_to_ensure_remaining(PhaseOutput::MAX_inst_gcstub_size) && cb.blob() == nullptr) {
+    if (cb.insts()->maybe_expand_to_ensure_remaining(PhaseOutput::max_inst_gcstub_size()) && cb.blob() == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -887,5 +887,5 @@ int C2Compiler::initial_code_buffer_size(int const_size) {
   // See Compile::init_scratch_buffer_blob
   int locs_size = sizeof(relocInfo) * PhaseOutput::MAX_locs_size;
   int slop = 2 * CodeSection::end_slop(); // space between sections
-  return PhaseOutput::MAX_inst_size + PhaseOutput::MAX_stubs_size + const_size + slop + locs_size;
+  return PhaseOutput::max_inst_size() + PhaseOutput::MAX_stubs_size + const_size + slop + locs_size;
 }

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -27,6 +27,7 @@
 #include "code/compiledIC.hpp"
 #include "code/debugInfo.hpp"
 #include "code/debugInfoRec.hpp"
+#include "code/SCCache.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compilerDirectives.hpp"
 #include "compiler/disassembler.hpp"

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1370,7 +1370,7 @@ CodeBuffer* PhaseOutput::init_buffer() {
   int exception_handler_req = HandlerImpl::size_exception_handler() + MAX_stubs_size; // add marginal slop for handler
   int deopt_handler_req     = HandlerImpl::size_deopt_handler()     + MAX_stubs_size; // add marginal slop for handler
   stub_req += MAX_stubs_size;   // ensure per-stub margin
-  code_req += MAX_inst_size;    // ensure per-instruction margin
+  code_req += max_inst_size();  // ensure per-instruction margin
 
   if (StressCodeBuffers)
     code_req = const_req = stub_req = exception_handler_req = deopt_handler_req = 0x10;  // force expansion
@@ -1567,7 +1567,7 @@ void PhaseOutput::fill_buffer(C2_MacroAssembler* masm, uint* blk_starts) {
           last_inst++;
           C->cfg()->map_node_to_block(nop, block);
           // Ensure enough space.
-          masm->code()->insts()->maybe_expand_to_ensure_remaining(MAX_inst_size);
+          masm->code()->insts()->maybe_expand_to_ensure_remaining(max_inst_size());
           if ((masm->code()->blob() == nullptr) || (!CompileBroker::should_compile_new_jobs())) {
             C->record_failure("CodeCache is full");
             return;
@@ -1696,7 +1696,7 @@ void PhaseOutput::fill_buffer(C2_MacroAssembler* masm, uint* blk_starts) {
       }
 
       // Verify that there is sufficient space remaining
-      masm->code()->insts()->maybe_expand_to_ensure_remaining(MAX_inst_size);
+      masm->code()->insts()->maybe_expand_to_ensure_remaining(max_inst_size());
       if ((masm->code()->blob() == nullptr) || (!CompileBroker::should_compile_new_jobs())) {
         C->record_failure("CodeCache is full");
         return;
@@ -3353,7 +3353,7 @@ uint PhaseOutput::scratch_emit_size(const Node* n) {
   // expensive, since it has to grab the code cache lock.
   BufferBlob* blob = this->scratch_buffer_blob();
   assert(blob != nullptr, "Initialize BufferBlob at start");
-  assert(blob->size() > MAX_inst_size, "sanity");
+  assert(blob->size() > max_inst_size(), "sanity");
   relocInfo* locs_buf = scratch_locs_memory();
   address blob_begin = blob->content_begin();
   address blob_end   = (address)locs_buf;
@@ -3667,3 +3667,17 @@ void PhaseOutput::print_statistics() {
   Scheduling::print_statistics();
 }
 #endif
+
+int PhaseOutput::max_inst_size() {
+  if (SCCache::is_on_for_write()) {
+    // See the comment in output.hpp.
+    return 16384;
+  } else {
+    return mainline_MAX_inst_size;
+  }
+}
+
+int PhaseOutput::max_inst_gcstub_size() {
+  assert(mainline_MAX_inst_size <= max_inst_size(), "Sanity");
+  return mainline_MAX_inst_size;
+}

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1362,8 +1362,10 @@ CodeBuffer* PhaseOutput::init_buffer() {
 
   int pad_req   = NativeCall::byte_size();
 
+  // Despite the name "stub", GC barrier stubs are emitted into
+  // the insn section, and should be counted in code_req.
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
-  stub_req += bs->estimate_stub_size();
+  code_req += bs->estimate_stub_size();
 
   // nmethod and CodeBuffer count stubs & constants as part of method's code.
   // class HandlerImpl is platform-specific and defined in the *.ad files.

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1362,10 +1362,8 @@ CodeBuffer* PhaseOutput::init_buffer() {
 
   int pad_req   = NativeCall::byte_size();
 
-  // Despite the name "stub", GC barrier stubs are emitted into
-  // the insn section, and should be counted in code_req.
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
-  code_req += bs->estimate_stub_size();
+  stub_req += bs->estimate_stub_size();
 
   // nmethod and CodeBuffer count stubs & constants as part of method's code.
   // class HandlerImpl is platform-specific and defined in the *.ad files.

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -201,8 +201,6 @@ public:
     MAX_stubs_size      = 128
   };
 
-  static_assert(MAX_inst_gcstub_size <= MAX_inst_size);
-
   int               frame_slots() const         { return _frame_slots; }
   int               frame_size_in_words() const; // frame_slots in units of the polymorphic 'words'
   int               frame_size_in_bytes() const { return _frame_slots << LogBytesPerInt; }

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -182,8 +182,13 @@ public:
 
   BufferSizingData* buffer_sizing_data()        { return &_buf_sizes; }
 
+  // SCCache::write_nmethod bails when nmethod buffer is expanded.
+  // Large methods would routinely expand the buffer, making themselves
+  // ineligible for SCCache stores. In order to minimize this effect,
+  // we default to larger default sizes.
+  // TODO: Revert this back to mainline once SCCache is fixed.
   enum ScratchBufferBlob {
-    MAX_inst_size       = 2048,
+    MAX_inst_size       = 8192,
     MAX_locs_size       = 128, // number of relocInfo elements
     MAX_const_size      = 128,
     MAX_stubs_size      = 128

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -201,6 +201,8 @@ public:
     MAX_stubs_size      = 128
   };
 
+  static_assert(MAX_inst_gcstub_size <= MAX_inst_size, "sanity");
+
   int               frame_slots() const         { return _frame_slots; }
   int               frame_size_in_words() const; // frame_slots in units of the polymorphic 'words'
   int               frame_size_in_bytes() const { return _frame_slots << LogBytesPerInt; }

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -185,23 +185,28 @@ public:
   // SCCache::write_nmethod bails when nmethod buffer is expanded.
   // Large methods would routinely expand the buffer, making themselves
   // ineligible for SCCache stores. In order to minimize this effect,
-  // we default to larger default sizes.
+  // we default to larger default sizes. We do this only when SCC dumping
+  // is active, to avoid impact on default configuration.
   //
   // Additionally, GC barrier stubs expand up to MAX_inst_size in mainline,
   // which also forced resizes often. Current code replaces it with
-  // MAX_inst_gcstub_size, which equals to old MAX_inst_size, so GC stubs
+  // max_inst_gcstub_size, which equals to old MAX_inst_size, so GC stubs
   // still fit nicely, and do not force the resizes too often.
+  //
+  // The old enum is renamed, so direct misuse in new code from mainline would
+  // be caught as build failure.
   //
   // TODO: Revert this back to mainline once SCCache is fixed.
   enum ScratchBufferBlob {
-    MAX_inst_size       = 16384,
-    MAX_inst_gcstub_size= 2048,
+    mainline_MAX_inst_size = 2048,
     MAX_locs_size       = 128, // number of relocInfo elements
     MAX_const_size      = 128,
     MAX_stubs_size      = 128
   };
 
-  static_assert(MAX_inst_gcstub_size <= MAX_inst_size, "sanity");
+  // Current uses of MAX_inst_size should be replaced with these getters:
+  static int max_inst_size();
+  static int max_inst_gcstub_size();
 
   int               frame_slots() const         { return _frame_slots; }
   int               frame_size_in_words() const; // frame_slots in units of the polymorphic 'words'

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -186,13 +186,22 @@ public:
   // Large methods would routinely expand the buffer, making themselves
   // ineligible for SCCache stores. In order to minimize this effect,
   // we default to larger default sizes.
+  //
+  // Additionally, GC barrier stubs expand up to MAX_inst_size in mainline,
+  // which also forced resizes often. Current code replaces it with
+  // MAX_inst_gcstub_size, which equals to old MAX_inst_size, so GC stubs
+  // still fit nicely, and do not force the resizes too often.
+  //
   // TODO: Revert this back to mainline once SCCache is fixed.
   enum ScratchBufferBlob {
-    MAX_inst_size       = 8192,
+    MAX_inst_size       = 16384,
+    MAX_inst_gcstub_size= 2048,
     MAX_locs_size       = 128, // number of relocInfo elements
     MAX_const_size      = 128,
     MAX_stubs_size      = 128
   };
+
+  static_assert(MAX_inst_gcstub_size <= MAX_inst_size);
 
   int               frame_slots() const         { return _frame_slots; }
   int               frame_size_in_words() const; // frame_slots in units of the polymorphic 'words'


### PR DESCRIPTION
Due to current prototype limitation, we cannot yet store the generated code that has the expanded code buffer. I tried to address that directly, but I think relocations disagree with the whole thing, so this implementation limitation stays for a bit longer. I turned the bailout due to that cause from `info` into `warning`.

On `JavacBenchApp 50`, this causes us to lose 700 (!) C2 compiled methods from the SCC! We can dodge significant part of the hit by bumping the default code buffer sizes, and thus making buffers less likely to require resizing, and thus allowing to store more code in SCC. 

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8348858](https://bugs.openjdk.org/browse/JDK-8348858): [leyden] Bump the default code buffer sizes to store more generated code (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer) ⚠️ Review applies to [5ee9bb60](https://git.openjdk.org/leyden/pull/28/files/5ee9bb60fc0ba83d2b052b73a07b41c0b2ac8fc9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.org/leyden.git pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/28.diff">https://git.openjdk.org/leyden/pull/28.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/28#issuecomment-2619088510)
</details>
