### PR TITLE
8351004: [leyden] Add test cases for cached Reference objects

### DIFF
--- a/src/hotspot/share/cds/aotClassInitializer.cpp
+++ b/src/hotspot/share/cds/aotClassInitializer.cpp
@@ -27,6 +27,7 @@
 #include "cds/cdsConfig.hpp"
 #include "dumpTimeClassInfo.inline.hpp"
 #include "cds/heapShared.hpp"
+#include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionaryShared.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "memory/resourceArea.hpp"
@@ -34,8 +35,11 @@
 #include "oops/instanceKlass.inline.hpp"
 #include "oops/symbol.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
+#include "runtime/java.hpp"
 #include "runtime/javaCalls.hpp"
 #include "runtime/mutexLocker.hpp"
+
+DEBUG_ONLY(InstanceKlass* _aot_init_class = nullptr;)
 
 // Detector for class names we wish to handle specially.
 // It is either an exact string match or a string prefix match.
@@ -321,6 +325,12 @@ bool AOTClassInitializer::can_archive_initialized_mirror(InstanceKlass* ik) {
     }
   }
 
+#ifdef ASSERT
+  if (ik == _aot_init_class) {
+    return true;
+  }
+#endif
+
   return false;
 }
 
@@ -479,3 +489,33 @@ void AOTClassInitializer::maybe_preinit_class(InstanceKlass* ik, TRAPS) {
   }
 #endif
 }
+
+#ifdef ASSERT
+void AOTClassInitializer::init_test_class(TRAPS) {
+  // -XX:AOTInitTestClass is used in regression tests for adding additional AOT-initialized classes
+  // and heap objects into the AOT cache. The tests must be carefully written to avoid including
+  // any classes that cannot be AOT-initialized.
+  //
+  // -XX:AOTInitTestClass is NOT a general mechanism for including user-defined objects into
+  // the AOT cache. Therefore, this option is NOT available in product JVM.
+  if (AOTInitTestClass != nullptr && CDSConfig::is_initing_classes_at_dump_time()) {
+    log_info(cds)("Debug build only: force initialization of AOTInitTestClass %s", AOTInitTestClass);
+    TempNewSymbol class_name = SymbolTable::new_symbol(AOTInitTestClass);
+    Handle app_loader(THREAD, SystemDictionary::java_system_loader());
+    Klass* k = SystemDictionary::resolve_or_null(class_name, app_loader, CHECK);
+    if (k == nullptr) {
+      vm_exit_during_initialization("AOTInitTestClass not found", AOTInitTestClass);
+    }
+    if (!k->is_instance_klass()) {
+      vm_exit_during_initialization("Invalid name for AOTInitTestClass", AOTInitTestClass);
+    }
+
+    _aot_init_class = InstanceKlass::cast(k);
+    _aot_init_class->initialize(CHECK);
+  }
+}
+
+bool AOTClassInitializer::has_test_class() {
+  return _aot_init_class != nullptr;
+}
+#endif

--- a/src/hotspot/share/cds/aotClassInitializer.hpp
+++ b/src/hotspot/share/cds/aotClassInitializer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,10 @@ public:
 
   static bool is_runtime_setup_required(InstanceKlass* ik);
   static void call_runtime_setup(JavaThread* current, InstanceKlass* ik);
+
+  // Support for regression testing. Available in debug builds only.
+  static void init_test_class(TRAPS) NOT_DEBUG_RETURN;
+  static bool has_test_class() NOT_DEBUG({ return false; });
 };
 
 #endif // SHARE_CDS_AOTCLASSINITIALIZER_HPP

--- a/src/hotspot/share/cds/cds_globals.hpp
+++ b/src/hotspot/share/cds/cds_globals.hpp
@@ -71,6 +71,10 @@
           "\"archivedObjects\" of the specified class is stored in the "    \
           "CDS archive heap")                                               \
                                                                             \
