### PR TITLE
8350115: [leyden] Clean up name_and_sig_as_C_string uses

### DIFF
--- a/src/hotspot/share/code/SCCache.cpp
+++ b/src/hotspot/share/code/SCCache.cpp
@@ -1320,18 +1320,17 @@ Klass* SCCReader::read_klass(const methodHandle& comp_method, bool shared) {
     }
     assert(k->is_klass(), "sanity");
     ResourceMark rm;
-    const char* comp_name = comp_method->name_and_sig_as_C_string();
     if (k->is_instance_klass() && !InstanceKlass::cast(k)->is_loaded()) {
       set_lookup_failed();
       log_info(scc)("%d '%s' (L%d): Lookup failed for klass %s: not loaded",
-                       compile_id(), comp_name, comp_level(), k->external_name());
+                       compile_id(), comp_method->name_and_sig_as_C_string(), comp_level(), k->external_name());
       return nullptr;
     } else
     // Allow not initialized klass which was uninitialized during code caching or for preload
     if (k->is_instance_klass() && !InstanceKlass::cast(k)->is_initialized() && (init_state == 1) && !_preload) {
       set_lookup_failed();
       log_info(scc)("%d '%s' (L%d): Lookup failed for klass %s: not initialized",
-                       compile_id(), comp_name, comp_level(), k->external_name());
+                       compile_id(), comp_method->name_and_sig_as_C_string(), comp_level(), k->external_name());
       return nullptr;
     }
     if (array_dim > 0) {
@@ -1406,26 +1405,30 @@ Method* SCCReader::read_method(const methodHandle& comp_method, bool shared) {
     }
     assert(m->is_method(), "sanity");
     ResourceMark rm;
-    const char* comp_name = comp_method->name_and_sig_as_C_string();
     Klass* k = m->method_holder();
     if (!k->is_instance_klass()) {
       set_lookup_failed();
-      log_info(scc)("%d '%s' (L%d): Lookup failed for holder %s: not instance klass", compile_id(), comp_name, comp_level(), k->external_name());
+      log_info(scc)("%d '%s' (L%d): Lookup failed for holder %s: not instance klass",
+                    compile_id(), comp_method->name_and_sig_as_C_string(), comp_level(), k->external_name());
       return nullptr;
     } else if (!MetaspaceShared::is_in_shared_metaspace((address)k)) {
       set_lookup_failed();
-      log_info(scc)("%d '%s' (L%d): Lookup failed for holder %s: not in CDS", compile_id(), comp_name, comp_level(), k->external_name());
+      log_info(scc)("%d '%s' (L%d): Lookup failed for holder %s: not in CDS",
+                    compile_id(), comp_method->name_and_sig_as_C_string(), comp_level(), k->external_name());
       return nullptr;
     } else if (!InstanceKlass::cast(k)->is_loaded()) {
       set_lookup_failed();
-      log_info(scc)("%d '%s' (L%d): Lookup failed for holder %s: not loaded", compile_id(), comp_name, comp_level(), k->external_name());
+      log_info(scc)("%d '%s' (L%d): Lookup failed for holder %s: not loaded",
+                    compile_id(), comp_method->name_and_sig_as_C_string(), comp_level(), k->external_name());
       return nullptr;
     } else if (!InstanceKlass::cast(k)->is_linked()) {
       set_lookup_failed();
-      log_info(scc)("%d '%s' (L%d): Lookup failed for holder %s: not linked%s", compile_id(), comp_name, comp_level(), k->external_name(), (_preload ? " for code preload" : ""));
+      log_info(scc)("%d '%s' (L%d): Lookup failed for holder %s: not linked%s",
+                    compile_id(), comp_method->name_and_sig_as_C_string(), comp_level(), k->external_name(), (_preload ? " for code preload" : ""));
       return nullptr;
     }
-    log_info(scc)("%d (L%d): Shared method lookup: %s", compile_id(), comp_level(), m->name_and_sig_as_C_string());
+    log_info(scc)("%d (L%d): Shared method lookup: %s",
+                  compile_id(), comp_level(), m->name_and_sig_as_C_string());
     return m;
   }
   int holder_length = *(int*)addr(code_offset);
@@ -3429,9 +3432,8 @@ SCCEntry* SCCache::write_nmethod(const methodHandle& method,
 #endif
   {
     ResourceMark rm;
-    const char* name   = method->name_and_sig_as_C_string();
     log_info(scc, nmethod)("%d (L%d): Wrote nmethod '%s'%s to AOT Code Cache",
-                           comp_id, (int)comp_level, name, (_for_preload ? " (for preload)" : ""));
+                           comp_id, (int)comp_level, method->name_and_sig_as_C_string(), (_for_preload ? " (for preload)" : ""));
   }
   if (VerifyCachedCode) {
     return nullptr;


### PR DESCRIPTION
Now that we have optimized a lot of unnecessary compilations, profiles show that various `name_and_sig_as_C_string` are taking about 1.2% in Leyden benchmark profiles. We should sweep those up into conditional log statements and/or common the paths where we actually need these names outside of logging. 

After this fix, the profile impact of `name_and_sig_as_C_string` is `<0.05%`.

Performance impact on benchmarks is currently hidden by benchmark noise.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8350115](https://bugs.openjdk.org/browse/JDK-8350115): [leyden] Clean up name_and_sig_as_C_string uses (**Enhancement** - P4)


### Reviewers
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.org/leyden.git pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/43.diff">https://git.openjdk.org/leyden/pull/43.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/43#issuecomment-2659777450)
</details>
