### PR TITLE
8355296: [leyden] Some methods are stuck at level=0 with -XX:-TieredCompilation

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -1139,7 +1139,6 @@ bool CompilationPolicy::should_create_mdo(const methodHandle& method, CompLevel 
     if (mtd != nullptr && mtd->saw_level(CompLevel_full_optimization)) {
       return true;
     }
-    return false;
   }
 
   if (is_old(method)) {
@@ -1365,32 +1364,29 @@ CompLevel CompilationPolicy::trained_transition(const methodHandle& method, Comp
 template<typename Predicate>
 CompLevel CompilationPolicy::common(const methodHandle& method, CompLevel cur_level, JavaThread* THREAD, bool disable_feedback) {
   CompLevel next_level = cur_level;
-  int i = method->invocation_count();
-  int b = method->backedge_count();
 
   if (force_comp_at_level_simple(method)) {
     next_level = CompLevel_simple;
-  } else {
-    if (MethodTrainingData::have_data()) {
-      MethodTrainingData* mtd = MethodTrainingData::find_fast(method);
-      if (mtd == nullptr) {
-        // We haven't see compilations of this method in training. It's either very cold or the behavior changed.
-        // Feed it to the standard TF with no profiling delay.
-        next_level = standard_transition<Predicate>(method, cur_level, false /*delay_profiling*/, disable_feedback);
-      } else {
-        next_level = trained_transition(method, cur_level, mtd, THREAD);
-        if (cur_level == next_level) {
-          // trained_transtion() is going to return the same level if no startup/warmup optimizations apply.
-          // In order to catch possible pathologies due to behavior change we feed the event to the regular
-          // TF but with profiling delay.
-          next_level = standard_transition<Predicate>(method, cur_level, true /*delay_profiling*/, disable_feedback);
-        }
-      }
-    } else if (is_trivial(method) || method->is_native()) {
-      next_level = CompilationModeFlag::disable_intermediate() ? CompLevel_full_optimization : CompLevel_simple;
-    } else {
+  } else if (is_trivial(method) || method->is_native()) {
+    // We do not care if there is profiling data for these methods, throw them to compiler.
+    next_level = CompilationModeFlag::disable_intermediate() ? CompLevel_full_optimization : CompLevel_simple;
+  } else if (MethodTrainingData::have_data()) {
+    MethodTrainingData* mtd = MethodTrainingData::find_fast(method);
+    if (mtd == nullptr) {
+      // We haven't see compilations of this method in training. It's either very cold or the behavior changed.
+      // Feed it to the standard TF with no profiling delay.
       next_level = standard_transition<Predicate>(method, cur_level, false /*delay_profiling*/, disable_feedback);
+    } else {
+      next_level = trained_transition(method, cur_level, mtd, THREAD);
+      if (cur_level == next_level) {
+        // trained_transtion() is going to return the same level if no startup/warmup optimizations apply.
+        // In order to catch possible pathologies due to behavior change we feed the event to the regular
+        // TF but with profiling delay.
+        next_level = standard_transition<Predicate>(method, cur_level, true /*delay_profiling*/, disable_feedback);
+      }
     }
+  } else {
+    next_level = standard_transition<Predicate>(method, cur_level, false /*delay_profiling*/, disable_feedback);
   }
   return (next_level != cur_level) ? limit_level(next_level) : next_level;
 }


### PR DESCRIPTION
Discovered this originally when testing Persistent Profiles PR in Leyden. In short, the transition from level=0 would not go to level=4 ever for some methods, if we disable intermediate levels. I believe this is one the causes for at least some performance artifacts I seen in Leyden testing last week. 

There are two bugs:
 1. In `CompilationPolicy::common`: Trivial/native method shortcut was lost, so trivial methods enter through the normal profiled policy. Maybe there was a good reason to lose it? Not clear...
 2. In `CompilationPolicy::should_create_mdo`: When training data is used we _only_ create MDOs for methods that are referenced in TD. This has a major knock-on effect on _normal_ JIT compilations that want to see MDO invocation/backedge counters. Instead, MDO is missing, so interpreter only increments MCS counters, and then compilation policy misses the transitions.

(1) is really subsumed by (2), so we can really only do (2).

See reproducers and logs in the issue. More performance data in comments.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8355296](https://bugs.openjdk.org/browse/JDK-8355296): [leyden] Some methods are stuck at level=0 with -XX:-TieredCompilation (**Enhancement** - P4)


### Reviewers
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/leyden.git pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/57.diff">https://git.openjdk.org/leyden/pull/57.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/57#issuecomment-2822124060)
</details>
