### PR TITLE
8349717: [leyden] compiler/inlining/LateInlinePrinting.java is failing

### DIFF
--- a/test/hotspot/jtreg/compiler/inlining/LateInlinePrinting.java
+++ b/test/hotspot/jtreg/compiler/inlining/LateInlinePrinting.java
@@ -84,19 +84,16 @@ public class LateInlinePrinting {
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
         analyzer.shouldHaveExitValue(0);
 
-        analyzer.shouldContain("""
-compiler.inlining.LateInlinePrinting$TestLateInlining::test2 (7 bytes)
-                            @ 0   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined1 (1 bytes)   inline (hot)   late inline succeeded
-                            @ 3   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined2 (1 bytes)   inline (hot)   late inline succeeded
-                            """);
-        analyzer.shouldContain("""
-compiler.inlining.LateInlinePrinting$TestLateInlining::test1 (13 bytes)
-                            @ 0   compiler.inlining.LateInlinePrinting$TestLateInlining::test3 (1 bytes)   inline (hot)   late inline succeeded
-                            @ 3   compiler.inlining.LateInlinePrinting$TestLateInlining::testFailInline (1 bytes)   failed to inline: disallowed by CompileCommand
-                            @ 6   compiler.inlining.LateInlinePrinting$TestLateInlining::testFailInline (1 bytes)   failed to inline: disallowed by CompileCommand
-                            @ 9   compiler.inlining.LateInlinePrinting$TestLateInlining::test2 (7 bytes)   inline (hot)   late inline succeeded
-                              @ 0   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined1 (1 bytes)   inline (hot)   late inline succeeded
-                              @ 3   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined2 (1 bytes)   inline (hot)   late inline succeeded
-                              """);
+        analyzer.shouldContain("compiler.inlining.LateInlinePrinting$TestLateInlining::test2 (7 bytes)");
+        analyzer.shouldContain("@ 0   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined1 (1 bytes)   inline (hot)   late inline succeeded");
+        analyzer.shouldContain("@ 3   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined2 (1 bytes)   inline (hot)   late inline succeeded");
+
+        analyzer.shouldContain("compiler.inlining.LateInlinePrinting$TestLateInlining::test1 (13 bytes)");
+        analyzer.shouldContain("@ 0   compiler.inlining.LateInlinePrinting$TestLateInlining::test3 (1 bytes)   inline (hot)   late inline succeeded");
+        analyzer.shouldContain("@ 3   compiler.inlining.LateInlinePrinting$TestLateInlining::testFailInline (1 bytes)   failed to inline: disallowed by CompileCommand");
+        analyzer.shouldContain("@ 6   compiler.inlining.LateInlinePrinting$TestLateInlining::testFailInline (1 bytes)   failed to inline: disallowed by CompileCommand");
+        analyzer.shouldContain("@ 9   compiler.inlining.LateInlinePrinting$TestLateInlining::test2 (7 bytes)   inline (hot)   late inline succeeded");
+        analyzer.shouldContain("@ 0   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined1 (1 bytes)   inline (hot)   late inline succeeded");
+        analyzer.shouldContain("@ 3   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined2 (1 bytes)   inline (hot)   late inline succeeded");
     }
 }


### PR DESCRIPTION
There are lots of mainline reports about this test, see links. We see a failure in current GHA for Leyden. For Leyden, there are additional specifics: we print advanced compile task information in compile log, so we get indenting/format mismatches.

Leyden dumps this:

```
     57 W0.0 Q0.0 C0.7 3 b compiler.inlining.LateInlinePrinting$TestLateInlining::test2 (7 bytes)
                            @ 0 compiler.inlining.LateInlinePrinting$TestLateInlining::test3 (1 bytes) inline (hot) late inline succeeded
                            @ 3 compiler.inlining.LateInlinePrinting$TestLateInlining::testFailInline (1 bytes) failed to inline: disallowed by CompileCommand
                            @ 6 compiler.inlining.LateInlinePrinting$TestLateInlining::testFailInline (1 bytes) failed to inline: disallowed by CompileCommand
                            @ 9 compiler.inlining.LateInlinePrinting$TestLateInlining::test2 (7 bytes) inline (hot) late inline succeeded
                              @ 0 compiler.inlining.LateInlinePrinting$TestLateInlining::inlined1 (1 bytes) inline (hot) late inline succeeded
                              @ 3 compiler.inlining.LateInlinePrinting$TestLateInlining::inlined2 (1 bytes) inline (hot) late inline succeeded
     58 W0.0 Q0.0 C1.1 4 b compiler.inlining.LateInlinePrinting$TestLateInlining::test1 (13 bytes)
```

So, this bug fixes the test for Leyden specifically, while mainline is figuring out the rest.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8349717](https://bugs.openjdk.org/browse/JDK-8349717): [leyden] compiler/inlining/LateInlinePrinting.java is failing (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.org/leyden.git pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/35.diff">https://git.openjdk.org/leyden/pull/35.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/35#issuecomment-2647853958)
</details>
