### PR TITLE
Fix ARM builds after incomplete merge

### DIFF
--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -246,7 +246,7 @@ void log_vm_init_stats() {
 
 void print_bytecode_count() {
   if (CountBytecodes || TraceBytecodes || StopInterpreterAt) {
-    tty->print_cr("[BytecodeCounter::counter_value = " JLONG_FORMAT "]", BytecodeCounter::counter_value());
+    tty->print_cr("[BytecodeCounter::counter_value = %zu]", BytecodeCounter::counter_value());
   }
 }
 


### PR DESCRIPTION
We seem to have missed this upstream rewrite (JDK-8350642) with recent merge, which makes ARM builds in GHA failing. This PR picks up the line version from mainline.