### PR TITLE
8349722: [leyden] Option to block until preloading is complete

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1760,9 +1760,10 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
     }
     bool is_blocking = ReplayCompiles                                             ||
                        !directive->BackgroundCompilationOption                    ||
+                       (PreloadBlocking && (compile_reason == CompileTask::Reason_Preload)) ||
                        (compile_reason == CompileTask::Reason_Precompile)         ||
                        (compile_reason == CompileTask::Reason_PrecompileForPreload);
-	  compile_method_base(method, osr_bci, comp_level, hot_method, hot_count, compile_reason, requires_online_compilation, is_blocking, THREAD);
+    compile_method_base(method, osr_bci, comp_level, hot_method, hot_count, compile_reason, requires_online_compilation, is_blocking, THREAD);
   }
 
   // return requested nmethod

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -491,7 +491,7 @@
   product(bool, PrecompileOnlyAndExit, false,                               \
           "Exit after precompilation step is over")                         \
                                                                             \
-  product(bool, PreloadBlocking, false,                                     \
+  product(bool, PreloadBlocking, false, DIAGNOSTIC,                         \
           "Preload code is processed with blocking. Startup would not "     \
           "proceed until all code preloaded code is done loading.")         \
                                                                             \

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -490,6 +490,11 @@
                                                                             \
   product(bool, PrecompileOnlyAndExit, false,                               \
           "Exit after precompilation step is over")                         \
+                                                                            \
+  product(bool, PreloadBlocking, false,                                     \
+          "Preload code is processed with blocking. Startup would not "     \
+          "proceed until all code preloaded code is done loading.")         \
+                                                                            \
 
 // end of COMPILER_FLAGS
 


### PR DESCRIPTION
During one of the meetings, @iwanowww suggested there is a diagnostic option to block the execution until all preloaded code is finished loading. For the Java application, it would then look as if the entirety of preload code was loaded "instantaneously", which helps to estimate the performance floor for a given workload.

I have found no such option in current Leyden prototype, though, so this RFE should implement one. 

This is indeed helpful, especially combined with #32, which allows to run with only C2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8349722](https://bugs.openjdk.org/browse/JDK-8349722): [leyden] Option to block until preloading is complete (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.org/leyden.git pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/36.diff">https://git.openjdk.org/leyden/pull/36.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/36#issuecomment-2648206294)
</details>
