### PR TITLE
8349905: [leyden] Make SCCache depend on CDS build feature

### DIFF
--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -123,6 +123,8 @@ ifneq ($(call check-jvm-feature, cds), true)
   JVM_EXCLUDE_FILES += \
       classLoaderDataShared.cpp \
       classLoaderExt.cpp \
+      precompiler.cpp \
+      SCCache.cpp \
       systemDictionaryShared.cpp
   JVM_EXCLUDE_PATTERNS += cds/
 endif

--- a/src/hotspot/share/code/SCCache.hpp
+++ b/src/hotspot/share/code/SCCache.hpp
@@ -485,12 +485,12 @@ public:
   void load_strings();
   int store_strings();
 
-  static void init_extrs_table();
-  static void init_early_stubs_table();
-  static void init_shared_blobs_table();
-  static void init_stubs_table();
-  static void init_opto_table();
-  static void init_c1_table();
+  static void init_extrs_table() NOT_CDS_RETURN;
+  static void init_early_stubs_table() NOT_CDS_RETURN;
+  static void init_shared_blobs_table() NOT_CDS_RETURN;
+  static void init_stubs_table() NOT_CDS_RETURN;
+  static void init_opto_table() NOT_CDS_RETURN;
+  static void init_c1_table() NOT_CDS_RETURN;
   address address_for_id(int id) const { return _table->address_for_id(id); }
 
   bool for_read()  const { return _for_read  && !_failed; }
@@ -514,8 +514,8 @@ public:
 
   bool finish_write();
 
-  static bool load_stub(StubCodeGenerator* cgen, vmIntrinsicID id, const char* name, address start);
-  static bool store_stub(StubCodeGenerator* cgen, vmIntrinsicID id, const char* name, address start);
+  static bool load_stub(StubCodeGenerator* cgen, vmIntrinsicID id, const char* name, address start) NOT_CDS_RETURN_(false);
+  static bool store_stub(StubCodeGenerator* cgen, vmIntrinsicID id, const char* name, address start) NOT_CDS_RETURN_(false);
 
   bool write_klass(Klass* klass);
   bool write_method(Method* method);
@@ -535,13 +535,13 @@ public:
   bool write_metadata(Metadata* m);
   bool write_metadata(OopRecorder* oop_recorder);
 
-  static bool load_exception_blob(CodeBuffer* buffer, int* pc_offset);
-  static bool store_exception_blob(CodeBuffer* buffer, int pc_offset);
+  static bool load_exception_blob(CodeBuffer* buffer, int* pc_offset) NOT_CDS_RETURN_(false);
+  static bool store_exception_blob(CodeBuffer* buffer, int pc_offset) NOT_CDS_RETURN_(false);
 
-  static bool load_adapter(CodeBuffer* buffer, uint32_t id, const char* basic_sig, uint32_t offsets[4]);
-  static bool store_adapter(CodeBuffer* buffer, uint32_t id, const char* basic_sig, uint32_t offsets[4]);
+  static bool load_adapter(CodeBuffer* buffer, uint32_t id, const char* basic_sig, uint32_t offsets[4]) NOT_CDS_RETURN_(false);
+  static bool store_adapter(CodeBuffer* buffer, uint32_t id, const char* basic_sig, uint32_t offsets[4]) NOT_CDS_RETURN_(false);
 
-  static bool load_nmethod(ciEnv* env, ciMethod* target, int entry_bci, AbstractCompiler* compiler, CompLevel comp_level);
+  static bool load_nmethod(ciEnv* env, ciMethod* target, int entry_bci, AbstractCompiler* compiler, CompLevel comp_level) NOT_CDS_RETURN_(false);
 
   static SCCEntry* store_nmethod(const methodHandle& method,
                      int compile_id,
@@ -562,7 +562,7 @@ public:
                      bool has_unsafe_access,
                      bool has_wide_vectors,
                      bool has_monitors,
-                     bool has_scoped_access);
+                     bool has_scoped_access) NOT_CDS_RETURN_(nullptr);
 
   static uint store_entries_cnt() {
     if (is_on_for_write()) {
@@ -585,17 +585,17 @@ private:
   }
 public:
   static SCCache* cache() { return _cache; }
-  static void initialize();
-  static void init2();
-  static void close();
-  static bool is_on() { return _cache != nullptr && !_cache->closing(); }
-  static bool is_C3_on();
-  static bool is_code_load_thread_on();
+  static void initialize() NOT_CDS_RETURN;
+  static void init2() NOT_CDS_RETURN;
+  static void close() NOT_CDS_RETURN;
+  static bool is_on() CDS_ONLY({ return _cache != nullptr && !_cache->closing(); }) NOT_CDS_RETURN_(false);
+  static bool is_C3_on() NOT_CDS_RETURN_(false);
+  static bool is_code_load_thread_on() NOT_CDS_RETURN_(false);
   static bool is_on_for_read()  { return is_on() && _cache->for_read(); }
   static bool is_on_for_write() { return is_on() && _cache->for_write(); }
   static bool gen_preload_code(ciMethod* m, int entry_bci);
-  static bool allow_const_field(ciConstant& value);
-  static void invalidate(SCCEntry* entry);
+  static bool allow_const_field(ciConstant& value) NOT_CDS_RETURN_(false);
+  static void invalidate(SCCEntry* entry) NOT_CDS_RETURN;
   static bool is_loaded(SCCEntry* entry);
   static SCCEntry* find_code_entry(const methodHandle& method, uint comp_level);
   static void preload_code(JavaThread* thread);
@@ -622,12 +622,12 @@ public:
     }
   }
 
-  static void add_C_string(const char* str);
+  static void add_C_string(const char* str) NOT_CDS_RETURN;
 
-  static void print_on(outputStream* st);
-  static void print_statistics_on(outputStream* st);
-  static void print_timers_on(outputStream* st);
-  static void print_unused_entries_on(outputStream* st);
+  static void print_on(outputStream* st) NOT_CDS_RETURN;
+  static void print_statistics_on(outputStream* st) NOT_CDS_RETURN;
+  static void print_timers_on(outputStream* st) NOT_CDS_RETURN;
+  static void print_unused_entries_on(outputStream* st) NOT_CDS_RETURN;
 
   static void new_workflow_start_writing_cache() NOT_CDS_JAVA_HEAP_RETURN;
   static void new_workflow_end_writing_cache() NOT_CDS_JAVA_HEAP_RETURN;

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -865,7 +865,6 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
     java_lang_Throwable::print(PENDING_EXCEPTION, tty);
     vm_exit_during_initialization("ClassLoader::initialize_module_path() failed unexpectedly");
   }
-#endif
 
   if (PrecompileCode) {
     Precompiler::compile_cached_code(CHECK_JNI_ERR);
@@ -875,6 +874,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
       vm_direct_exit(0, "Code precompiation is over");
     }
   }
+#endif
 
 #if defined(COMPILER2)
   // Pre-load cached compiled methods


### PR DESCRIPTION
As we are moving more SCCache code to CDS archives, we need to start depending on CDS feature being enabled during the build to get access to SCCache stuff. A common configuration where CDS is not available is Minimal VM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8349905](https://bugs.openjdk.org/browse/JDK-8349905): [leyden] Make SCCache depend on CDS build feature (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.org/leyden.git pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/40.diff">https://git.openjdk.org/leyden/pull/40.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/40#issuecomment-2653363613)
</details>
