### PR TITLE
8348957: [leyden] Excess PrintCompilation printing on compile task start

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2463,10 +2463,6 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
   elapsedTimer time;
 
   DirectiveSet* directive = task->directive();
-  if (directive->PrintCompilationOption) {
-    ResourceMark rm;
-    task->print_tty();
-  }
 
   CompilerThread* thread = CompilerThread::current();
   ResourceMark rm(thread);
@@ -2481,6 +2477,7 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
   bool is_osr = (osr_bci != standard_entry_bci);
   bool should_log = (thread->log() != nullptr);
   bool should_break = false;
+  bool should_print_compilation = PrintCompilation || directive->PrintCompilationOption;
   const int task_level = task->comp_level();
   AbstractCompiler* comp = task->compiler();
   {
@@ -2722,7 +2719,7 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
   method->clear_queued_for_compilation();
   method->set_pending_queue_processed(false);
 
-  if (PrintCompilation) {
+  if (should_print_compilation) {
     ResourceMark rm;
     task->print_tty();
   }


### PR DESCRIPTION
This bothers me a bit in current -XX:+PrintCompilation logs. For various reasons, we have the `DirectiveSet` for every method, which initialized `PrintCompilationOption = true` when `-XX:+PrintCompilation` is set, which prints the compile task at the task start. We don't need that printout, we only really care about the printout at the end of the compilation. 

Before:

```
$ grep com.sun.tools.javac.comp.Resolve::notOverriddenIn out
    105    W0.0                    646      AP 4       com.sun.tools.javac.comp.Resolve::notOverriddenIn (124 bytes)
    105    W0.0   Q52.2    C0.1    646      AP 4       com.sun.tools.javac.comp.Resolve::notOverriddenIn (124 bytes)
    252    W0.1                   3745      A  4       com.sun.tools.javac.comp.Resolve::notOverriddenIn (124 bytes)
    252                            646      AP 4       com.sun.tools.javac.comp.Resolve::notOverriddenIn (124 bytes)   made not entrant
    252    W0.1    Q0.0    C0.1   3745      A  4       com.sun.tools.javac.comp.Resolve::notOverriddenIn (124 bytes)
```

After:

```
     88    W0.0   Q31.3    C0.2    696      AP 4       com.sun.tools.javac.comp.Resolve::notOverriddenIn (124 bytes)
    239                            696      AP 4       com.sun.tools.javac.comp.Resolve::notOverriddenIn (124 bytes)   made not entrant
    239    W0.1    Q0.0    C0.1   3809      A  4       com.sun.tools.javac.comp.Resolve::notOverriddenIn (124 bytes)
```

I'll also look into upstreaming the extended compile task logging, since it is useful to study compilation dynamics outside of Leyden as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8348957](https://bugs.openjdk.org/browse/JDK-8348957): [leyden] Excess PrintCompilation printing on compile task start (**Enhancement** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.org/leyden.git pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/29.diff">https://git.openjdk.org/leyden/pull/29.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/29#issuecomment-2621394679)
</details>
