### PR TITLE
8355334: [leyden] Missing type profile info in archived training data

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -459,7 +459,7 @@ bool ArchiveBuilder::gather_one_source_obj(MetaspaceClosure::Ref* ref, bool read
 
   if (ref->msotype() == MetaspaceObj::MethodDataType) {
     MethodData* md = (MethodData*)ref->obj();
-    md->clean_method_data(true);
+    md->clean_method_data(false /* always_clean */);
   }
 
   assert(p->read_only() == src_info.read_only(), "must be");

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -326,7 +326,7 @@ static bool is_excluded(Klass* k) {
   if (SafepointSynchronize::is_at_safepoint() &&
       CDSConfig::is_dumping_archive() &&
       CDSConfig::current_thread_is_vm_or_dumper()) {
-    if (k->is_instance_klass() && InstanceKlass::cast(k)->is_loaded() == false) {
+    if (k->is_instance_klass() && !InstanceKlass::cast(k)->is_loaded()) {
       log_debug(cds)("Purged %s from MDO: unloaded class", k->name()->as_C_string());
       return true;
     } else if (CDSConfig::is_dumping_dynamic_archive() && k->is_shared()) {

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -321,6 +321,19 @@ void VirtualCallTypeData::post_initialize(BytecodeStream* stream, MethodData* md
   }
 }
 
+static bool is_excluded(Klass* k) {
+#if INCLUDE_CDS
+  if (SafepointSynchronize::is_at_safepoint() && CDSConfig::is_dumping_archive()) {
+    if (k->is_instance_klass() && InstanceKlass::cast(k)->is_loaded() == false) {
+      return true;
+    } else {
+      return SystemDictionaryShared::should_be_excluded(k);
+    }
+  }
+#endif
+  return false;
+}
+
 void TypeStackSlotEntries::clean_weak_klass_links(bool always_clean) {
   for (int i = 0; i < _number_of_entries; i++) {
     intptr_t p = type(i);
@@ -329,7 +342,7 @@ void TypeStackSlotEntries::clean_weak_klass_links(bool always_clean) {
       if (!always_clean && k->is_instance_klass() && InstanceKlass::cast(k)->is_not_initialized()) {
         continue; // skip not-yet-initialized classes // TODO: maybe clear the slot instead?
       }
-      if (always_clean || !k->is_loader_alive()) {
+      if (always_clean || !k->is_loader_alive() || is_excluded(k)) {
         set_type(i, with_status((Klass*)nullptr, p));
       }
     }
@@ -350,7 +363,7 @@ void ReturnTypeEntry::clean_weak_klass_links(bool always_clean) {
     if (!always_clean && k->is_instance_klass() && InstanceKlass::cast(k)->is_not_initialized()) {
       return; // skip not-yet-initialized classes // TODO: maybe clear the slot instead?
     }
-    if (always_clean || !k->is_loader_alive()) {
+    if (always_clean || !k->is_loader_alive() || is_excluded(k)) {
       set_type(with_status((Klass*)nullptr, p));
     }
   }
@@ -440,7 +453,7 @@ void ReceiverTypeData::clean_weak_klass_links(bool always_clean) {
       if (!always_clean && p->is_instance_klass() && InstanceKlass::cast(p)->is_not_initialized()) {
         continue; // skip not-yet-initialized classes // TODO: maybe clear the slot instead?
       }
-      if (always_clean || !p->is_loader_alive()) {
+      if (always_clean || !p->is_loader_alive() || is_excluded(p)) {
         clear_row(row);
       }
     }
@@ -1866,14 +1879,7 @@ void MethodData::clean_extra_data(CleanExtraDataClosure* cl) {
       SpeculativeTrapData* data = new SpeculativeTrapData(dp);
       Method* m = data->method();
       assert(m != nullptr, "should have a method");
-      bool exclude = false;
-      if (SafepointSynchronize::is_at_safepoint() && CDSConfig::is_dumping_archive()) {
-#if INCLUDE_CDS
-        InstanceKlass* holder = m->method_holder();
-        exclude = (holder == nullptr || !holder->is_loaded() || SystemDictionaryShared::check_for_exclusion(holder, nullptr));
-#endif
-      }
-      if (exclude || !cl->is_live(m)) {
+      if (is_excluded(m->method_holder()) || !cl->is_live(m)) {
         // "shift" accumulates the number of cells for dead
         // SpeculativeTrapData entries that have been seen so
         // far. Following entries must be shifted left by that many

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -326,6 +326,8 @@ static bool is_excluded(Klass* k) {
   if (SafepointSynchronize::is_at_safepoint() && CDSConfig::is_dumping_archive()) {
     if (k->is_instance_klass() && InstanceKlass::cast(k)->is_loaded() == false) {
       return true;
+    } else if (CDSConfig::is_dumping_dynamic_archive() && k->is_shared()) {
+      return false;
     } else {
       return SystemDictionaryShared::should_be_excluded(k);
     }


### PR DESCRIPTION
There's a regression from #56 which causes pruning of all type profiles from archived training data. It severely affects quality of compiled code.

Proposed fix removes only excluded classes.

Testing: hs-tier1 - hs-tier2, JavacBench

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8355334](https://bugs.openjdk.org/browse/JDK-8355334): [leyden] Missing type profile info in archived training data (**Bug** - P3)


### Reviewers
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - Committer)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer) ⚠️ Review applies to [06969e94](https://git.openjdk.org/leyden/pull/59/files/06969e94eca40d03ad7a35524b616c379bd9f0d8)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - Committer) ⚠️ Review applies to [06969e94](https://git.openjdk.org/leyden/pull/59/files/06969e94eca40d03ad7a35524b616c379bd9f0d8)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.org/leyden.git pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/59.diff">https://git.openjdk.org/leyden/pull/59.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/59#issuecomment-2822934810)
</details>
