### PR TITLE
8354330: [leyden] Crash inside AdapterHandlerEntry::metaspace_pointers_do

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -457,6 +457,11 @@ bool ArchiveBuilder::gather_one_source_obj(MetaspaceClosure::Ref* ref, bool read
   }
 #endif
 
+  if (ref->msotype() == MetaspaceObj::MethodDataType) {
+    MethodData* md = (MethodData*)ref->obj();
+    md->clean_method_data(true);
+  }
+
   assert(p->read_only() == src_info.read_only(), "must be");
 
   if (created && src_info.should_copy()) {

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1771,7 +1771,6 @@ bool MethodData::profile_parameters_for_method(const methodHandle& m) {
 }
 
 void MethodData::metaspace_pointers_do(MetaspaceClosure* it) {
-  clean_method_data(true);
   log_trace(cds)("Iter(MethodData): %p for %p %s", this, _method, _method->name_and_sig_as_C_string());
   it->push(&_method);
   if (_parameters_type_data_di != no_parameters) {
@@ -1946,16 +1945,11 @@ void MethodData::clean_method_data(bool always_clean) {
 
   CleanExtraDataKlassClosure cl(always_clean);
 
-  if (SafepointSynchronize::is_at_safepoint() && 0) {
-    precond(CDSConfig::is_dumping_archive());
-    clean_extra_data(&cl);
-    verify_extra_data_clean(&cl);
-  } else {
-    // Lock to modify extra data, and prevent Safepoint from breaking the lock
-    MutexLocker ml(extra_data_lock(), Mutex::_no_safepoint_check_flag);
-    clean_extra_data(&cl);
-    verify_extra_data_clean(&cl);
-  }
+  // Lock to modify extra data, and prevent Safepoint from breaking the lock
+  MutexLocker ml(extra_data_lock(), Mutex::_no_safepoint_check_flag);
+
+  clean_extra_data(&cl);
+  verify_extra_data_clean(&cl);
 }
 
 // This is called during redefinition to clean all "old" redefined

--- a/src/hotspot/share/oops/trainingData.cpp
+++ b/src/hotspot/share/oops/trainingData.cpp
@@ -205,6 +205,9 @@ CompileTrainingData* CompileTrainingData::make(CompileTask* task) {
   int compile_id = task->compile_id();
   Thread* thread = Thread::current();
   methodHandle m(thread, task->method());
+  if (m->method_holder() == nullptr) {
+    return nullptr; // do not record (dynamically generated method)
+  }
   MethodTrainingData* mtd = MethodTrainingData::make(m);
   if (mtd == nullptr) {
     return nullptr; // allocation failure


### PR DESCRIPTION
The crash happens when a `SpeculativeTrapData` points to a `Method` that belongs to an excluded class. In this particular case, the `Method` is `java.lang.invoke.LambdaForm$MH/0x800000034.invoke(java.lang.Object, java.lang.Object)` and the holder class (a hidden class) is excluded from the binary AOT config file.

Te fix is to call `MethodData::clean_method_data(true)` on all archived `MethodData`. I had to adjust the rank of `MethodData::extra_data_lock()` to be lower than `DumpTimeTable_lock`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8354330](https://bugs.openjdk.org/browse/JDK-8354330): [leyden] Crash inside AdapterHandlerEntry::metaspace_pointers_do (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/56/head:pull/56` \
`$ git checkout pull/56`

Update a local copy of the PR: \
`$ git checkout pull/56` \
`$ git pull https://git.openjdk.org/leyden.git pull/56/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 56`

View PR using the GUI difftool: \
`$ git pr show -t 56`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/56.diff">https://git.openjdk.org/leyden/pull/56.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/56#issuecomment-2798949777)
</details>
