### PR TITLE
8352042: [leyden] Parallel precompilation

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2045,6 +2045,10 @@ void CompileBroker::wait_for_completion(CompileTask* task) {
   }
 }
 
+void CompileBroker::wait_for_no_active_tasks() {
+  CompileTask::wait_for_no_active_tasks();
+}
+
 /**
  * Initialize compiler thread(s) + compiler object(s). The postcondition
  * of this function is that the compiler runtimes are initialized and that

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1755,9 +1755,7 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
     }
     bool is_blocking = ReplayCompiles                                             ||
                        !directive->BackgroundCompilationOption                    ||
-                       (PreloadBlocking && (compile_reason == CompileTask::Reason_Preload)) ||
-                       (compile_reason == CompileTask::Reason_Precompile)         ||
-                       (compile_reason == CompileTask::Reason_PrecompileForPreload);
+                       (PreloadBlocking && (compile_reason == CompileTask::Reason_Preload));
     compile_method_base(method, osr_bci, comp_level, hot_method, hot_count, compile_reason, requires_online_compilation, is_blocking, THREAD);
   }
 

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -298,6 +298,10 @@ class CompileBroker: AllStatic {
 #if INCLUDE_JVMCI
   static bool wait_for_jvmci_completion(JVMCICompiler* comp, CompileTask* task, JavaThread* thread);
 #endif
+public:
+  static void wait_for_no_active_tasks();
+
+private:
 
   static void free_buffer_blob_if_allocated(CompilerThread* thread);
 

--- a/src/hotspot/share/compiler/compileLog.cpp
+++ b/src/hotspot/share/compiler/compileLog.cpp
@@ -49,7 +49,7 @@ CompileLog::CompileLog(const char* file_name, FILE* fp, intx thread_id)
    strcpy((char*)_file, file_name);
 
   // link into the global list
-  { MutexLocker locker(CompileTaskAlloc_lock);
+  { MonitorLocker locker(CompileTaskAlloc_lock);
     _next = _first;
     _first = this;
   }

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -44,7 +44,7 @@ int CompileTask::_active_tasks = 0;
  * Allocate a CompileTask, from the free list if possible.
  */
 CompileTask* CompileTask::allocate() {
-  MutexLocker locker(CompileTaskAlloc_lock);
+  MonitorLocker locker(CompileTaskAlloc_lock);
   CompileTask* task = nullptr;
 
   if (_task_free_list != nullptr) {
@@ -66,7 +66,7 @@ CompileTask* CompileTask::allocate() {
 * Add a task to the free list.
 */
 void CompileTask::free(CompileTask* task) {
-  MutexLocker locker(CompileTaskAlloc_lock);
+  MonitorLocker locker(CompileTaskAlloc_lock);
   if (!task->is_free()) {
     assert(!task->lock()->is_locked(), "Should not be locked when freed");
     if ((task->_method_holder != nullptr && JNIHandles::is_weak_global_handle(task->_method_holder)) ||
@@ -87,12 +87,17 @@ void CompileTask::free(CompileTask* task) {
     task->set_next(_task_free_list);
     _task_free_list = task;
     _active_tasks--;
+    if (_active_tasks == 0) {
+      locker.notify_all();
+    }
   }
 }
 
-int CompileTask::active_tasks() {
-  MutexLocker locker(CompileTaskAlloc_lock);
-  return _active_tasks;
+void CompileTask::wait_for_no_active_tasks() {
+  MonitorLocker locker(CompileTaskAlloc_lock);
+  while (_active_tasks > 0) {
+    locker.wait();
+  }
 }
 
 void CompileTask::initialize(int compile_id,

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -95,6 +95,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
 
  private:
   static CompileTask*  _task_free_list;
+  static int           _active_tasks;
   Monitor*             _lock;
   int                  _compile_id;
   Method*              _method;
@@ -151,6 +152,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
 
   static CompileTask* allocate();
   static void         free(CompileTask* task);
+  static int          active_tasks();
 
   int          compile_id() const                   { return _compile_id; }
   Method*      method() const                       { return _method; }

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -152,7 +152,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
 
   static CompileTask* allocate();
   static void         free(CompileTask* task);
-  static int          active_tasks();
+  static void         wait_for_no_active_tasks();
 
   int          compile_id() const                   { return _compile_id; }
   Method*      method() const                       { return _method; }

--- a/src/hotspot/share/compiler/precompiler.cpp
+++ b/src/hotspot/share/compiler/precompiler.cpp
@@ -32,7 +32,6 @@
 #include "compiler/precompiler.hpp"
 #include "logging/logStream.hpp"
 #include "memory/allocation.hpp"
-#include "oops/method.inline.hpp"
 #include "oops/trainingData.hpp"
 #include "runtime/handles.inline.hpp"
 
@@ -175,7 +174,7 @@ public:
   void precompile(ArchiveBuilder* builder, TRAPS) {
     sort_methods_by_compile_id();
     schedule_compilations(THREAD);
-    CompileTask::wait_for_no_active_tasks();
+    CompileBroker::wait_for_no_active_tasks();
     print_compilation_status(builder);
   }
 };

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -88,7 +88,7 @@ Monitor* MethodCompileQueueSC1_lock   = nullptr;
 Monitor* MethodCompileQueueSC2_lock   = nullptr;
 Monitor* CompileThread_lock           = nullptr;
 Monitor* Compilation_lock             = nullptr;
-Mutex*   CompileTaskAlloc_lock        = nullptr;
+Monitor* CompileTaskAlloc_lock        = nullptr;
 Mutex*   CompileStatistics_lock       = nullptr;
 Mutex*   DirectivesStack_lock         = nullptr;
 Monitor* Terminator_lock              = nullptr;
@@ -355,7 +355,7 @@ void mutex_init() {
     MUTEX_DEFL(G1RareEvent_lock             , PaddedMutex  , Threads_lock, true);
   }
 
-  MUTEX_DEFL(CompileTaskAlloc_lock          , PaddedMutex  ,  MethodCompileQueue_lock);
+  MUTEX_DEFL(CompileTaskAlloc_lock          , PaddedMonitor,  MethodCompileQueue_lock);
 #if INCLUDE_PARALLELGC
   if (UseParallelGC) {
     MUTEX_DEFL(PSOldGenExpand_lock          , PaddedMutex  , Heap_lock, true);

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -91,7 +91,7 @@ extern Monitor* CompileThread_lock;              // a lock held by compile threa
 extern Monitor* Compilation_lock;                // a lock used to pause compilation
 extern Mutex*   TrainingData_lock;               // a lock used when accessing training records
 extern Monitor* TrainingReplayQueue_lock;        // a lock held when class are added/removed to the training replay queue
-extern Mutex*   CompileTaskAlloc_lock;           // a lock held when CompileTasks are allocated
+extern Monitor* CompileTaskAlloc_lock;           // a lock held when CompileTasks are allocated
 extern Mutex*   CompileStatistics_lock;          // a lock held when updating compilation statistics
 extern Mutex*   DirectivesStack_lock;            // a lock held when mutating the dirstack and ref counting directives
 extern Monitor* Terminator_lock;                 // a lock used to guard termination of the vm


### PR DESCRIPTION
For simplicity reasons, our current precompilation code uses effectively single-threaded blocking compiles. Even for simple cases, this makes assembly phase remarkably long. This does not scale well. We need to do precompilations in parallel. 

Unfortunately, I haven't found a good way to check that all async compilations are completed, so I introduced a new one.

Additional testing:
 - [x] Ad-hoc precompilation tests
 - [x] Linux x86_64 server fastdebug, `runtime/cds` 