### PR TITLE
8350488: [leyden] Experimental AOT-only mode

### DIFF
--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1186,7 +1186,7 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
 // native method than the typical interpreter frame setup.
 address TemplateInterpreterGenerator::generate_native_entry(bool synchronized, bool runtime_upcalls) {
   // determine code generation flags
-  bool inc_counter  = UseCompiler || CountCompiledCalls;
+  bool inc_counter = (UseCompiler || CountCompiledCalls) && !PreloadOnly;
 
   // r1: Method*
   // rscratch1: sender sp
@@ -1638,7 +1638,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized, b
 //
 address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized, bool runtime_upcalls) {
   // determine code generation flags
-  bool inc_counter  = UseCompiler || CountCompiledCalls;
+  bool inc_counter = (UseCompiler || CountCompiledCalls) && !PreloadOnly;
 
   // rscratch1: sender sp
   address entry_point = __ pc();

--- a/src/hotspot/cpu/arm/templateInterpreterGenerator_arm.cpp
+++ b/src/hotspot/cpu/arm/templateInterpreterGenerator_arm.cpp
@@ -809,7 +809,7 @@ address TemplateInterpreterGenerator::generate_Float_floatToFloat16_entry() { re
 
 address TemplateInterpreterGenerator::generate_native_entry(bool synchronized, bool runtime_upcalls) {
   // determine code generation flags
-  bool inc_counter  = UseCompiler || CountCompiledCalls;
+  bool inc_counter = (UseCompiler || CountCompiledCalls) && !PreloadOnly;
 
   // Incoming registers:
   //
@@ -1143,7 +1143,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized, b
 //
 address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized, bool runtime_upcalls) {
   // determine code generation flags
-  bool inc_counter  = UseCompiler || CountCompiledCalls;
+  bool inc_counter = (UseCompiler || CountCompiledCalls) && !PreloadOnly;
 
   // Rmethod: Method*
   // Rthread: thread

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -1229,7 +1229,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized, b
 
   address entry = __ pc();
 
-  const bool inc_counter = UseCompiler || CountCompiledCalls;
+  const bool inc_counter = (UseCompiler || CountCompiledCalls) && !PreloadOnly;
 
   // -----------------------------------------------------------------------------
   // Allocate a new frame that represents the native callee (i2n frame).
@@ -1685,7 +1685,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized, b
 // Generic interpreted method entry to (asm) interpreter.
 //
 address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized, bool runtime_upcalls) {
-  bool inc_counter = UseCompiler || CountCompiledCalls;
+  bool inc_counter = (UseCompiler || CountCompiledCalls) && !PreloadOnly;
   address entry = __ pc();
   // Generate the code to allocate the interpreter stack frame.
   Register Rsize_of_parameters = R4_ARG2, // Written by generate_fixed_frame.

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -989,7 +989,7 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
 // native method than the typical interpreter frame setup.
 address TemplateInterpreterGenerator::generate_native_entry(bool synchronized, bool runtime_upcalls) {
   // determine code generation flags
-  bool inc_counter = UseCompiler || CountCompiledCalls;
+  bool inc_counter = (UseCompiler || CountCompiledCalls) && !PreloadOnly;
 
   // x11: Method*
   // x30: sender sp
@@ -1413,7 +1413,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized, b
 address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized, bool runtime_upcalls) {
 
   // determine code generation flags
-  const bool inc_counter  = UseCompiler || CountCompiledCalls;
+  const bool inc_counter = (UseCompiler || CountCompiledCalls) && !PreloadOnly;
 
   // t0: sender sp
   address entry_point = __ pc();

--- a/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
@@ -1307,7 +1307,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
 // native method than the typical interpreter frame setup.
 address TemplateInterpreterGenerator::generate_native_entry(bool synchronized, bool runtime_upcalls) {
   // Determine code generation flags.
-  bool inc_counter = UseCompiler || CountCompiledCalls;
+  bool inc_counter = (UseCompiler || CountCompiledCalls) && !PreloadOnly;
 
   // Interpreter entry for ordinary Java methods.
   //
@@ -1666,7 +1666,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized, b
 address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized, bool runtime_upcalls) {
   address entry_point = __ pc();
 
-  bool inc_counter = UseCompiler || CountCompiledCalls;
+  bool inc_counter = (UseCompiler || CountCompiledCalls) && !PreloadOnly;
 
   // Interpreter entry for ordinary Java methods.
   //

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -811,7 +811,7 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
 // native method than the typical interpreter frame setup.
 address TemplateInterpreterGenerator::generate_native_entry(bool synchronized, bool runtime_upcalls) {
   // determine code generation flags
-  bool inc_counter  = UseCompiler || CountCompiledCalls;
+  bool inc_counter = (UseCompiler || CountCompiledCalls) && !PreloadOnly;
 
   // rbx: Method*
   // rbcp: sender sp
@@ -1380,7 +1380,7 @@ address TemplateInterpreterGenerator::generate_abstract_entry(void) {
 //
 address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized, bool runtime_upcalls) {
   // determine code generation flags
-  bool inc_counter  = UseCompiler || CountCompiledCalls;
+  bool inc_counter = (UseCompiler || CountCompiledCalls) && !PreloadOnly;
 
   // ebx: Method*
   // rbcp: sender sp (set in InterpreterMacroAssembler::prepare_to_jump_from_interpreted / generate_call_stub)

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -3274,6 +3274,10 @@ void LIRGenerator::increment_event_counter(CodeEmitInfo* info, LIR_Opr step, int
 void LIRGenerator::increment_event_counter_impl(CodeEmitInfo* info,
                                                 ciMethod *method, LIR_Opr step, int frequency,
                                                 int bci, bool backedge, bool notify) {
+  if (PreloadOnly) {
+    // Nothing to do if we only use preload code.
+    return;
+  }
   assert(frequency == 0 || is_power_of_2(frequency + 1), "Frequency must be x^2 - 1 or 0");
   int level = _compilation->env()->comp_level();
   assert(level > CompLevel_simple, "Shouldn't be here");

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -587,6 +587,17 @@ void CompilerConfig::ergo_initialize() {
   set_jvmci_specific_flags();
 #endif
 
+  if (PreloadOnly) {
+    // Disable profiling/counter updates in interpreter and C1.
+    // This effectively disables most of the normal JIT (re-)compilations.
+    FLAG_SET_DEFAULT(ProfileInterpreter, false);
+    FLAG_SET_DEFAULT(UseOnStackReplacement, false);
+    FLAG_SET_DEFAULT(UseLoopCounter, false);
+
+    // Disable compilations through training data replay.
+    FLAG_SET_DEFAULT(ReplayTraining, false);
+  }
+
   if (UseOnStackReplacement && !UseLoopCounter) {
     warning("On-stack-replacement requires loop counters; enabling loop counters");
     FLAG_SET_DEFAULT(UseLoopCounter, true);

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -495,6 +495,10 @@
           "Preload code is processed with blocking. Startup would not "     \
           "proceed until all code preloaded code is done loading.")         \
                                                                             \
+  product(bool, PreloadOnly, false, EXPERIMENTAL,                           \
+          "Use preload code exclusively. This effectively disables most of "\
+          "profiling and JIT compilation, running close to AOT-only mode.") \
+                                                                            \
 
 // end of COMPILER_FLAGS
 

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1181,6 +1181,8 @@ JRT_END
 
 
 nmethod* InterpreterRuntime::frequency_counter_overflow(JavaThread* current, address branch_bcp) {
+  assert(!PreloadOnly, "Should not be using interpreter counters");
+
   // Enable WXWrite: the function is called directly by interpreter.
   MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, current));
 
@@ -1285,6 +1287,7 @@ JRT_END
 #endif // ASSERT
 
 JRT_ENTRY_PROF(void, InterpreterRuntime, update_mdp_for_ret, InterpreterRuntime::update_mdp_for_ret(JavaThread* current, int return_bci))
+  assert(!PreloadOnly, "Should not be using interpreter counters");
   assert(ProfileInterpreter, "must be profiling interpreter");
   ResourceMark rm(current);
   LastFrameAccessor last_frame(current);


### PR DESCRIPTION
There are interesting use cases where we want the AOT-only mode. We can emulate this in current Leyden prototype by relying on preload code, and stopping any profiling, which would naturally lead to no JIT compilations. This would also make interpreter code a bit faster in case we need to fall back there. This mode looks also helpful for studying the compiler dynamics.

Additional testing:
 - [x] Eyeballing compilation logs with `-XX:+PreloadOnly`
 - [x] Linux x86_64 server fastdebug, `runtime/cds`
 - [x] Linux x86_64 server fastdebug, `runtime/cds` with `-XX:+PreloadOnly`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8350488](https://bugs.openjdk.org/browse/JDK-8350488): [leyden] Experimental AOT-only mode (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.org/leyden.git pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/44.diff">https://git.openjdk.org/leyden/pull/44.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/44#issuecomment-2674201600)
</details>
