### PR TITLE
8349181: [leyden] tools/sincechecker/modules/java.base/JavaBaseCheckSince.java fails

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -1520,13 +1520,14 @@ public final class System {
 
     /**
      * Returns whether the AOT system is recording training data.
-     *
-     * @return  whether the AOT system is recording training data.
+     * @return whether the AOT system is recording training data.
+     * @since 25
      */
     public static native boolean AOTIsTraining();
 
     /**
      * Will stop the recording of AOT training data.
+     * @since 25
      */
     public static native void AOTEndTraining();
 


### PR DESCRIPTION
Trivial testbug fix.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, test now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8349181](https://bugs.openjdk.org/browse/JDK-8349181): [leyden] tools/sincechecker/modules/java.base/JavaBaseCheckSince.java fails (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.org/leyden.git pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/31.diff">https://git.openjdk.org/leyden/pull/31.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/31#issuecomment-2628884020)
</details>