+  develop(ccstr, AOTInitTestClass, nullptr,                                 \
+          "For JVM internal testing only. The specified class is stored "   \
+          "in the initialized state in the AOT cache ")                     \
+                                                                            \
   product(ccstr, DumpLoadedClassList, nullptr,                              \
           "Dump the names all loaded classes, that could be stored into "   \
           "the CDS archive, in the specified file")                         \

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -988,8 +988,11 @@ void KlassSubGraphInfo::add_subgraph_object_klass(Klass* orig_k) {
 #ifdef ASSERT
     InstanceKlass* ik = InstanceKlass::cast(orig_k);
     if (CDSConfig::is_dumping_invokedynamic()) {
+      // -XX:AOTInitTestClass must be used carefully in regression tests to
+      // include only classes that are safe to aot-initialize.
       assert(ik->class_loader() == nullptr ||
-             HeapShared::is_lambda_proxy_klass(ik),
+             HeapShared::is_lambda_proxy_klass(ik) ||
+             AOTClassInitializer::has_test_class(),
             "we can archive only instances of boot classes or lambda proxy classes");
     } else {
       assert(ik->class_loader() == nullptr, "must be boot class");

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -788,6 +788,7 @@ bool MetaspaceShared::may_be_eagerly_linked(InstanceKlass* ik) {
 
 void MetaspaceShared::link_shared_classes(bool jcmd_request, TRAPS) {
   AOTClassLinker::initialize();
+  AOTClassInitializer::init_test_class(CHECK);
 
   if (!jcmd_request && !CDSConfig::is_dumping_dynamic_archive()
       && !CDSConfig::is_dumping_preimage_static_archive()   // FIXME -- remove this for Leyden??

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/WeakReferenceTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/WeakReferenceTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test various test cases for archived WeakReference objects.
+ * @requires vm.cds.write.archived.java.heap
+ * @requires vm.cds.supports.aot.class.linking
+ * @requires vm.debug
+ * @comment work around JDK-8345635
+ * @requires !vm.jvmci.enabled
+ * @comment TODO ...tested only against G1
+ * @requires vm.gc.G1
+ * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @build WeakReferenceTest
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar weakref.jar
+ *             WeakReferenceTestApp WeakReferenceTestApp$Inner ShouldNotBeAOTInited ShouldNotBeArchived SharedQueue
+ * @run driver WeakReferenceTest AOT
+ */
+
+import java.lang.ref.WeakReference;
+import java.lang.ref.ReferenceQueue;
+import jdk.test.lib.cds.CDSAppTester;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.helpers.ClassFileInstaller;
+
+public class WeakReferenceTest {
+    static final String appJar = ClassFileInstaller.getJarPath("weakref.jar");
+    static final String mainClass = "WeakReferenceTestApp";
+
+    public static void main(String[] args) throws Exception {
+        Tester t = new Tester();
+        t.run(args);
+    }
+
+    static class Tester extends CDSAppTester {
+        public Tester() {
+            super(mainClass);
+        }
+
+        @Override
+        public String classpath(RunMode runMode) {
+            return appJar;
+        }
+
+        @Override
+        public String[] vmArgs(RunMode runMode) {
+            if (runMode == RunMode.ASSEMBLY) {
+                return new String[] {
+                    "-Xlog:gc,cds+class=debug",
+                    "-XX:AOTInitTestClass=WeakReferenceTestApp",
+                    "-Xlog:cds+map,cds+map+oops=trace:file=cds.oops.txt:none:filesize=0",
+                };
+            } else {
+                return new String[] {
+                    "-Xlog:gc",
+                };
+            }
+        }
+
+        @Override
+        public String[] appCommandLine(RunMode runMode) {
+            return new String[] {
+                mainClass,
+                runMode.toString(),
+            };
+        }
+
+        @Override
+        public void checkExecution(OutputAnalyzer out, RunMode runMode) throws Exception {
+            out.shouldHaveExitValue(0);
+            out.shouldNotContain("Unexpected exception:");
+        }
+    }
+}
+
+// TODO: Add test: cleaner should work in both assembly phase and production run
+
+class WeakReferenceTestApp {
+    // This class is NOT aot-initialized
+    static class Inner {
+        static boolean WeakReferenceTestApp_clinit_executed;
+    }
+
+    static {
+        Inner.WeakReferenceTestApp_clinit_executed = true;
+
+        // During the assembly phase, this block of code is called during the assembly
+        // phase (triggered by the -XX:AOTInitTestClass=WeakReferenceTestApp flag).
+        // It runs the clinit_for_testXXX() method to set up the aot-initialized data structures
+        // that are used by  each testXXX() function.
+        //
+        // Note that this function is also called during the training run.
+        // This function is NOT called during the production run, because WeakReferenceTestApp
+        // is aot-initialized.
+
+        clinit_for_testCollectedInAssembly();
+        clinit_for_testWeakReferenceCollection();
+        clinit_for_testQueue();
+    }
+
+    static WeakReference makeRef() {
+        System.out.println("WeakReferenceTestApp::makeRef() is executed");
+        WeakReference r = new WeakReference(root);
+        System.out.println("r.get() = " + r.get());
+
+        ShouldNotBeAOTInited.doit();
+        return r;
+    }
+
+    static WeakReference makeRef2() {
+        return new WeakReference(new WeakReferenceTestApp());
+    }
+
+    public static void main(String[] args) {
+        try {
+            runTests(args);
+        } catch (Throwable t) {
+            System.err.println("Unexpected exception:");
+            t.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    static void runTests(String[] args) throws Exception {
+        boolean isProduction = args[0].equals("PRODUCTION");
+
+        if (isProduction && Inner.WeakReferenceTestApp_clinit_executed) {
+            throw new RuntimeException("WeakReferenceTestApp should have been aot-inited");
+        }
+
+        if (isProduction) {
+            // A GC should have happened before the heap objects are written into
+            // the AOT cache. So any unreachable referents should have been collected.
+        } else {
+            // We are in the training run. Simulate the GC mentioned in the above comment,
+            // so the test cases should observe the same states as in the production run.
+            System.gc();
+        }
+
+        testCollectedInAssembly(isProduction);
+        testWeakReferenceCollection(isProduction);
+        testQueue(isProduction);
+    }
+
+    //----------------------------------------------------------------------
+    // Set up for testCollectedInAssembly()
+    static WeakReference refToCollectedObj;
+
+    static void clinit_for_testCollectedInAssembly() {
+        // The referent will be GC-ed in the assembly run when the JVM forces a full GC.
+        refToCollectedObj = new WeakReference(new String("collected in assembly"));
+    }
+
+    // [TEST CASE] Test the storage of a WeakReference whose referent has been collected during the assembly phase.
+    static void testCollectedInAssembly(boolean isProduction) {
+        System.out.println("refToCollectedObj.get() = " + refToCollectedObj.get());
+        System.out.println("refToCollectedObj.isEnqueued() = " + refToCollectedObj.isEnqueued());
+
+        if (refToCollectedObj.get() != null) {
+            throw new RuntimeException("refToCollectedObj.get() should have been GC'ed");
+        }
+
+        /*
+         * FIXME -- why does this fail, even in training run?
+
+        if (!refToCollectedObj.isEnqueued()) {
+            throw new RuntimeException("refToCollectedObj.isEnqueued() should be true");
+        }
+        */
+    }
+
+    //----------------------------------------------------------------------
+    // Set up for testWeakReferenceCollection()
+    static Object root;
+    static WeakReference ref;
+
+    static void clinit_for_testWeakReferenceCollection() {
+        root = new WeakReferenceTestApp();
+        ref = makeRef();
+    }
+
+    // [TEST CASE] A WeakReference allocated in assembly phase should be collectable in the production run
+    static void testWeakReferenceCollection(boolean isProduction) {
+        WeakReference ref2 = makeRef2();
+        System.out.println("ref.get() = " + ref.get());   // created during assembly phase
+        System.out.println("ref2.get() = " + ref2.get()); // created during production run
+
+        if (ref.get() == null) {
+            throw new RuntimeException("ref.get() should not be null");
+        }
+        if (ref2.get() == null) {
+            throw new RuntimeException("ref2.get() should not be null");
+        }
+
+        System.out.println("... running GC ...");
+        root = null;
+        System.gc();
+
+        System.out.println("ref.get() = " + ref.get());
+        System.out.println("ref2.get() = " + ref2.get());
+
+        if (ref.get() != null) {
+            throw new RuntimeException("ref.get() should be null");
+        }
+        if (ref2.get() != null) {
+            throw new RuntimeException("ref2.get() should be null");
+        }
+
+        System.out.println("ShouldNotBeAOTInited.doit_executed = " + ShouldNotBeAOTInited.doit_executed);
+        if (isProduction && ShouldNotBeAOTInited.doit_executed) {
+            throw new RuntimeException("ShouldNotBeAOTInited should not have been aot-inited");
+        }
+    }
+
+    //----------------------------------------------------------------------
+    // Set up for testQueue()
+    static WeakReference refWithQueue;
+    static SharedQueue sharedQueueInstance;
+
+    static void clinit_for_testQueue() {
+        // Make sure SharedQueue is also cached in *initialized* state.
+        sharedQueueInstance = SharedQueue.sharedQueueInstance;
+
+        refWithQueue = new WeakReference(String.class, SharedQueue.queue());
+        ShouldNotBeArchived.ref = new WeakReference(ShouldNotBeArchived.instance, SharedQueue.queue());
+
+
+        // Set to 2 in training run and assembly phase, but this state shouldn't be stored in
+        // AOT cache.
+        ShouldNotBeArchived.state = 2;
+    }
+
+    // [TEST CASE] Unrelated WeakReferences shouldn't be cached even if they are registered with the same queue
+    static void testQueue(boolean isProduction) {
+        System.out.println("refWithQueue.get() = " + refWithQueue.get());
+        System.out.println("ShouldNotBeArchived.state = " + ShouldNotBeArchived.state);
+
+        // [1] Although refWithQueue and ShouldNotBeArchived.ref are registered with the same queue, as both
+        //     of their referents are strongly referenced, they are not added to the queue's "head".
+        //     (Per javadoc: "registered reference objects are appended by the garbage collector after the
+        //     appropriate reachability changes are detected");
+        // [2] When the assembly phase scans refWithQueue, it shouldn't discover ShouldNotBeArchived.ref (via the queue),
+        //     so ShouldNotBeArchived.ref should not be stored in the AOT cache.
+        // [3] As a result, ShouldNotBeArchived should be cached in the *not initialized" state. Its <clinit>
+        //     will be executed in the production run to set ShouldNotBeArchived.state to 1.
+        if (isProduction && ShouldNotBeArchived.state != 1) {
+            throw new RuntimeException("ShouldNotBeArchived should be 1 but is " + ShouldNotBeArchived.state);
+        }
+    }
+}
+
+class ShouldNotBeAOTInited {
+    static WeakReference ref;
+    static boolean doit_executed;
+    static {
+        System.out.println("ShouldNotBeAOTInited.<clinit> called");
+    }
+    static void doit() {
+        System.out.println("ShouldNotBeAOTInited.doit()> called");
+        doit_executed = true;
+        ref = new WeakReference(new ShouldNotBeAOTInited());
+    }
+}
+
+class ShouldNotBeArchived {
+    static ShouldNotBeArchived instance = new ShouldNotBeArchived();
+    static WeakReference ref;
+    static int state = 1;
+}
+
+class SharedQueue {
+    static SharedQueue sharedQueueInstance = new SharedQueue();
+    private ReferenceQueue<Object> theQueue = new ReferenceQueue<Object>();
+
+    static ReferenceQueue<Object> queue() {
+        return sharedQueueInstance.theQueue;
+    }
+}


### PR DESCRIPTION
[JDK-8341587](https://bugs.openjdk.org/browse/JDK-8341587) allows Soft/Weak `Reference` objects to be stored in the AOT cache. Currently Soft/Weak references are used only for supporting method handles. However, we need to make sure that the support for cached Reference is correctly implemented:

1. When we add other types of objects to the AOT cache that use `Reference` objects (e.g., [JDK-8351005](https://bugs.openjdk.org/browse/JDK-8351005) "Revert back to SoftReference for Class::reflectionData"), they should work as expected.
2. The cached `Reference` objects used by the method handles implementation (such as those used by `MethodType.internTable`) should not be unnecessarily coupled with unrelated Reference (e.g., via the `Reference::link` field due to operations in `java.lang.ref.ReferenceQueue` or `java.lang.ref.Finalizer`). Otherwise, this could cause unrelated objects to be unintentionally stored in the AOT cache.
3. `java.lang.ref.Cleaner` should work as expected during both the AOT assembly phase and production run.
4. Finalization should work as expected during both the AOT assembly phase and production run.

This RFE adds a flag (`-XX:AOTInitTestClass=...`, available **only** in debug builds) to store arbitrary heap objects into the AOT cache. With this flag, we can the behavior of `Reference` in the AOT cache so that we can determine if the current support for Reference objects in Leyden is good enough for upstreaming to the mainline.

This RFE doesn't not test everything as listed above cases. Some additional test cases may be added by a subsequent commit.

I have observed the following:

**[A]** Cached `WeakReference` objects seem to be supported by the GC in the production run. See `testWeakReferenceCollection()`: if a referent is no longer reachable, `ref.get()` returns `null`.

**[B]** Case (2) doesn't seem to be a concern: `testQueue()` shows that the assembly phase won't accidentally find unrelated `WeakReference` objects even if they share the same queue as a `WeakReference` that's destined to be cached. See comments in `testQueue()` for more details.

**[C]** `MethodType.internTable` is a `ReferencedKeySet` that internally uses `WeakReference` to automatically remove elements that are no longer referenced. However, with `grep -n referent.*null cds.oops.txt` in the test's output directory, we can see a few `WeakReferenceKeys` whose `referent` has been collected, but we didn't remove these keys from the `internTable` at `(0xfffcd3e1)`:

```
0x00000007ffe6b2e8: @@ Object  jdk.internal.util.WeakReferenceKey
 - klass: 'jdk/internal/util/WeakReferenceKey' 0x00000008002f9ad8
 - fields (4 words):
 - private 'referent' 'Ljava/lang/Object;' @12 null
 - volatile 'queue' 'Ljava/lang/ref/ReferenceQueue;' @16 0x00000007ffe6afb0 (0xfffcd5f6) java.lang.ref.ReferenceQueue
 - volatile 'next' 'Ljava/lang/ref/Reference;' @20 null
 - private transient 'discovered' 'Ljava/lang/ref/Reference;' @24 0x00000007ffe6b308 (0xfffcd661) jdk.internal.util.WeakReferenceKey
 - private final 'hashcode' 'I' @28  52198401 (0x031c7c01)

0x00000007ffe6afb0: @@ Object (0xfffcd5f6) java.lang.ref.ReferenceQueue
 - klass: 'java/lang/ref/ReferenceQueue' 0x000000080014f178
 - fields (4 words):
 - private volatile 'head' 'Ljava/lang/ref/Reference;' @12 null
 - private 'queueLength' 'J' @16  0 (0x0000000000000000)
 - private final 'lock' 'Ljava/lang/ref/ReferenceQueue$Lock;' @24 0x00000007ffee0c78 (0xfffdc18f) java.lang.ref.ReferenceQueue$Lock

0x00000007ffe69f08: @@ Object (0xfffcd3e1) jdk.internal.util.ReferencedKeyMap
 - klass: 'jdk/internal/util/ReferencedKeyMap' 0x00000008002f7298
 - fields (3 words):
 - private final 'isSoft' 'Z' @12  false (0x00)
 - private final 'map' 'Ljava/util/Map;' @16 0x00000007ffe69f20 (0xfffcd3e4) java.util.concurrent.ConcurrentHashMap
 - private final 'stale' 'Ljava/lang/ref/ReferenceQueue;' @20 0x00000007ffe6afb0 (0xfffcd5f6) java.lang.ref.ReferenceQueue
```

The `(0xfffcd65d) WeakReferenceKey` should have been added to the `ReferencedKeyMap::stale` queue, but we can see that the queue is empty.

We can see a few non-null  `Reference::discovered` field in `cds.oops.txt`. These are waiting for the `Reference$ReferenceHandler` thread to move them onto the target `ReferenceQueue.`

However, take a look at the following two lines in the `WeakReferenceTestApp.aot.log` file from the test's output directory: The `Reference$ReferenceHandler` thread is disabled in the assembly phase.

```
[0.137s][info ][cds] JVM_StartThread() ignored: java.lang.ref.Reference$ReferenceHandler
[0.137s][info ][cds] JVM_StartThread() ignored: java.lang.ref.Finalizer$FinalizerThread
```

There are two reasons that we run only a single Java thread during the assembly phase:

- Historically, we wanted the contents of the CDS archive deterministic. Concurrently executing Java threads made this very difficult, so we basically hijacked `Thread::start()` to disallow the launching of new Java threads.
- Right before we enter a safepoint to dump the AOT cache, we execute a small amount of Java code (in the main Java thread) to clean up global states. Concurrent Java threads may step on these clean up operations.

Maybe we can enable multiple Java threads for Leyden

- With new Leyden optimizations such as profiling and AOT compilation, the AOT cache is no longer deterministic anyway. It will be exceedingly difficult to get deterministic contents.
- As @shipilev mentioned offline, we may need a way for the GC to tell us that it "has finished all (concurrent) work". At that point, we can wait for the ReferenceHandler/FinalizerThread to become quiescent before we start the global clean up operations. We need to restrict these operations such that they won't cause additional GCs, etc.

Also, we need to call `jdk.internal.util.ReferencedKeyMap::removeStaleReferences()` during the global clean up:

```
    public void removeStaleReferences() {
        while (true) {
            Object key = stale.poll();
            if (key == null) {
                break;
            }
            map.remove(key);
        }
    }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8351004](https://bugs.openjdk.org/browse/JDK-8351004): [leyden] Add test cases for cached Reference objects (**Enhancement** - P4)


### Reviewers
 * [John R Rose](https://openjdk.org/census#jrose) (@rose00 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.org/leyden.git pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/45.diff">https://git.openjdk.org/leyden/pull/45.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/45#issuecomment-2692571210)
</details>
