### PR TITLE
Fix SCCache stats logged on exit

### DIFF
--- a/src/hotspot/share/code/SCCache.cpp
+++ b/src/hotspot/share/code/SCCache.cpp
@@ -1134,11 +1134,11 @@ bool SCCache::finish_write() {
         preload_entries[preload_entries_cnt++] = entries_count;
       }
       if (entries_address[i].kind() == SCCEntry::Adapter) {
-	adapters_count[1]++;
+        adapters_count[1]++;
       } else if (entries_address[i].kind() == SCCEntry::Stub) {
-	stubs_count[1]++;
+        stubs_count[1]++;
       } else if (entries_address[i].kind() == SCCEntry::Blob) {
-	blobs_count[1]++;
+        blobs_count[1]++;
       } else if (entries_address[i].kind() == SCCEntry::Code) {
         nmethods_count[1]++;
       }

--- a/src/hotspot/share/code/SCCache.cpp
+++ b/src/hotspot/share/code/SCCache.cpp
@@ -1051,13 +1051,17 @@ void SCCache::log_stats_on_exit() {
     log.print_cr("Wrote %d SCCEntry entries(%u max size) to AOT Code Cache",
                  total_stats.total_count(), max_size);
     for (uint kind = SCCEntry::None; kind < SCCEntry::Kind_count; kind++) {
-      log.print_cr("  %s: total=%u(old=%u+new=%u)",
-                   sccentry_kind_name[kind], total_stats.entry_count(kind), prev_stats.entry_count(kind), current_stats.entry_count(kind));
-      if (kind == SCCEntry::Code) {
-        for (uint lvl = CompLevel_none; lvl < AOTCompLevel_count; lvl++) {
-          log.print_cr("    Tier %d: total=%u(old=%u+new=%u)",
-                       lvl, total_stats.nmethod_count(lvl), prev_stats.nmethod_count(lvl), current_stats.nmethod_count(lvl));
-        }
+      if (total_stats.entry_count(kind) > 0) {
+	log.print_cr("  %s: total=%u(old=%u+new=%u)",
+		     sccentry_kind_name[kind], total_stats.entry_count(kind), prev_stats.entry_count(kind), current_stats.entry_count(kind));
+	if (kind == SCCEntry::Code) {
+	  for (uint lvl = CompLevel_none; lvl < AOTCompLevel_count; lvl++) {
+            if (total_stats.nmethod_count(lvl) > 0) {
+	    log.print_cr("    Tier %d: total=%u(old=%u+new=%u)",
+			 lvl, total_stats.nmethod_count(lvl), prev_stats.nmethod_count(lvl), current_stats.nmethod_count(lvl));
+            }
+	  }
+	}
       }
     }
     log.print_cr("Total=%u(old=%u+new=%u)", total_stats.total_count(), prev_stats.total_count(), current_stats.total_count());

--- a/src/hotspot/share/code/SCCache.cpp
+++ b/src/hotspot/share/code/SCCache.cpp
@@ -1052,16 +1052,16 @@ void SCCache::log_stats_on_exit() {
                  total_stats.total_count(), max_size);
     for (uint kind = SCCEntry::None; kind < SCCEntry::Kind_count; kind++) {
       if (total_stats.entry_count(kind) > 0) {
-	log.print_cr("  %s: total=%u(old=%u+new=%u)",
-		     sccentry_kind_name[kind], total_stats.entry_count(kind), prev_stats.entry_count(kind), current_stats.entry_count(kind));
-	if (kind == SCCEntry::Code) {
-	  for (uint lvl = CompLevel_none; lvl < AOTCompLevel_count; lvl++) {
+        log.print_cr("  %s: total=%u(old=%u+new=%u)",
+                     sccentry_kind_name[kind], total_stats.entry_count(kind), prev_stats.entry_count(kind), current_stats.entry_count(kind));
+        if (kind == SCCEntry::Code) {
+          for (uint lvl = CompLevel_none; lvl < AOTCompLevel_count; lvl++) {
             if (total_stats.nmethod_count(lvl) > 0) {
-	    log.print_cr("    Tier %d: total=%u(old=%u+new=%u)",
-			 lvl, total_stats.nmethod_count(lvl), prev_stats.nmethod_count(lvl), current_stats.nmethod_count(lvl));
+              log.print_cr("    Tier %d: total=%u(old=%u+new=%u)",
+                           lvl, total_stats.nmethod_count(lvl), prev_stats.nmethod_count(lvl), current_stats.nmethod_count(lvl));
             }
-	  }
-	}
+          }
+        }
       }
     }
     log.print_cr("Total=%u(old=%u+new=%u)", total_stats.total_count(), prev_stats.total_count(), current_stats.total_count());

--- a/src/hotspot/share/code/SCCache.hpp
+++ b/src/hotspot/share/code/SCCache.hpp
@@ -25,6 +25,8 @@
 #ifndef SHARE_CODE_SCCACHE_HPP
 #define SHARE_CODE_SCCACHE_HPP
 
+#include "compiler/compilerDefinitions.hpp"
+
 /*
  * Startup Code Cache (SCC) collects compiled code and metadata during
  * an application training runs.
@@ -57,7 +59,6 @@ class SCCache;
 class StubCodeGenerator;
 
 enum class vmIntrinsicID : int;
-enum CompLevel : signed char;
 
 class SCConfig {
   uint _compressedOopShift;


### PR DESCRIPTION
The count of various SCCEntry kinds is not correctly computed. This patch fixes it.
This code was introduced as part of i2c2i adapters and was picked up from Andrew Dinn's work on storing stub and blobs. Clearly I messed it up.
The patch also computes and shows the counts for old entries and new entries separately. Though not useful for now, but in incremental workflow it may be helpful to distinguish between the old and new entries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer) ⚠️ Review applies to [7bde7dee](https://git.openjdk.org/leyden/pull/42/files/7bde7dee7f044a479c43a539de2180879147446d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/42/head:pull/42` \
`$ git checkout pull/42`

Update a local copy of the PR: \
`$ git checkout pull/42` \
`$ git pull https://git.openjdk.org/leyden.git pull/42/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 42`

View PR using the GUI difftool: \
`$ git pr show -t 42`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/42.diff">https://git.openjdk.org/leyden/pull/42.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/42#issuecomment-2658165653)
</details>
