### PR TITLE
Missing nmethod preload bit after #27

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1090,6 +1090,7 @@ void ciEnv::make_code_usable(JavaThread* thread, ciMethod* target, bool preload,
       }
 #endif // ASSERT
       if (preload) {
+        nm->set_preloaded(true);
         method->set_preload_code(nm);
       }
       if (!preload || target->holder()->is_linked()) {


### PR DESCRIPTION
Noticed in experiments that we no longer print "AP" in print compilation logs for preload code. I think #27 missed setting a relevant bit on `nmethod`.

Output before:

```
     52    W0.0   Q17.5    C0.0    A0.0    465      AP 4       com.sun.tools.javac.util.StringNameTable::fromString (50 bytes)
     53                                    465      A  4       com.sun.tools.javac.util.StringNameTable::fromString (50 bytes)   made not entrant: uncommon trap
```

Note this is compile task "465", yet it loses the "AP" in the middle of the run.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/51/head:pull/51` \
`$ git checkout pull/51`

Update a local copy of the PR: \
`$ git checkout pull/51` \
`$ git pull https://git.openjdk.org/leyden.git pull/51/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 51`

View PR using the GUI difftool: \
`$ git pr show -t 51`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/51.diff">https://git.openjdk.org/leyden/pull/51.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/51#issuecomment-2769728214)
</details>
