### PR TITLE
8349713: [leyden] Memory map the cached code file

### DIFF
--- a/src/hotspot/share/code/SCCache.cpp
+++ b/src/hotspot/share/code/SCCache.cpp
@@ -537,7 +537,6 @@ SCCache::SCCache(const char* cache_path, int fd, uint load_size) {
   _C_strings_buf  = nullptr;
   _load_buffer = nullptr;
   _store_buffer = nullptr;
-  _C_load_buffer = nullptr;
   _C_store_buffer = nullptr;
   _store_entries_cnt = 0;
   _gen_preload_code = false;
@@ -551,26 +550,16 @@ SCCache::SCCache(const char* cache_path, int fd, uint load_size) {
 
   if (_for_read) {
     // Read cache
-    if (MmapCachedCode) {
-      // Implementation note: the mapping is not read-only, because entries are updated in-place.
-      // However, this mapping is MAP_PRIVATE, which means the changes to mapping do not reflect
-      // in the backing file. TODO: Avoid in-place modifications, so we do not have to rely on this?
-      _load_buffer = os::map_memory(fd, _cache_path, 0, nullptr, load_size,
-                                   false,false, mtCode);
-    } else {
-      _C_load_buffer = NEW_C_HEAP_ARRAY(char, load_size + DATA_ALIGNMENT, mtCode);
-      _load_buffer = align_up(_C_load_buffer, DATA_ALIGNMENT);
-      uint n = (uint)::read(fd, _load_buffer, load_size);
-      if (n != load_size) {
-        _load_buffer = nullptr;
-      }
-    }
+    // Implementation note: the mapping is not read-only, because entries are updated in-place.
+    // However, this mapping is MAP_PRIVATE, which means the changes to mapping do not reflect
+    // in the backing file. TODO: Avoid in-place modifications, so we do not have to rely on this?
+    _load_buffer = os::map_memory(fd, _cache_path, 0, nullptr, load_size, false, false, mtCode);
     if (_load_buffer == nullptr) {
-      log_warning(scc, init)("Failed to read/mmap %d bytes at address " INTPTR_FORMAT " from Startup Code Cache file '%s'", load_size, p2i(_load_buffer), _cache_path);
+      log_warning(scc, init)("Failed to mmap %d bytes at address " INTPTR_FORMAT " from Startup Code Cache file '%s'", load_size, p2i(_load_buffer), _cache_path);
       set_failed();
       return;
     }
-    log_info(scc, init)("Read/mmaped %d bytes at address " INTPTR_FORMAT " from Startup Code Cache '%s'", load_size, p2i(_load_buffer), _cache_path);
+    log_info(scc, init)("Mmaped %d bytes at address " INTPTR_FORMAT " from Startup Code Cache '%s'", load_size, p2i(_load_buffer), _cache_path);
 
     _load_header = (SCCHeader*)addr(0);
     const char* scc_jvm_version = addr(_load_header->jvm_version_offset());
@@ -779,17 +768,9 @@ SCCache::~SCCache() {
     finish_write();
   }
   FREE_C_HEAP_ARRAY(char, _cache_path);
-  if (MmapCachedCode) {
-    if (_load_buffer != nullptr) {
-      os::unmap_memory(_load_buffer, _load_size);
-      _load_buffer = nullptr;
-    }
-  } else {
-    if (_C_load_buffer != nullptr) {
-      FREE_C_HEAP_ARRAY(char, _C_load_buffer);
-      _C_load_buffer = nullptr;
-      _load_buffer = nullptr;
-    }
+  if (_load_buffer != nullptr) {
+    os::unmap_memory(_load_buffer, _load_size);
+    _load_buffer = nullptr;
   }
   if (_C_store_buffer != nullptr) {
     FREE_C_HEAP_ARRAY(char, _C_store_buffer);

--- a/src/hotspot/share/code/SCCache.cpp
+++ b/src/hotspot/share/code/SCCache.cpp
@@ -537,6 +537,7 @@ SCCache::SCCache(const char* cache_path, int fd, uint load_size) {
   _C_strings_buf  = nullptr;
   _load_buffer = nullptr;
   _store_buffer = nullptr;
+  _C_load_buffer = nullptr;
   _C_store_buffer = nullptr;
   _store_entries_cnt = 0;
   _gen_preload_code = false;
@@ -550,16 +551,26 @@ SCCache::SCCache(const char* cache_path, int fd, uint load_size) {
 
   if (_for_read) {
     // Read cache
-    // Implementation note: the mapping is not read-only, because entries are updated in-place.
-    // However, this mapping is MAP_PRIVATE, which means the changes to mapping do not reflect
-    // in the backing file. TODO: Avoid in-place modifications, so we do not have to rely on this?
-    _load_buffer = os::map_memory(fd, _cache_path, 0, nullptr, load_size, false, false, mtCode);
+    if (MmapCachedCode) {
+      // Implementation note: the mapping is not read-only, because entries are updated in-place.
+      // However, this mapping is MAP_PRIVATE, which means the changes to mapping do not reflect
+      // in the backing file. TODO: Avoid in-place modifications, so we do not have to rely on this?
+      _load_buffer = os::map_memory(fd, _cache_path, 0, nullptr, load_size,
+                                   false,false, mtCode);
+    } else {
+      _C_load_buffer = NEW_C_HEAP_ARRAY(char, load_size + DATA_ALIGNMENT, mtCode);
+      _load_buffer = align_up(_C_load_buffer, DATA_ALIGNMENT);
+      uint n = (uint)::read(fd, _load_buffer, load_size);
+      if (n != load_size) {
+        _load_buffer = nullptr;
+      }
+    }
     if (_load_buffer == nullptr) {
-      log_warning(scc, init)("Failed to mmap %d bytes at address " INTPTR_FORMAT " from Startup Code Cache file '%s'", load_size, p2i(_load_buffer), _cache_path);
+      log_warning(scc, init)("Failed to read/mmap %d bytes at address " INTPTR_FORMAT " from Startup Code Cache file '%s'", load_size, p2i(_load_buffer), _cache_path);
       set_failed();
       return;
     }
-    log_info(scc, init)("Mmaped %d bytes at address " INTPTR_FORMAT " from Startup Code Cache '%s'", load_size, p2i(_load_buffer), _cache_path);
+    log_info(scc, init)("Read/mmaped %d bytes at address " INTPTR_FORMAT " from Startup Code Cache '%s'", load_size, p2i(_load_buffer), _cache_path);
 
     _load_header = (SCCHeader*)addr(0);
     const char* scc_jvm_version = addr(_load_header->jvm_version_offset());
@@ -768,9 +779,17 @@ SCCache::~SCCache() {
     finish_write();
   }
   FREE_C_HEAP_ARRAY(char, _cache_path);
-  if (_load_buffer != nullptr) {
-    os::unmap_memory(_load_buffer, _load_size);
-    _load_buffer = nullptr;
+  if (MmapCachedCode) {
+    if (_load_buffer != nullptr) {
+      os::unmap_memory(_load_buffer, _load_size);
+      _load_buffer = nullptr;
+    }
+  } else {
+    if (_C_load_buffer != nullptr) {
+      FREE_C_HEAP_ARRAY(char, _C_load_buffer);
+      _C_load_buffer = nullptr;
+      _load_buffer = nullptr;
+    }
   }
   if (_C_store_buffer != nullptr) {
     FREE_C_HEAP_ARRAY(char, _C_store_buffer);

--- a/src/hotspot/share/code/SCCache.hpp
+++ b/src/hotspot/share/code/SCCache.hpp
@@ -385,6 +385,7 @@ private:
   const char* _cache_path;
   char*       _load_buffer;    // Aligned buffer for loading cached code
   char*       _store_buffer;   // Aligned buffer for storing cached code
+  char*       _C_load_buffer;  // Original unaligned buffer
   char*       _C_store_buffer; // Original unaligned buffer
 
   uint        _write_position; // Position in _store_buffer

--- a/src/hotspot/share/code/SCCache.hpp
+++ b/src/hotspot/share/code/SCCache.hpp
@@ -385,7 +385,6 @@ private:
   const char* _cache_path;
   char*       _load_buffer;    // Aligned buffer for loading cached code
   char*       _store_buffer;   // Aligned buffer for storing cached code
-  char*       _C_load_buffer;  // Original unaligned buffer
   char*       _C_store_buffer; // Original unaligned buffer
 
   uint        _write_position; // Position in _store_buffer

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -456,9 +456,6 @@
   product(uint, CachedCodeMaxSize, 10*M,                                    \
           "Buffer size in bytes for code caching")                          \
                                                                             \
-  product(bool, MmapCachedCode, NOT_WINDOWS(true) WINDOWS_ONLY(false),      \
-          "Mmap cached code file instead of reading it fully at startup.")  \
-                                                                            \
   product(bool, VerifyCachedCode, false, DIAGNOSTIC,                        \
           "Load compiled code but not publish")                             \
                                                                             \

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -456,6 +456,9 @@
   product(uint, CachedCodeMaxSize, 10*M,                                    \
           "Buffer size in bytes for code caching")                          \
                                                                             \
+  product(bool, MmapCachedCode, NOT_WINDOWS(true) WINDOWS_ONLY(false),      \
+          "Mmap cached code file instead of reading it fully at startup.")  \
+                                                                            \
   product(bool, VerifyCachedCode, false, DIAGNOSTIC,                        \
           "Load compiled code but not publish")                             \
                                                                             \


### PR DESCRIPTION
It is visible in profiles for lots of applications that reading the SC cache file at startup costs significantly. On JavacBenchApp example, loading ~25M code requires about 30ms. This is ~1 GB/sec, so it is I/O limited.

We should really mmap the SC cache file to alleviate these costs. Let the actual SC readers (separate threads) to eat the cost of reading from the backing file. 

I was not entirely sure COW for file mappings works correctly on Windows, so I excepted that one.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8349713](https://bugs.openjdk.org/browse/JDK-8349713): [leyden] Memory map the cached code file (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.org/leyden.git pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/34.diff">https://git.openjdk.org/leyden/pull/34.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/34#issuecomment-2647824324)
</details>
