### PR TITLE
8349748: [leyden] ciEnv::register_method should lock the correct queue lock

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1020,7 +1020,7 @@ void ciEnv::register_method(ciMethod* target,
     CodeCache::gc_on_allocation();
 
     // To prevent compile queue updates.
-    MutexLocker locker(THREAD, MethodCompileQueue_lock);
+    MutexLocker locker(THREAD, task()->compile_queue()->lock());
 
     // Prevent InstanceKlass::add_to_hierarchy from running
     // and invalidating our dependencies until we install this method.


### PR DESCRIPTION
Mainline code locks `MethodCompileQueue_lock` in `ciEnv::register_method`. But with Leyden-s `UseGlobalCompileQueueLock = false`, we have separate locks, per compile queue. So it seems to stand to reason we should be locking those locks, not a global one.

I have not been able to attribute this gap to any bug or performance issue, but I think we better fix this proactively.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8349748](https://bugs.openjdk.org/browse/JDK-8349748): [leyden] ciEnv::register_method should lock the correct queue lock (**Bug** - P4)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/leyden.git pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/37.diff">https://git.openjdk.org/leyden/pull/37.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/37#issuecomment-2648825064)
</details>
