### PR TITLE
8355352: [premain] rename AOT Code classes and logging tags

### DIFF
--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -128,7 +128,7 @@ ifneq ($(call check-jvm-feature, cds), true)
       classLoaderDataShared.cpp \
       classLoaderExt.cpp \
       precompiler.cpp \
-      SCCache.cpp \
+      aotCodeCache.cpp \
       systemDictionaryShared.cpp \
       trainingData.cpp
   JVM_EXCLUDE_PATTERNS += cds/

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -34,7 +34,7 @@
 #include "ci/ciArrayKlass.hpp"
 #include "ci/ciInstance.hpp"
 #include "ci/ciUtilities.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/gc_globals.hpp"
@@ -530,8 +530,8 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
 
     case T_LONG: {
       assert(patch_code == lir_patch_none, "no patching handled here");
-      if (SCCache::is_on_for_write()) {
-        // SCA needs relocation info for card table base
+      if (AOTCodeCache::is_on_for_write()) {
+        // AOT code needs relocation info for card table base
         address b = c->as_pointer();
         if (is_card_table_address(b)) {
           __ lea(dest->as_register_lo(), ExternalAddress(b));

--- a/src/hotspot/cpu/aarch64/gc/g1/g1BarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/g1/g1BarrierSetAssembler_aarch64.cpp
@@ -24,7 +24,7 @@
 
 #include "asm/macroAssembler.inline.hpp"
 #if INCLUDE_CDS
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #endif
 #include "gc/g1/g1BarrierSet.hpp"
 #include "gc/g1/g1BarrierSetAssembler.hpp"
@@ -214,7 +214,7 @@ static void generate_post_barrier_fast_path(MacroAssembler* masm,
   // AOT code needs to load the barrier grain shift from the aot
   // runtime constants area in the code cache otherwise we can compile
   // it as an immediate operand
-  if (SCCache::is_on_for_write()) {
+  if (AOTCodeCache::is_on_for_write()) {
     address grain_shift_address = (address)AOTRuntimeConstants::grain_shift_address();
     __ eor(tmp1, store_addr, new_val);
     __ lea(tmp2, ExternalAddress(grain_shift_address));
@@ -239,7 +239,7 @@ static void generate_post_barrier_fast_path(MacroAssembler* masm,
   // AOT code needs to load the barrier card shift from the aot
   // runtime constants area in the code cache otherwise we can compile
   // it as an immediate operand
-  if (SCCache::is_on_for_write()) {
+  if (AOTCodeCache::is_on_for_write()) {
     address card_shift_address = (address)AOTRuntimeConstants::card_shift_address();
     __ lea(tmp2, ExternalAddress(card_shift_address));
     __ ldrb(tmp2, tmp2);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -27,8 +27,8 @@
 #define CPU_AARCH64_MACROASSEMBLER_AARCH64_HPP
 
 #include "asm/assembler.inline.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/vmreg.hpp"
-#include "code/SCCache.hpp"
 #include "metaprogramming/enableIf.hpp"
 #include "oops/compressedOops.hpp"
 #include "oops/compressedKlass.hpp"
@@ -1316,7 +1316,7 @@ public:
 
   // Check if branches to the non nmethod section require a far jump
   static bool codestub_branch_needs_far_jump() {
-    if (SCCache::is_on_for_write()) {
+    if (AOTCodeCache::is_on_for_write()) {
       // To calculate far_codestub_branch_size correctly.
       return true;
     }

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -27,7 +27,7 @@
 #include "asm/macroAssembler.inline.hpp"
 #include "asm/register.hpp"
 #include "atomic_aarch64.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/oopMap.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
@@ -5888,7 +5888,7 @@ class StubGenerator: public StubCodeGenerator {
 
     address start = __ pc();
  
-    if (SCCache::load_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start)) {
+    if (AOTCodeCache::load_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start)) {
       return start;
     }
     const Register x     = r0;
@@ -5912,7 +5912,7 @@ class StubGenerator: public StubCodeGenerator {
     __ leave(); // required for proper stackwalking of RuntimeStub frame
     __ ret(lr);
 
-    SCCache::store_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start);
+    AOTCodeCache::store_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start);
     return start;
   }
 
@@ -5925,7 +5925,7 @@ class StubGenerator: public StubCodeGenerator {
     StubCodeMark mark(this, stub_id);
     address start = __ pc();
 
-    if (SCCache::load_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start)) {
+    if (AOTCodeCache::load_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start)) {
       return start;
     }
     const Register x     = r0;
@@ -5954,7 +5954,7 @@ class StubGenerator: public StubCodeGenerator {
     __ leave();
     __ ret(lr);
 
-    SCCache::store_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start);
+    AOTCodeCache::store_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start);
     return start;
   }
 
@@ -5965,7 +5965,7 @@ class StubGenerator: public StubCodeGenerator {
 
     address start = __ pc();
 
-    if (SCCache::load_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start)) {
+    if (AOTCodeCache::load_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start)) {
       return start;
     }
     const Register out     = r0;
@@ -5980,7 +5980,7 @@ class StubGenerator: public StubCodeGenerator {
     __ leave();
     __ ret(lr);
 
-    SCCache::store_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start);
+    AOTCodeCache::store_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start);
     return start;
   }
 

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -33,7 +33,7 @@
 #include "ci/ciArrayKlass.hpp"
 #include "ci/ciInstance.hpp"
 #include "ci/ciUtilities.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/oopMap.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/gc_globals.hpp"
@@ -533,8 +533,8 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
 
     case T_LONG: {
       assert(patch_code == lir_patch_none, "no patching handled here");
-      if (SCCache::is_on_for_write()) {
-        // SCA needs relocation info for card table base
+      if (AOTCodeCache::is_on_for_write()) {
+        // AOTCodeCache needs relocation info for card table base
         address b = c->as_pointer();
         if (is_card_table_address(b)) {
           __ lea(dest->as_register_lo(), ExternalAddress(b));

--- a/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
@@ -24,7 +24,7 @@
 
 #include "asm/macroAssembler.inline.hpp"
 #if INCLUDE_CDS
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #endif
 #include "gc/g1/g1BarrierSet.hpp"
 #include "gc/g1/g1BarrierSetAssembler.hpp"
@@ -307,7 +307,7 @@ static void generate_post_barrier_fast_path(MacroAssembler* masm,
   // runtime constants area in the code cache otherwise we can compile
   // it as an immediate operand
 
-  if (SCCache::is_on_for_write()) {
+  if (AOTCodeCache::is_on_for_write()) {
     address grain_shift_addr = AOTRuntimeConstants::grain_shift_address();
     Register save = pick_different_reg(rcx, tmp, new_val, store_addr);
     __ push(save);
@@ -341,7 +341,7 @@ static void generate_post_barrier_fast_path(MacroAssembler* masm,
   // AOT code needs to load the barrier card shift from the aot
   // runtime constants area in the code cache otherwise we can compile
   // it as an immediate operand
-  if (SCCache::is_on_for_write()) {
+  if (AOTCodeCache::is_on_for_write()) {
     address card_shift_addr = AOTRuntimeConstants::card_shift_address();
     Register save = pick_different_reg(rcx, tmp);
     __ push(save);
@@ -360,8 +360,8 @@ static void generate_post_barrier_fast_path(MacroAssembler* masm,
   }
   // Do not use ExternalAddress to load 'byte_map_base', since 'byte_map_base' is NOT
   // a valid address and therefore is not properly handled by the relocation code.
-  if (SCCache::is_on_for_write()) {
-    // SCA needs relocation info for this address
+  if (AOTCodeCache::is_on_for_write()) {
+    // AOT code needs relocation info for this address
     __ lea(tmp2, ExternalAddress((address)ct->card_table()->byte_map_base()));   // tmp2 := card table base address
   } else {
     __ movptr(tmp2, (intptr_t)ct->card_table()->byte_map_base());   // tmp2 := card table base address
@@ -716,8 +716,8 @@ void G1BarrierSetAssembler::generate_c1_post_barrier_runtime_stub(StubAssembler*
   __ shrptr(card_addr, CardTable::card_shift());
   // Do not use ExternalAddress to load 'byte_map_base', since 'byte_map_base' is NOT
   // a valid address and therefore is not properly handled by the relocation code.
-  if (SCCache::is_on()) {
-    // SCA needs relocation info for this address
+  if (AOTCodeCache::is_on()) {
+    // AOT code needs relocation info for this address
     __ lea(cardtable, ExternalAddress((address)ct->card_table()->byte_map_base()));
   } else {
     __ movptr(cardtable, (intptr_t)ct->card_table()->byte_map_base());

--- a/src/hotspot/cpu/x86/gc/shared/cardTableBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/cardTableBarrierSetAssembler_x86.cpp
@@ -23,7 +23,7 @@
  */
 
 #include "asm/macroAssembler.inline.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
@@ -65,8 +65,8 @@ void CardTableBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembl
   __ shrptr(end, CardTable::card_shift());
   __ subptr(end, addr); // end --> cards count
 
-  if (SCCache::is_on_for_write()) {
-    // SCA needs relocation info for this address
+  if (AOTCodeCache::is_on_for_write()) {
+    // AOT code needs relocation info for this address
     __ lea(tmp, ExternalAddress((address)byte_map_base));
   } else {
     __ mov64(tmp, byte_map_base);
@@ -109,8 +109,8 @@ void CardTableBarrierSetAssembler::store_check(MacroAssembler* masm, Register ob
   // never need to be relocated. On 64bit however the value may be too
   // large for a 32bit displacement.
   intptr_t byte_map_base = (intptr_t)ct->byte_map_base();
-  if (SCCache::is_on_for_write()) {
-    // SCA needs relocation info for this address
+  if (AOTCodeCache::is_on_for_write()) {
+    // AOT code needs relocation info for this address
     ExternalAddress cardtable((address)byte_map_base);
     Address index(noreg, obj, Address::times_1);
     card_addr = __ as_Address(ArrayAddress(cardtable, index), rscratch1);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -24,7 +24,7 @@
 
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "compiler/compiler_globals.hpp"
 #include "compiler/disassembler.hpp"
@@ -760,7 +760,7 @@ void MacroAssembler::stop(const char* msg) {
   andq(rsp, -16); // align stack as required by ABI
   call(RuntimeAddress(CAST_FROM_FN_PTR(address, MacroAssembler::debug64)));
   hlt();
-  SCCache::add_C_string(msg);
+  AOTCodeCache::add_C_string(msg);
 }
 
 void MacroAssembler::warn(const char* msg) {
@@ -10896,8 +10896,8 @@ void MacroAssembler::restore_legacy_gprs() {
 void MacroAssembler::load_aotrc_address(Register reg, address a) {
 #if INCLUDE_CDS
   assert(AOTRuntimeConstants::contains(a), "address out of range for data area");
-  if (SCCache::is_on_for_write()) {
-    // all aotrc field addresses should be registered in the SCC address table
+  if (AOTCodeCache::is_on_for_write()) {
+    // all aotrc field addresses should be registered in the AOTCodeCache address table
     lea(reg, ExternalAddress(a));
   } else {
     mov64(reg, (uint64_t)a);

--- a/src/hotspot/cpu/x86/runtime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/runtime_x86_64.cpp
@@ -25,7 +25,7 @@
 #ifdef COMPILER2
 #include "asm/macroAssembler.hpp"
 #include "asm/macroAssembler.inline.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/vmreg.hpp"
 #include "interpreter/interpreter.hpp"
 #include "opto/runtime.hpp"
@@ -270,7 +270,7 @@ ExceptionBlob* OptoRuntime::generate_exception_blob() {
   CodeBuffer buffer(name, 2048, 1024);
 
   int pc_offset = 0;
-  if (SCCache::load_exception_blob(&buffer, &pc_offset)) {
+  if (AOTCodeCache::load_exception_blob(&buffer, &pc_offset)) {
     OopMapSet* oop_maps = new OopMapSet();
     oop_maps->add_gc_map(pc_offset, new OopMap(SimpleRuntimeFrame::framesize, 0));
 
@@ -367,7 +367,7 @@ ExceptionBlob* OptoRuntime::generate_exception_blob() {
   // Make sure all code is generated
   masm->flush();
 
-  SCCache::store_exception_blob(&buffer, pc_offset);
+  AOTCodeCache::store_exception_blob(&buffer, pc_offset);
   // Set exception blob
   return ExceptionBlob::create(&buffer, oop_maps, SimpleRuntimeFrame::framesize >> 1);
 }

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -25,7 +25,7 @@
 #include "asm/macroAssembler.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/vmIntrinsics.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/oopMap.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
@@ -3160,7 +3160,7 @@ address StubGenerator::generate_multiplyToLen() {
   StubCodeMark mark(this, stub_id);
   address start = __ pc();
 
-  if (SCCache::load_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start)) {
+  if (AOTCodeCache::load_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start)) {
     return start;
   }
 
@@ -3200,7 +3200,7 @@ address StubGenerator::generate_multiplyToLen() {
   __ leave(); // required for proper stackwalking of RuntimeStub frame
   __ ret(0);
 
-  SCCache::store_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start);
+  AOTCodeCache::store_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start);
   return start;
 }
 
@@ -3274,7 +3274,7 @@ address StubGenerator::generate_squareToLen() {
   StubCodeMark mark(this, stub_id);
   address start = __ pc();
 
-  if (SCCache::load_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start)) {
+  if (AOTCodeCache::load_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start)) {
     return start;
   }
 
@@ -3305,7 +3305,7 @@ address StubGenerator::generate_squareToLen() {
   __ leave(); // required for proper stackwalking of RuntimeStub frame
   __ ret(0);
 
-  SCCache::store_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start);
+  AOTCodeCache::store_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start);
   return start;
 }
 
@@ -3405,7 +3405,7 @@ address StubGenerator::generate_mulAdd() {
   StubCodeMark mark(this, stub_id);
   address start = __ pc();
 
-  if (SCCache::load_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start)) {
+  if (AOTCodeCache::load_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start)) {
     return start;
   }
 
@@ -3442,7 +3442,7 @@ address StubGenerator::generate_mulAdd() {
   __ leave(); // required for proper stackwalking of RuntimeStub frame
   __ ret(0);
 
-  SCCache::store_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start);
+  AOTCodeCache::store_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start);
   return start;
 }
 

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -1850,7 +1850,7 @@ encode %{
 
   enc_class Java_To_Runtime(method meth) %{
     // No relocation needed
-    if (SCCache::is_on_for_write()) {
+    if (AOTCodeCache::is_on_for_write()) {
       // Created runtime_call_type relocation when caching code
       __ lea(r10, RuntimeAddress((address)$meth$$method));
     } else {

--- a/src/hotspot/share/adlc/main.cpp
+++ b/src/hotspot/share/adlc/main.cpp
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
   AD.addInclude(AD._CPP_file, "code/compiledIC.hpp");
   AD.addInclude(AD._CPP_file, "code/nativeInst.hpp");
   AD.addInclude(AD._CPP_file, "code/vmreg.inline.hpp");
-  AD.addInclude(AD._CPP_file, "code/SCCache.hpp");
+  AD.addInclude(AD._CPP_file, "code/aotCodeCache.hpp");
   AD.addInclude(AD._CPP_file, "gc/shared/collectedHeap.inline.hpp");
   AD.addInclude(AD._CPP_file, "oops/compressedOops.hpp");
   AD.addInclude(AD._CPP_file, "oops/markWord.hpp");
@@ -258,7 +258,7 @@ int main(int argc, char *argv[])
   AD.addInclude(AD._CPP_PEEPHOLE_file, "adfiles", get_basename(AD._HPP_file._name));
   AD.addInclude(AD._CPP_PIPELINE_file, "adfiles", get_basename(AD._HPP_file._name));
   AD.addInclude(AD._DFA_file, "adfiles", get_basename(AD._HPP_file._name));
-  AD.addInclude(AD._DFA_file, "code/SCCache.hpp");
+  AD.addInclude(AD._DFA_file, "code/aotCodeCache.hpp");
   AD.addInclude(AD._DFA_file, "oops/compressedOops.hpp");
   AD.addInclude(AD._DFA_file, "opto/cfgnode.hpp");  // Use PROB_MAX in predicate.
   AD.addInclude(AD._DFA_file, "opto/intrinsicnode.hpp");

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -90,7 +90,7 @@ public:
 // They are filled concurrently, and concatenated at the end.
 class CodeSection {
   friend class CodeBuffer;
-  friend class SCCReader;
+  friend class AOTCodeReader;
  public:
   typedef int csize_t;  // code size type; would be size_t except for history
 
@@ -516,7 +516,7 @@ typedef GrowableArray<SharedStubToInterpRequest> SharedStubToInterpRequests;
 class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
   friend class CodeSection;
   friend class StubCodeGenerator;
-  friend class SCCReader;
+  friend class AOTCodeReader;
 
  private:
   // CodeBuffers must be allocated on the stack except for a single

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -33,7 +33,7 @@
 #include "ci/ciInstance.hpp"
 #include "ci/ciObjArray.hpp"
 #include "ci/ciUtilities.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/compilerOracle.hpp"
 #include "gc/shared/barrierSet.hpp"
@@ -3193,13 +3193,13 @@ void LIRGenerator::increment_event_counter_impl(CodeEmitInfo* info,
       bailout("method counters allocation failed");
       return;
     }
-if (SCCache::is_on()) {
-    counter_holder = new_register(T_METADATA);
-    __ metadata2reg(counters_adr, counter_holder);
-} else {
-    counter_holder = new_pointer_register();
-    __ move(LIR_OprFact::intptrConst(counters_adr), counter_holder);
-}
+    if (AOTCodeCache::is_on()) {
+      counter_holder = new_register(T_METADATA);
+      __ metadata2reg(counters_adr, counter_holder);
+    } else {
+      counter_holder = new_pointer_register();
+      __ move(LIR_OprFact::intptrConst(counters_adr), counter_holder);
+    }
     offset = in_bytes(backedge ? MethodCounters::backedge_counter_offset() :
                                  MethodCounters::invocation_counter_offset());
   } else if (level == CompLevel_full_profile) {

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -43,7 +43,7 @@
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionaryShared.hpp"
 #include "classfile/vmClasses.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "interpreter/abstractInterpreter.hpp"
 #include "jvm.h"
 #include "logging/log.hpp"
@@ -330,8 +330,8 @@ void ArchiveBuilder::sort_klasses() {
 }
 
 address ArchiveBuilder::reserve_buffer() {
-  // SCCache::max_aot_code_size() accounts for cached code region.
-  size_t buffer_size = LP64_ONLY(CompressedClassSpaceSize) NOT_LP64(256 * M) + SCCache::max_aot_code_size();
+  // AOTCodeCache::max_aot_code_size() accounts for cached code region.
+  size_t buffer_size = LP64_ONLY(CompressedClassSpaceSize) NOT_LP64(256 * M) + AOTCodeCache::max_aot_code_size();
   ReservedSpace rs = MemoryReserver::reserve(buffer_size,
                                              MetaspaceShared::core_region_alignment(),
                                              os::vm_page_size());

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -32,7 +32,6 @@
 #include "classfile/classLoaderDataShared.hpp"
 #include "classfile/moduleEntry.hpp"
 #include "classfile/systemDictionaryShared.hpp"
-#include "code/SCCache.hpp"
 #include "include/jvm_io.h"
 #include "logging/log.hpp"
 #include "prims/jvmtiExport.hpp"

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -60,8 +60,8 @@
 #include "classfile/systemDictionaryShared.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/codeCache.hpp"
-#include "code/SCCache.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/precompiler.hpp"
 #include "gc/shared/gcVMOperations.hpp"
@@ -1098,8 +1098,8 @@ void MetaspaceShared::preload_and_dump_impl(StaticArchiveBuilder& builder, TRAPS
       {
         builder.start_cc_region();
         Precompiler::compile_cached_code(&builder, CHECK);
-        // Write the contents to cached code region and close SCCache before packing the region
-        SCCache::close();
+        // Write the contents to cached code region and close AOTCodeCache before packing the region
+        AOTCodeCache::close();
         builder.end_cc_region();
       }
       CDSConfig::disable_dumping_cached_code();
@@ -2100,7 +2100,7 @@ void MetaspaceShared::initialize_shared_spaces() {
   static_mapinfo->patch_heap_embedded_pointers();
   ArchiveHeapLoader::finish_initialization();
   Universe::load_archived_object_instances();
-  SCCache::initialize();
+  AOTCodeCache::initialize();
 
   // Close the mapinfo file
   static_mapinfo->close();
@@ -2155,7 +2155,7 @@ void MetaspaceShared::initialize_shared_spaces() {
 
     if (LoadCachedCode) {
       tty->print_cr("\n\nCached Code");
-      SCCache::print_on(tty);
+      AOTCodeCache::print_on(tty);
     }
 
     // collect shared symbols and strings

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -39,8 +39,8 @@
 
 class CompileTask;
 class OopMapSet;
-class SCCEntry;
-class SCCReader;
+class AOTCodeEntry;
+class AOTCodeReader;
 
 // ciEnv
 //
@@ -296,8 +296,8 @@ private:
 
   // Helper rountimes to factor out common code used by routines that register a method
   // i.e. register_aot_method() and register_method()
-  bool is_compilation_valid(JavaThread* thread, ciMethod* target, bool preload, bool install_code, CodeBuffer* code_buffer, SCCEntry* scc_entry);
-  void make_code_usable(JavaThread* thread, ciMethod* target, bool preload, int entry_bci, SCCEntry* scc_entry, nmethod* nm);
+  bool is_compilation_valid(JavaThread* thread, ciMethod* target, bool preload, bool install_code, CodeBuffer* code_buffer, AOTCodeEntry* aot_code_entry);
+  void make_code_usable(JavaThread* thread, ciMethod* target, bool preload, int entry_bci, AOTCodeEntry* aot_code_entry, nmethod* nm);
 
 public:
   enum {
@@ -387,7 +387,7 @@ public:
                            AsmRemarks& asm_remarks,
                            DbgStrings& dbg_strings,
 #endif /* PRODUCT */
-                           SCCReader* scc_reader);
+                           AOTCodeReader* aot_code_reader);
 
   // Register the result of a compilation.
   void register_method(ciMethod*                 target,
@@ -408,7 +408,7 @@ public:
                        bool                      has_scoped_access,
                        int                       immediate_oops_patched,
                        bool                      install_code,
-                       SCCEntry*                 entry = nullptr);
+                       AOTCodeEntry*             entry = nullptr);
 
   // Access to certain well known ciObjects.
 #define VM_CLASS_FUNC(name, ignore_s) \
@@ -499,11 +499,11 @@ public:
   void metadata_do(MetadataClosure* f) { _factory->metadata_do(f); }
 
 private:
-  SCCEntry* _scc_clinit_barriers_entry;
+  AOTCodeEntry* _aot_clinit_barriers_entry;
 
 public:
-  void  set_scc_clinit_barriers_entry(SCCEntry* entry) { _scc_clinit_barriers_entry = entry; }
-  SCCEntry* scc_clinit_barriers_entry()          const { return _scc_clinit_barriers_entry; }
+  void  set_aot_clinit_barriers_entry(AOTCodeEntry* entry) { _aot_clinit_barriers_entry = entry; }
+  AOTCodeEntry* aot_clinit_barriers_entry()          const { return _aot_clinit_barriers_entry; }
 
   // Replay support
 private:

--- a/src/hotspot/share/ci/ciField.cpp
+++ b/src/hotspot/share/ci/ciField.cpp
@@ -28,7 +28,7 @@
 #include "ci/ciUtilities.inline.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/vmClasses.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "interpreter/linkResolver.hpp"
 #include "oops/klass.inline.hpp"
@@ -315,7 +315,7 @@ ciConstant ciField::constant_value() {
   if (FoldStableValues && is_stable() && _constant_value.is_null_or_zero()) {
     return ciConstant();
   }
-  if (!SCCache::allow_const_field(_constant_value)) {
+  if (!AOTCodeCache::allow_const_field(_constant_value)) {
     return ciConstant();
   }
   return _constant_value;
@@ -331,7 +331,7 @@ ciConstant ciField::constant_value_of(ciObject* object) {
   if (FoldStableValues && is_stable() && field_value.is_null_or_zero()) {
     return ciConstant();
   }
-  if (!SCCache::allow_const_field(field_value)) {
+  if (!AOTCodeCache::allow_const_field(field_value)) {
     return ciConstant();
   }
   return field_value;

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1233,7 +1233,7 @@ int ciMethod::inline_instructions_size() {
   if (_inline_instructions_size == -1) {
     GUARDED_VM_ENTRY(
       nmethod* code = get_Method()->code();
-      if (code != nullptr && !code->is_scc() && (code->comp_level() == CompLevel_full_optimization)) {
+      if (code != nullptr && !code->is_aot() && (code->comp_level() == CompLevel_full_optimization)) {
         int isize = code->insts_end() - code->verified_entry_point() - code->skipped_instructions_size();
         _inline_instructions_size = isize > 0 ? isize : 0;
       } else {

--- a/src/hotspot/share/ci/ciObject.cpp
+++ b/src/hotspot/share/ci/ciObject.cpp
@@ -24,7 +24,7 @@
 
 #include "ci/ciObject.hpp"
 #include "ci/ciUtilities.inline.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/jniHandles.inline.hpp"
@@ -203,7 +203,7 @@ void ciObject::add_to_constant_value_cache(int off, ciConstant val) {
 // ------------------------------------------------------------------
 // ciObject::should_be_constant()
 bool ciObject::should_be_constant() {
-  if (ScavengeRootsInCode >= 2 && !(SCCache::is_on_for_write())) {
+  if (ScavengeRootsInCode >= 2 && !(AOTCodeCache::is_on_for_write())) {
     return true;  // force everybody to be a constant
   }
   if (is_null_object()) {
@@ -220,7 +220,7 @@ bool ciObject::should_be_constant() {
   }
   if ((klass()->is_subclass_of(env->MethodHandle_klass()) ||
        klass()->is_subclass_of(env->CallSite_klass())) &&
-      !(SCCache::is_on_for_write())) { // For now disable it when caching startup code.
+      !(AOTCodeCache::is_on_for_write())) { // For now disable it when caching startup code.
     // We want to treat these aggressively.
     return true;
   }

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -22,7 +22,6 @@
  *
  */
 
-#include "code/SCCache.hpp"
 #include "code/codeBlob.hpp"
 #include "code/codeCache.hpp"
 #include "code/relocInfo.hpp"
@@ -188,7 +187,7 @@ void CodeBlob::purge() {
     os::free(_mutable_data);
     _mutable_data = blob_end(); // Valid not null address
   }
-  if (_oop_maps != nullptr && !SCCache::is_address_in_aot_cache((address)_oop_maps)) {
+  if (_oop_maps != nullptr && !AOTCodeCache::is_address_in_aot_cache((address)_oop_maps)) {
     delete _oop_maps;
     _oop_maps = nullptr;
   }

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -26,7 +26,7 @@
 #define SHARE_CODE_CODEBLOB_HPP
 
 #include "asm/codeBuffer.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compilerDefinitions.hpp"
 #include "compiler/oopMap.hpp"
 #include "runtime/javaFrameAnchor.hpp"
@@ -157,7 +157,7 @@ protected:
 public:
 
   ~CodeBlob() {
-    assert(_oop_maps == nullptr || SCCache::is_address_in_aot_cache((address)_oop_maps), "Not flushed");
+    assert(_oop_maps == nullptr || AOTCodeCache::is_address_in_aot_cache((address)_oop_maps), "Not flushed");
   }
 
   // Returns the space needed for CodeBlob

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -31,7 +31,6 @@
 #include "code/dependencyContext.hpp"
 #include "code/nmethod.hpp"
 #include "code/pcDesc.hpp"
-#include "code/SCCache.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compilerDefinitions.inline.hpp"
@@ -1557,7 +1556,7 @@ void CodeCache::print_nmethod_statistics_on(outputStream* st) {
     }
     assert(!nm->preloaded() || nm->comp_level() == CompLevel_full_optimization, "");
 
-    int idx1 = nm->is_scc() ? 1 : 0;
+    int idx1 = nm->is_aot() ? 1 : 0;
     int idx2 = nm->comp_level() + (nm->preloaded() ? 1 : 0);
     int idx3 = (nm->is_in_use()      ? 0 :
                (nm->is_not_entrant() ? 1 :

--- a/src/hotspot/share/code/exceptionHandlerTable.hpp
+++ b/src/hotspot/share/code/exceptionHandlerTable.hpp
@@ -84,8 +84,8 @@ class HandlerTableEntry {
 
 class nmethod;
 class ExceptionHandlerTable {
-  friend class SCCache;
-  friend class SCCReader;
+  friend class AOTCodeCache;
+  friend class AOTCodeReader;
 
  private:
   HandlerTableEntry* _table;    // the table
@@ -147,8 +147,8 @@ class ExceptionHandlerTable {
 typedef  uint              implicit_null_entry;
 
 class ImplicitExceptionTable {
-  friend class SCCache;
-  friend class SCCReader;
+  friend class AOTCodeCache;
+  friend class AOTCodeReader;
  private:
   uint _size;
   uint _len;

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -45,8 +45,8 @@ class JvmtiThreadState;
 class MetadataClosure;
 class NativeCallWrapper;
 class OopIterateClosure;
-class SCCReader;
-class SCCEntry;
+class AOTCodeReader;
+class AOTCodeEntry;
 class ScopeDesc;
 class xmlStream;
 
@@ -263,7 +263,7 @@ class nmethod : public CodeBlob {
   CompLevel    _comp_level;            // compilation level (s1)
   CompilerType _compiler_type;         // which compiler made this nmethod (u1)
 
-  SCCEntry* _scc_entry;
+  AOTCodeEntry* _aot_code_entry;
 
   bool _used; // has this nmethod ever been invoked?
 
@@ -337,7 +337,7 @@ class nmethod : public CodeBlob {
           ImplicitExceptionTable* nul_chk_table,
           AbstractCompiler* compiler,
           CompLevel comp_level
-          , SCCEntry* scc_entry
+          , AOTCodeEntry* aot_code_entry
 #if INCLUDE_JVMCI
           , char* speculations = nullptr,
           int speculations_len = 0,
@@ -496,7 +496,7 @@ class nmethod : public CodeBlob {
                             AsmRemarks& asm_remarks,
                             DbgStrings& dbg_strings,
 #endif /* PRODUCT */
-                            SCCReader* scc_reader);
+                            AOTCodeReader* aot_code_reader);
 
 public:
   // create nmethod using archived nmethod from AOT code cache
@@ -515,7 +515,7 @@ public:
                               AsmRemarks& asm_remarks,
                               DbgStrings& dbg_strings,
 #endif /* PRODUCT */
-                              SCCReader* scc_reader);
+                              AOTCodeReader* aot_code_reader);
 
   // create nmethod with entry_bci
   static nmethod* new_nmethod(const methodHandle& method,
@@ -532,7 +532,7 @@ public:
                               ImplicitExceptionTable* nul_chk_table,
                               AbstractCompiler* compiler,
                               CompLevel comp_level
-                              , SCCEntry* scc_entry
+                              , AOTCodeEntry* aot_code_entry
 #if INCLUDE_JVMCI
                               , char* speculations = nullptr,
                               int speculations_len = 0,
@@ -960,9 +960,9 @@ public:
 
   int orig_pc_offset() { return _orig_pc_offset; }
 
-  SCCEntry* scc_entry() const { return _scc_entry; }
-  bool is_scc() const { return scc_entry() != nullptr; }
-  void set_scc_entry(SCCEntry* entry) { _scc_entry = entry; }
+  AOTCodeEntry* aot_code_entry() const { return _aot_code_entry; }
+  bool is_aot() const { return aot_code_entry() != nullptr; }
+  void set_aot_code_entry(AOTCodeEntry* entry) { _aot_code_entry = entry; }
 
   bool     used() const { return _used; }
   void set_used()       { _used = true; }

--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -23,11 +23,11 @@
  */
 
 #include "ci/ciUtilities.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/codeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "code/nmethod.hpp"
 #include "code/relocInfo.hpp"
-#include "code/SCCache.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "oops/compressedOops.inline.hpp"
@@ -476,7 +476,7 @@ void external_word_Relocation::pack_data_to(CodeSection* dest) {
   short* p = (short*) dest->locs_end();
   int index = ExternalsRecorder::find_index(_target);
   // Use 4 bytes to store index to be able patch it when
-  // updating relocations in SCCReader::read_relocations().
+  // updating relocations in AOTCodeReader::read_relocations().
   p = add_jint(p, index);
   dest->set_locs_end((relocInfo*) p);
 }
@@ -750,8 +750,8 @@ void external_word_Relocation::fix_relocation_after_move(const CodeBuffer* src, 
   // location, which means  there is nothing to fix here.  In either case, the
   // resulting target should be an "external" address.
 #ifdef ASSERT
-  if (SCCache::is_on()) {
-    // SCA needs relocation info for card table base which may point to CodeCache
+  if (AOTCodeCache::is_on()) {
+    // AOTCode needs relocation info for card table base which may point to CodeCache
     if (is_card_table_address(target())) {
       return;
     }

--- a/src/hotspot/share/code/relocInfo.hpp
+++ b/src/hotspot/share/code/relocInfo.hpp
@@ -672,7 +672,7 @@ class RelocIterator : public StackObj {
 
 class Relocation {
   friend class RelocIterator;
-  friend class SCCReader;
+  friend class AOTCodeReader;
 
  private:
   // When a relocation has been created by a RelocIterator,

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -23,7 +23,7 @@
  */
 
 #include "cds/aotLinkedClassBulkLoader.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/scopeDesc.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
@@ -306,7 +306,7 @@ bool CompilationPolicy::force_comp_at_level_simple(const methodHandle& method) {
     if (UseJVMCICompiler) {
       AbstractCompiler* comp = CompileBroker::compiler(CompLevel_full_optimization);
       if (comp != nullptr && comp->is_jvmci() && ((JVMCICompiler*) comp)->force_comp_at_level_simple(method)) {
-        return !SCCache::is_C3_on();
+        return !AOTCodeCache::is_C3_on();
       }
     }
 #endif
@@ -643,7 +643,7 @@ void CompilationPolicy::initialize() {
         int c1_count = MAX2(count - libjvmci_count, 1);
         set_c2_count(libjvmci_count);
         set_c1_count(c1_count);
-      } else if (SCCache::is_C3_on()) {
+      } else if (AOTCodeCache::is_C3_on()) {
         set_c1_count(MAX2(count / 3, 1));
         set_c2_count(MAX2(count - c1_count(), 1));
         set_c3_count(1);
@@ -659,7 +659,7 @@ void CompilationPolicy::initialize() {
       set_c2_count(count);
       count *= 2; // satisfy the assert below
     }
-    if (SCCache::is_code_load_thread_on()) {
+    if (AOTCodeCache::is_code_load_thread_on()) {
       set_sc_count((c1_only || c2_only) ? 1 : 2); // At minimum we need 2 threads to load C1 and C2 cached code in parallel
     }
     assert(count == c1_count() + c2_count(), "inconsistent compiler thread count");
@@ -804,8 +804,8 @@ CompileTask* CompilationPolicy::select_task(CompileQueue* compile_queue, JavaThr
       task = next_task;
       continue;
     }
-    if (task->is_scc()) {
-      // SCC tasks are on separate queue, and they should load fast. There is no need to walk
+    if (task->is_aot()) {
+      // AOTCodeCache tasks are on separate queue, and they should load fast. There is no need to walk
       // the rest of the queue, just take the task and go.
       return task;
     }
@@ -1091,7 +1091,7 @@ bool CompilationPolicy::compare_methods(Method* x, Method* y) {
 }
 
 bool CompilationPolicy::compare_tasks(CompileTask* x, CompileTask* y) {
-  assert(!x->is_scc() && !y->is_scc(), "SC tasks are not expected here");
+  assert(!x->is_aot() && !y->is_aot(), "SC tasks are not expected here");
   if (x->compile_reason() != y->compile_reason() && y->compile_reason() == CompileTask::Reason_MustBeCompiled) {
     return true;
   }

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -265,8 +265,8 @@ class CompileBroker: AllStatic {
   static jlong _peak_compilation_time;
 
   static CompilerStatistics _stats_per_level[];
-  static CompilerStatistics _scc_stats;
-  static CompilerStatistics _scc_stats_per_level[];
+  static CompilerStatistics _aot_stats;
+  static CompilerStatistics _aot_stats_per_level[];
 
   static volatile int _print_compilation_warning;
 
@@ -290,7 +290,7 @@ class CompileBroker: AllStatic {
                                           int                 comp_level,
                                           const methodHandle& hot_method,
                                           int                 hot_count,
-                                          SCCEntry*           scc_entry,
+                                          AOTCodeEntry*       aot_code_entry,
                                           CompileTask::CompileReason compile_reason,
                                           bool                requires_online_compilation,
                                           bool                blocking);
@@ -322,13 +322,13 @@ private:
                                   bool blocking,
                                   Thread* thread);
 
-  static CompileQueue* compile_queue(int comp_level, bool is_scc);
+  static CompileQueue* compile_queue(int comp_level, bool is_aot);
   static bool init_compiler_runtime();
   static void shutdown_compiler_runtime(AbstractCompiler* comp, CompilerThread* thread);
 
-  static SCCEntry* find_scc_entry(const methodHandle& method, int osr_bci, int comp_level,
-                                  CompileTask::CompileReason compile_reason,
-                                  bool requires_online_compilation);
+  static AOTCodeEntry* find_aot_code_entry(const methodHandle& method, int osr_bci, int comp_level,
+                                           CompileTask::CompileReason compile_reason,
+                                           bool requires_online_compilation);
 
 public:
   enum {
@@ -347,8 +347,8 @@ public:
                                       CompileTask::CompileReason compile_reason);
   static bool compilation_is_in_queue(const methodHandle& method);
   static void print_compile_queues(outputStream* st);
-  static int queue_size(int comp_level, bool is_scc = false) {
-    CompileQueue *q = compile_queue(comp_level, is_scc);
+  static int queue_size(int comp_level, bool is_aot = false) {
+    CompileQueue *q = compile_queue(comp_level, is_aot);
     return q != nullptr ? q->size() : 0;
   }
   static void compilation_init(JavaThread* THREAD);

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -22,7 +22,6 @@
  *
  */
 
-#include "code/SCCache.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compileLog.hpp"
@@ -106,7 +105,7 @@ void CompileTask::initialize(int compile_id,
                              int comp_level,
                              const methodHandle& hot_method,
                              int hot_count,
-                             SCCEntry* scc_entry,
+                             AOTCodeEntry* aot_code_entry,
                              CompileTask::CompileReason compile_reason,
                              CompileQueue* compile_queue,
                              bool requires_online_compilation,
@@ -147,7 +146,7 @@ void CompileTask::initialize(int compile_id,
   _failure_reason = nullptr;
   _failure_reason_on_C_heap = false;
   _training_data = nullptr;
-  _scc_entry = scc_entry;
+  _aot_code_entry = aot_code_entry;
   _compile_queue = compile_queue;
 
   AbstractCompiler* comp = CompileBroker::compiler(comp_level);
@@ -263,7 +262,7 @@ void CompileTask::print_tty() {
 // ------------------------------------------------------------------
 // CompileTask::print_impl
 void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, int comp_level,
-                             bool is_osr_method, int osr_bci, bool is_blocking, bool is_scc, bool is_preload,
+                             bool is_osr_method, int osr_bci, bool is_blocking, bool is_aot, bool is_preload,
                              const char* compiler_name,
                              const char* msg, bool short_form, bool cr,
                              jlong time_created, jlong time_queued, jlong time_started, jlong time_finished,
@@ -325,11 +324,11 @@ void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, i
   const char exception_char = has_exception_handler           ? '!' : ' ';
   const char blocking_char  = is_blocking                     ? 'b' : ' ';
   const char native_char    = is_native                       ? 'n' : ' ';
-  const char scc_char       = is_scc                          ? 'A' : ' ';
+  const char aot_char       = is_aot                          ? 'A' : ' ';
   const char preload_char   = is_preload                      ? 'P' : ' ';
 
   // print method attributes
-  st->print("%c%c%c%c%c%c%c ", compile_type, sync_char, exception_char, blocking_char, native_char, scc_char, preload_char);
+  st->print("%c%c%c%c%c%c%c ", compile_type, sync_char, exception_char, blocking_char, native_char, aot_char, preload_char);
 
   if (TieredCompilation) {
     if (comp_level != -1)  st->print("%d ", comp_level);
@@ -362,7 +361,7 @@ void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, i
 // CompileTask::print_compilation
 void CompileTask::print(outputStream* st, const char* msg, bool short_form, bool cr) {
   bool is_osr_method = osr_bci() != InvocationEntryBci;
-  print_impl(st, is_unloaded() ? nullptr : method(), compile_id(), comp_level(), is_osr_method, osr_bci(), is_blocking(), is_scc(), preload(),
+  print_impl(st, is_unloaded() ? nullptr : method(), compile_id(), comp_level(), is_osr_method, osr_bci(), is_blocking(), is_aot(), preload(),
              compiler()->name(), msg, short_form, cr, _time_created, _time_queued, _time_started, _time_finished, _aot_load_start, _aot_load_finish);
 }
 
@@ -560,7 +559,7 @@ void CompileTask::print_ul(const nmethod* nm, const char* msg) {
     print_impl(&ls, nm->method(), nm->compile_id(),
                nm->comp_level(), nm->is_osr_method(),
                nm->is_osr_method() ? nm->osr_entry_bci() : -1,
-               /*is_blocking*/ false, nm->scc_entry() != nullptr,
+               /*is_blocking*/ false, nm->aot_code_entry() != nullptr,
                nm->preloaded(), nm->compiler_name(),
                msg, /* short form */ true, /* cr */ true);
   }

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -34,7 +34,7 @@
 class CompileQueue;
 class CompileTrainingData;
 class DirectiveSet;
-class SCCEntry;
+class AOTCodeEntry;
 
 JVMCI_ONLY(class JVMCICompileState;)
 
@@ -110,7 +110,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
   CodeSection::csize_t _nm_insts_size;
   DirectiveSet*  _directive;
   AbstractCompiler*    _compiler;
-  SCCEntry*            _scc_entry;
+  AOTCodeEntry*        _aot_code_entry;
 #if INCLUDE_JVMCI
   bool                 _has_waiter;
   // Compilation state for a blocking JVMCI compilation
@@ -147,7 +147,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
   }
 
   void initialize(int compile_id, const methodHandle& method, int osr_bci, int comp_level,
-                  const methodHandle& hot_method, int hot_count, SCCEntry* scc_entry,
+                  const methodHandle& hot_method, int hot_count, AOTCodeEntry* aot_code_entry,
                   CompileTask::CompileReason compile_reason,
                   CompileQueue* compile_queue,
                   bool requires_online_compilation, bool is_blocking);
@@ -163,9 +163,9 @@ class CompileTask : public CHeapObj<mtCompiler> {
   bool         is_complete() const                  { return _is_complete; }
   bool         is_blocking() const                  { return _is_blocking; }
   bool         is_success() const                   { return _is_success; }
-  bool         is_scc() const                       { return _scc_entry != nullptr; }
-  void         clear_scc()                          { _scc_entry = nullptr; }
-  SCCEntry*    scc_entry()                          { return _scc_entry; }
+  bool         is_aot() const                       { return _aot_code_entry != nullptr; }
+  void         clear_aot()                          { _aot_code_entry = nullptr; }
+  AOTCodeEntry* aot_code_entry()                    { return _aot_code_entry; }
   bool         requires_online_compilation() const  { return _requires_online_compilation; }
   DirectiveSet* directive() const                   { return _directive; }
   CompileReason compile_reason() const              { return _compile_reason; }
@@ -272,7 +272,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
 private:
   static void  print_impl(outputStream* st, Method* method, int compile_id, int comp_level,
                                       bool is_osr_method = false, int osr_bci = -1, bool is_blocking = false,
-                                      bool is_scc = false, bool is_preload = false,
+                                      bool is_aot = false, bool is_preload = false,
                                       const char* compiler_name = nullptr,
                                       const char* msg = nullptr, bool short_form = false, bool cr = true,
                                       jlong time_created = 0, jlong time_queued = 0, jlong time_started = 0, jlong time_finished = 0,
@@ -284,7 +284,7 @@ public:
   static void  print(outputStream* st, const nmethod* nm, const char* msg = nullptr, bool short_form = false, bool cr = true) {
     print_impl(st, nm->method(), nm->compile_id(), nm->comp_level(),
                            nm->is_osr_method(), nm->is_osr_method() ? nm->osr_entry_bci() : -1, /*is_blocking*/ false,
-                           nm->scc_entry() != nullptr, nm->preloaded(),
+                           nm->aot_code_entry() != nullptr, nm->preloaded(),
                            nm->compiler_name(), msg, short_form, cr);
   }
   static void  print_ul(const nmethod* nm, const char* msg = nullptr);

--- a/src/hotspot/share/compiler/oopMap.hpp
+++ b/src/hotspot/share/compiler/oopMap.hpp
@@ -154,7 +154,7 @@ class OopMap: public ResourceObj {
   friend class VMStructs;
   friend class OopMapSet;
   friend class OopMapSort;
-  friend class SCCReader;
+  friend class AOTCodeReader;
  private:
   int  _pc_offset; // offset in the code that this OopMap corresponds to
   int  _omv_count; // number of OopMapValues in the stream
@@ -218,7 +218,7 @@ class OopMap: public ResourceObj {
 
 class OopMapSet : public ResourceObj {
   friend class VMStructs;
-  friend class SCCReader;
+  friend class AOTCodeReader;
  private:
   GrowableArray<OopMap*> _list;
 

--- a/src/hotspot/share/compiler/precompiler.cpp
+++ b/src/hotspot/share/compiler/precompiler.cpp
@@ -26,7 +26,7 @@
 #include "cds/cdsAccess.hpp"
 #include "cds/cdsConfig.hpp"
 #include "cds/runTimeClassInfo.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compiler_globals.hpp"
 #include "compiler/precompiler.hpp"
@@ -163,7 +163,7 @@ public:
           Method* requested_m = builder->to_requested(builder->get_buffered_addr(m));
           log.print(" -> %p", requested_m);
         }
-        log.print("] [%d] (%s)", SCCache::store_entries_cnt(), (is_success ? "success" : "FAILED"));
+        log.print("] [%d] (%s)", AOTCodeCache::store_entries_cnt(), (is_success ? "success" : "FAILED"));
       }
     }
 

--- a/src/hotspot/share/compiler/recompilationPolicy.cpp
+++ b/src/hotspot/share/compiler/recompilationPolicy.cpp
@@ -80,7 +80,7 @@ bool RecompilationPolicy::recompilation_step(int step, TRAPS) {
         continue;
       }
 
-      if (!AOTForceRecompilation && !(nm->is_scc() && nm->comp_level() == CompLevel_full_optimization)) {
+      if (!AOTForceRecompilation && !(nm->is_aot() && nm->comp_level() == CompLevel_full_optimization)) {
         // If it's already online-compiled at level 4, mark it as done.
         if (nm->comp_level() == CompLevel_full_optimization) {
           RecompilationSchedule::set_status_at(i, true);

--- a/src/hotspot/share/gc/g1/c1/g1BarrierSetC1.cpp
+++ b/src/hotspot/share/gc/g1/c1/g1BarrierSetC1.cpp
@@ -25,7 +25,7 @@
 #include "c1/c1_LIRGenerator.hpp"
 #include "c1/c1_CodeStubs.hpp"
 #if INCLUDE_CDS
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #endif
 #include "gc/g1/c1/g1BarrierSetC1.hpp"
 #include "gc/g1/g1BarrierSet.hpp"
@@ -171,7 +171,7 @@ void G1BarrierSetC1::post_barrier(LIRAccess& access, LIR_Opr addr, LIR_Opr new_v
     __ move(addr, xor_res);
     __ logical_xor(xor_res, new_val, xor_res);
 #if INCLUDE_CDS
-    if (SCCache::is_on_for_write()) {
+    if (AOTCodeCache::is_on_for_write()) {
       __ move(grain_shift_addr, grain_shift_reg);
       __ move(xor_res, xor_shift_res);
       __ move(grain_shift_indirect, grain_shift);
@@ -191,7 +191,7 @@ void G1BarrierSetC1::post_barrier(LIRAccess& access, LIR_Opr addr, LIR_Opr new_v
   } else {
     __ logical_xor(addr, new_val, xor_res);
 #if INCLUDE_CDS
-    if (SCCache::is_on_for_write()) {
+    if (AOTCodeCache::is_on_for_write()) {
       __ move(grain_shift_addr, grain_shift_reg);
       __ move(grain_shift_indirect, grain_shift);
       __ unsigned_shift_right(xor_res,

--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -23,9 +23,6 @@
  */
 
 #include "classfile/javaClasses.hpp"
-#if INCLUDE_CDS
-#include "code/SCCache.hpp"
-#endif
 #include "code/vmreg.inline.hpp"
 #include "gc/g1/c2/g1BarrierSetC2.hpp"
 #include "gc/g1/g1BarrierSet.hpp"

--- a/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.hpp
+++ b/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.hpp
@@ -190,10 +190,10 @@ public:
 #endif // PRODUCT
 };
 
-class SCAddressTable;
+class AOTCodeAddressTable;
 
 class ShenandoahBarrierSetC1 : public BarrierSetC1 {
-  friend class SCAddressTable;
+  friend class AOTCodeAddressTable;
 private:
   CodeBlob* _pre_barrier_c1_runtime_code_blob;
   CodeBlob* _load_reference_barrier_strong_rt_code_blob;

--- a/src/hotspot/share/gc/z/c1/zBarrierSetC1.hpp
+++ b/src/hotspot/share/gc/z/c1/zBarrierSetC1.hpp
@@ -87,10 +87,10 @@ public:
 #endif // PRODUCT
 };
 
-class SCAddressTable;
+class AOTCodeAddressTable;
 
 class ZBarrierSetC1 : public BarrierSetC1 {
-  friend SCAddressTable;
+  friend AOTCodeAddressTable;
 private:
   address _load_barrier_on_oop_field_preloaded_runtime_stub;
   address _load_barrier_on_weak_oop_field_preloaded_runtime_stub;

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -2164,7 +2164,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
                                  debug_info, dependencies, code_buffer,
                                  frame_words, oop_map_set,
                                  handler_table, implicit_exception_table,
-                                 compiler, comp_level, nullptr /* SCCEntry */,
+                                 compiler, comp_level, nullptr /* AOTCodeEntry */,
                                  speculations, speculations_len, data);
 
 

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -181,7 +181,6 @@ class outputStream;
   LOG_TAG(safepoint) \
   LOG_TAG(sampling) \
   LOG_TAG(scavenge) \
-  LOG_TAG(scc) \
   LOG_TAG(sealed) \
   LOG_TAG(setting) \
   LOG_TAG(smr) \

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1326,7 +1326,7 @@ void Method::link_method(const methodHandle& h_method, TRAPS) {
   if (_preload_code != nullptr) {
     MutexLocker ml(NMethodState_lock, Mutex::_no_safepoint_check_flag);
     set_code(h_method, _preload_code);
-    assert(((nmethod*)_preload_code)->scc_entry() == _scc_entry, "sanity");
+    assert(((nmethod*)_preload_code)->aot_code_entry() == _aot_code_entry, "sanity");
   }
 }
 

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -64,7 +64,7 @@ class ConstMethod;
 class InlineTableSizes;
 class nmethod;
 class InterpreterOopMap;
-class SCCEntry;
+class AOTCodeEntry;
 
 class Method : public Metadata {
  friend class VMStructs;
@@ -103,8 +103,8 @@ class Method : public Metadata {
   nmethod* volatile _code;                   // Points to the corresponding piece of native code
   volatile address  _from_interpreted_entry; // Cache of _code ? _adapter->i2c_entry() : _i2i_entry
 
-  nmethod*  _preload_code;  // preloaded SCCache code
-  SCCEntry* _scc_entry;     // SCCache entry for pre-loading code
+  nmethod*  _preload_code;       // preloaded AOT code
+  AOTCodeEntry* _aot_code_entry; // AOT Code Cache entry for pre-loading code
 
   // Constructor
   Method(ConstMethod* xconst, AccessFlags access_flags, Symbol* name);
@@ -395,11 +395,11 @@ public:
   void set_preload_code(nmethod* code) {
     _preload_code = code;
   }
-  void set_scc_entry(SCCEntry* entry) {
-    _scc_entry = entry;
+  void set_aot_code_entry(AOTCodeEntry* entry) {
+    _aot_code_entry = entry;
   }
-  SCCEntry* scc_entry() const {
-    return _scc_entry;
+  AOTCodeEntry* aot_code_entry() const {
+    return _aot_code_entry;
   }
 
   address get_i2c_entry();

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2142,7 +2142,7 @@ Node* GraphKit::uncommon_trap(int trap_request,
       (action != Deoptimization::Action_none)) {
     ResourceMark rm;
     ciMethod* cim = Compile::current()->method();
-    log_debug(scc,deoptimization)("Uncommon trap in preload code: reason=%s action=%s method=%s::%s bci=%d, %s",
+    log_debug(aot, codecache, deoptimization)("Uncommon trap in preload code: reason=%s action=%s method=%s::%s bci=%d, %s",
                   Deoptimization::trap_reason_name(reason), Deoptimization::trap_action_name(action),
                   cim->holder()->name()->as_klass_external_name(), cim->name()->as_klass_external_name(),
                   bci(), comment);

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -23,10 +23,10 @@
  */
 
 #include "asm/assembler.inline.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "code/debugInfo.hpp"
 #include "code/debugInfoRec.hpp"
-#include "code/SCCache.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compilerDirectives.hpp"
 #include "compiler/disassembler.hpp"
@@ -3674,7 +3674,7 @@ void PhaseOutput::print_statistics() {
 #endif
 
 int PhaseOutput::max_inst_size() {
-  if (SCCache::is_on_for_write()) {
+  if (AOTCodeCache::is_on_for_write()) {
     // See the comment in output.hpp.
     return 16384;
   } else {

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -182,11 +182,11 @@ public:
 
   BufferSizingData* buffer_sizing_data()        { return &_buf_sizes; }
 
-  // SCCache::write_nmethod bails when nmethod buffer is expanded.
+  // AOTCodeCache::write_nmethod bails when nmethod buffer is expanded.
   // Large methods would routinely expand the buffer, making themselves
-  // ineligible for SCCache stores. In order to minimize this effect,
-  // we default to larger default sizes. We do this only when SCC dumping
-  // is active, to avoid impact on default configuration.
+  // ineligible for AOTCodeCache stores. In order to minimize this effect,
+  // we default to larger default sizes. We do this only when AOTCodeCache
+  // dumping is active, to avoid impact on default configuration.
   //
   // Additionally, GC barrier stubs expand up to MAX_inst_size in mainline,
   // which also forced resizes often. Current code replaces it with
@@ -196,7 +196,7 @@ public:
   // The old enum is renamed, so direct misuse in new code from mainline would
   // be caught as build failure.
   //
-  // TODO: Revert this back to mainline once SCCache is fixed.
+  // TODO: Revert this back to mainline once AOTCodeCache is fixed.
   enum ScratchBufferBlob {
     mainline_MAX_inst_size = 2048,
     MAX_locs_size       = 128, // number of relocInfo elements

--- a/src/hotspot/share/opto/rootnode.cpp
+++ b/src/hotspot/share/opto/rootnode.cpp
@@ -30,7 +30,7 @@
 #include "opto/rootnode.hpp"
 #include "opto/subnode.hpp"
 #include "opto/type.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 
 //------------------------------Ideal------------------------------------------
 // Remove dead inputs
@@ -71,7 +71,7 @@ HaltNode::HaltNode(Node* ctrl, Node* frameptr, const char* halt_reason, bool rea
   init_req(TypeFunc::Memory,   top);
   init_req(TypeFunc::FramePtr, frameptr    );
   init_req(TypeFunc::ReturnAdr,top);
-  SCCache::add_C_string(halt_reason);
+  AOTCodeCache::add_C_string(halt_reason);
 }
 
 const Type *HaltNode::bottom_type() const { return Type::BOTTOM; }

--- a/src/hotspot/share/opto/runtime.hpp
+++ b/src/hotspot/share/opto/runtime.hpp
@@ -113,7 +113,7 @@ enum class OptoStubId :int {
 
 class OptoRuntime : public AllStatic {
   friend class Matcher;  // allow access to stub names
-  friend class SCAddressTable;
+  friend class AOTCodeAddressTable;
  private:
   // declare opto stub address/blob holder static fields
 #define C2_BLOB_FIELD_DECLARE(name, type) \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3762,7 +3762,7 @@ jint Arguments::apply_ergo() {
     warning("UseSecondarySupersTable is not supported");
     FLAG_SET_DEFAULT(UseSecondarySupersTable, false);
   }
-  UseSecondarySupersTable = false; // FIXME: Disabled for Leyden. Neet to fix SCAddressTable::id_for_address()
+  UseSecondarySupersTable = false; // FIXME: Disabled for Leyden. Neet to fix AOTCodeAddressTable::id_for_address()
   if (!UseSecondarySupersTable) {
     FLAG_SET_DEFAULT(StressSecondarySupers, false);
     FLAG_SET_DEFAULT(VerifySecondarySupers, false);

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -2863,7 +2863,7 @@ void Deoptimization::gather_statistics(nmethod* nm, DeoptReason reason, DeoptAct
 
   update(_deoptimization_hist[0][reason][1+action], bc);
 
-  uint lvl = nm->comp_level() + (nm->is_scc() ? 4 : 0) + (nm->preloaded() ? 1 : 0);
+  uint lvl = nm->comp_level() + (nm->is_aot() ? 4 : 0) + (nm->preloaded() ? 1 : 0);
   _deoptimization_hist[lvl][Reason_none][0][0] += 1;  // total
   _deoptimization_hist[lvl][reason][0][0]      += 1;  // per-reason total
   update(_deoptimization_hist[lvl][reason][1+action], bc);

--- a/src/hotspot/share/runtime/init.cpp
+++ b/src/hotspot/share/runtime/init.cpp
@@ -26,7 +26,7 @@
 #include "classfile/stringTable.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compiler_globals.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/gcHeapSummary.hpp"
@@ -159,7 +159,7 @@ jint init_globals() {
     LSAN_REGISTER_ROOT_REGION(summary.start(), summary.reserved_size());
   }
 #endif // LEAK_SANITIZER
-  SCCache::init2();        // depends on universe_init
+  AOTCodeCache::init2();        // depends on universe_init
   AsyncLogWriter::initialize();
   gc_barrier_stubs_init();   // depends on universe_init, must be before interpreter_init
   continuations_init();      // must precede continuation stub generation
@@ -172,8 +172,8 @@ jint init_globals() {
   InterfaceSupport_init();
   VMRegImpl::set_regName();  // need this before generate_stubs (for printing oop maps).
   SharedRuntime::generate_stubs();
-  SCCache::init_shared_blobs_table();  // need this after generate_stubs
-  SharedRuntime::init_adapter_library(); // do this after SCCache::init_shared_blobs_table
+  AOTCodeCache::init_shared_blobs_table();  // need this after generate_stubs
+  SharedRuntime::init_adapter_library(); // do this after AOTCodeCache::init_shared_blobs_table
   return JNI_OK;
 }
 
@@ -225,7 +225,7 @@ jint init_globals2() {
   }
   compiler_stubs_init(false /* in_compiler_thread */); // compiler's intrinsics stubs
   final_stubs_init();    // final StubRoutines stubs
-  SCCache::init_stubs_table();
+  AOTCodeCache::init_stubs_table();
   MethodHandles::generate_adapters();
 
   // All the flags that get adjusted by VM_Version_init and os::init_2

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -36,7 +36,7 @@
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "code/codeCache.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compilationMemoryStatistic.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
@@ -211,11 +211,11 @@ void log_vm_init_stats() {
       log.cr();
     }
 
-    if (SCCache::is_on_for_read()) {
+    if (AOTCodeCache::is_on_for_read()) {
       log.print_cr("Startup Code Cache: ");
-      SCCache::print_statistics_on(&log);
+      AOTCodeCache::print_statistics_on(&log);
       log.cr();
-      SCCache::print_timers_on(&log);
+      AOTCodeCache::print_timers_on(&log);
     }
 
     VMThread::print_counters_on(&log);
@@ -548,7 +548,7 @@ void before_exit(JavaThread* thread, bool halt) {
   }
 #endif
 
-  SCCache::close(); // Write final data and close archive
+  AOTCodeCache::close(); // Write final data and close archive
 
   // Hang forever on exit if we're reporting an error.
   if (ShowMessageBoxOnError && VMError::is_error_reported()) {

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -30,7 +30,7 @@
 #include "classfile/stringTable.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/codeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "code/nmethod.inline.hpp"
@@ -2845,7 +2845,7 @@ bool AdapterHandlerLibrary::lookup_aot_cache(AdapterHandlerEntry* handler, CodeB
   const char* name = AdapterHandlerLibrary::name(handler->fingerprint());
   const uint32_t id = AdapterHandlerLibrary::id(handler->fingerprint());
   uint32_t offsets[4];
-  if (SCCache::load_adapter(buffer, id, name, offsets)) {
+  if (AOTCodeCache::load_adapter(buffer, id, name, offsets)) {
     address i2c_entry = buffer->insts_begin();
     assert(offsets[0] == 0, "sanity check");
     handler->set_entry_points(i2c_entry, i2c_entry + offsets[1], i2c_entry + offsets[2], i2c_entry + offsets[3]);
@@ -2909,7 +2909,7 @@ bool AdapterHandlerLibrary::generate_adapter_code(AdapterBlob*& adapter_blob,
     offsets[1] = handler->get_c2i_entry() - handler->get_i2c_entry();
     offsets[2] = handler->get_c2i_unverified_entry() - handler->get_i2c_entry();
     offsets[3] = handler->get_c2i_no_clinit_check_entry() - handler->get_i2c_entry();
-    SCCache::store_adapter(&buffer, id, name, offsets);
+    AOTCodeCache::store_adapter(&buffer, id, name, offsets);
   }
 #ifdef ASSERT
   if (VerifyAdapterSharing) {

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -202,7 +202,7 @@ public:
   // Dependencies
   friend class StubGenerator;
   friend class VMStructs;
-  friend class SCAddressTable;
+  friend class AOTCodeAddressTable;
 #if INCLUDE_JVMCI
   friend class JVMCIVMStructs;
 #endif

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -38,7 +38,7 @@
 #include "classfile/systemDictionaryShared.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compileTask.hpp"
@@ -862,7 +862,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   if (PrecompileCode) {
     Precompiler::compile_cached_code(CHECK_JNI_ERR);
     if (PrecompileOnlyAndExit) {
-      SCCache::close();
+      AOTCodeCache::close();
       log_vm_init_stats();
       vm_direct_exit(0, "Code precompiation is over");
     }
@@ -871,7 +871,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 
 #if defined(COMPILER2)
   // Pre-load cached compiled methods
-  SCCache::preload_code(CHECK_JNI_ERR);
+  AOTCodeCache::preload_code(CHECK_JNI_ERR);
 #endif
 
   if (NativeHeapTrimmer::enabled()) {

--- a/test/hotspot/jtreg/premain/javac/javac-test.sh
+++ b/test/hotspot/jtreg/premain/javac/javac-test.sh
@@ -71,7 +71,7 @@ while true; do
         shift
     elif [[ $1 = "-lsc" ]]; then
         # Log shared code
-        EXTRA_ARGS="$EXTRA_ARGS -Xlog:scc -Xlog:scc,nmethod"
+        EXTRA_ARGS="$EXTRA_ARGS -Xlog:aot+codecache -Xlog:aot+codecache+nmethod"
         shift
     elif [[ $1 = "-r" ]]; then
         # Limit the run to a single test case
@@ -428,7 +428,7 @@ for i in $TESTS; do
     fi
 
     #----------------------------------------------------------------------
-    CMD="$JVM_AND_ARGS $EXTRA_ARGS -Xlog:scc*=warning:file=javac.scc-store.log::filesize=0 \
+    CMD="$JVM_AND_ARGS $EXTRA_ARGS -Xlog:aot+codecache*=warning:file=javac.aot-store.log::filesize=0 \
         -XX:SharedArchiveFile=$JSA2 $X2 -XX:+StoreCachedCode -XX:CachedCodeFile=${JSA2}-sc -XX:CachedCodeMaxSize=100M \
         -cp JavacBench.jar JavacBench $LOOPS"
     test-info "${STEP4}Run with $JSA2 and generate AOT code" &&
@@ -439,7 +439,7 @@ for i in $TESTS; do
     fi
 
     #----------------------------------------------------------------------
-    CMD="$JVM_AND_ARGS $EXTRA_ARGS -Xlog:scc*=warning:file=javac.scc-load.log::filesize=0 \
+    CMD="$JVM_AND_ARGS $EXTRA_ARGS -Xlog:aot+codecache*=warning:file=javac.aot-load.log::filesize=0 \
         -XX:SharedArchiveFile=$JSA2 $X2 -XX:+LoadCachedCode -XX:CachedCodeFile=${JSA2}-sc \
         -cp JavacBench.jar JavacBench $LOOPS"
     test-info "${STEP5}Final production run: with $JSA2 and load AOT code" &&

--- a/test/hotspot/jtreg/premain/javac_new_workflow/run.sh
+++ b/test/hotspot/jtreg/premain/javac_new_workflow/run.sh
@@ -40,7 +40,7 @@
 # as shown above, or edit the following line
 #
 # The training run uses two JVM processes. We add "pid" to the log to distinguish their output.
-TRAINING_OPTS="${TRAINING_OPTS} -Xlog:scc -Xlog:cds=debug::uptime,tags,pid"
+TRAINING_OPTS="${TRAINING_OPTS} -Xlog:aot+codecache -Xlog:cds=debug::uptime,tags,pid"
 TRAINING_OPTS="${TRAINING_OPTS} -XX:+AOTClassLinking"
 #TRAINING_OPTS="${TRAINING_OPTS} -XX:+UnlockDiagnosticVMOptions -XX:+AOTRecordTraining"
 
@@ -67,7 +67,7 @@ eval $cmd
 #========================================
 # Production run
 #    TODO: add flags for AOT cache
-cmd="$launcher $PRODUCTION_OPTS -Xlog:cds -Xlog:scc -XX:CacheDataStore=javac.cds $@ com.sun.tools.javac.Main HelloWorld.java"
+cmd="$launcher $PRODUCTION_OPTS -Xlog:cds -Xlog:aot+codecache -XX:CacheDataStore=javac.cds $@ com.sun.tools.javac.Main HelloWorld.java"
 perfcmd="perf stat -r 20 $(echo $cmd | sed -e 's/ [-]Xlog:[^ ]*//g')"
 echo "Production run: "
 echo "   $cmd"

--- a/test/hotspot/jtreg/premain/jmh/run.sh
+++ b/test/hotspot/jtreg/premain/jmh/run.sh
@@ -91,10 +91,10 @@ do_test "(STEP 3 of 5) Run with $APP-static.jsa and dump profile in $APP-dynamic
 
 do_test "(STEP 4 of 5) Run with $APP-dynamic.jsa and generate AOT code" \
     $JAVA -XX:SharedArchiveFile=$APP-dynamic.jsa -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+StoreCachedCode \
-        -Xlog:scc*=warning:file=$APP-store-sc.log \
+        -Xlog:aot+codecache*=warning:file=$APP-store-sc.log \
         -XX:CachedCodeFile=$APP-dynamic.jsa-sc -XX:CachedCodeMaxSize=100M $CMDLINE
 
 do_test "(STEP 5 of 5) Final production run: with $APP-dynamic.jsa and load AOT code" \
     $JAVA -XX:SharedArchiveFile=$APP-dynamic.jsa -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+LoadCachedCode \
-        -Xlog:scc*=warning:file=$APP-load-sc.log \
+        -Xlog:aot+codecache*=warning:file=$APP-load-sc.log \
         -XX:CachedCodeFile=$APP-dynamic.jsa-sc $CMDLINE

--- a/test/hotspot/jtreg/premain/lib/bench-lib-new-workflow.sh
+++ b/test/hotspot/jtreg/premain/lib/bench-lib-new-workflow.sh
@@ -56,7 +56,7 @@
 #
 #     LEYDEN_CALLER_OPTS
 #       extra args to be added to Leyden JVM runs
-#       e.g. LEYDEN_CALLER_OPTS='-Xlog:scc=error'
+#       e.g. LEYDEN_CALLER_OPTS='-Xlog:aot+codecache=error'
 #     TASKSET
 #       allows pinning of perf runs to specific processors
 #       e.g. setting TASKSET='taskest 0xff0' will execute

--- a/test/hotspot/jtreg/premain/lib/bench-lib.sh
+++ b/test/hotspot/jtreg/premain/lib/bench-lib.sh
@@ -233,7 +233,7 @@ function dump_one_jvm () {
         echo "(Premain  4 of 5) Run with $APPID-dynamic.jsa and generate AOT code"
         rm -f $APPID-store-sc.log
         (set -x; $JAVA -XX:SharedArchiveFile=$APPID-dynamic.jsa -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+StoreCachedCode \
-                       -Xlog:scc*=warning:file=$APPID-store-sc.log::filesize=0 \
+                       -Xlog:aot+codecache*=warning:file=$APPID-store-sc.log::filesize=0 \
                        -XX:CachedCodeFile=$APPID-dynamic.jsa-sc -XX:CachedCodeMaxSize=100M $CMDLINE) || exit 1
 
     fi
@@ -266,7 +266,7 @@ function exec_one_jvm () {
         RUNLOG=$RUNLOG,$(get_elapsed logs/${1}_td.$2)
         (set -x;
          perf stat -r $REPEAT $JAVA -XX:SharedArchiveFile=$APPID-dynamic.jsa -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+LoadCachedCode \
-              -XX:CachedCodeFile=$APPID-dynamic.jsa-sc -Xlog:scc=error \
+              -XX:CachedCodeFile=$APPID-dynamic.jsa-sc -Xlog:aot+codecache=error \
               $CMDLINE 2> logs/${1}_aot.$2
         )
         RUNLOG=$RUNLOG,$(get_elapsed logs/${1}_aot.$2)

--- a/test/hotspot/jtreg/premain/lib/premain-run.sh
+++ b/test/hotspot/jtreg/premain/lib/premain-run.sh
@@ -92,10 +92,10 @@ do_test "(STEP 3 of 5) Run with $APP-static.jsa and dump profile in $APP-dynamic
 
 do_test "(STEP 4 of 5) Run with $APP-dynamic.jsa and generate AOT code" \
     $JAVA -XX:SharedArchiveFile=$APP-dynamic.jsa -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+StoreCachedCode \
-        -Xlog:scc*=warning:file=$APP-store-sc.log::filesize=0 \
+        -Xlog:aot+codecache*=warning:file=$APP-store-sc.log::filesize=0 \
         -XX:CachedCodeFile=$APP-dynamic.jsa-sc -XX:CachedCodeMaxSize=100M $CMDLINE
 
 do_test "(STEP 5 of 5) Final production run: with $APP-dynamic.jsa and load AOT code" \
     $JAVA -XX:SharedArchiveFile=$APP-dynamic.jsa -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+LoadCachedCode \
-        -Xlog:scc*=warning:file=$APP-load-sc.log::filesize=0 \
+        -Xlog:aot+codecache*=warning:file=$APP-load-sc.log::filesize=0 \
         -XX:CachedCodeFile=$APP-dynamic.jsa-sc $CMDLINE

--- a/test/hotspot/jtreg/premain/spring-petclinic/WarmupMakefile
+++ b/test/hotspot/jtreg/premain/spring-petclinic/WarmupMakefile
@@ -281,7 +281,7 @@ ${PC_ST_CACHED_CODE}: ${PC_DYNAMIC_ST_JSA}
 
 ${PC_LT_CACHED_CODE}: ${PC_DYNAMIC_LT_JSA}
 	${PREMAIN_JAVA} -XX:SharedArchiveFile=${PC_DYNAMIC_LT_JSA} -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+StoreCachedCode \
-	     -Xlog:scc,cds=debug,cds+class=debug,cds+heap=warning,cds+resolve=debug:file=$@.log \
+	     -Xlog:aot+codecache=debug,cds=debug,cds+class=debug,cds+heap=warning,cds+resolve=debug:file=$@.log \
 	     -XX:CachedCodeFile=${PC_LT_CACHED_CODE} -XX:CachedCodeMaxSize=512M ${UNPACKED_CMDLINE} &> $@.out &
 	$(wait-for-startup)
 	$(run-jmeter)
@@ -305,7 +305,7 @@ ${PC_CDS}: ${PC_CDS_PREIMAGE}
 	rm -f ${PC_CDS}
 	${PREMAIN_JAVA} -XX:+AOTClassLinking -XX:CachedCodeMaxSize=512M \
 	       -XX:+UnlockDiagnosticVMOptions -XX:CDSPreimage=${PC_CDS_PREIMAGE} -XX:CacheDataStore=${PC_CDS} \
-	       -Xlog:scc,cds=debug,cds+class=debug,cds+heap=warning,cds+resolve=debug:file=$@.log \
+	       -Xlog:aot+codecache=debug,cds=debug,cds+class=debug,cds+heap=warning,cds+resolve=debug:file=$@.log \
 	       -XX:-AssemblyStepInlining \
 	       ${UNPACKED_CMDLINE} &> $@.out
 	ls -l $@

--- a/test/hotspot/jtreg/premain/spring-petclinic/bench.sh
+++ b/test/hotspot/jtreg/premain/spring-petclinic/bench.sh
@@ -42,7 +42,7 @@ cd pet-clinic-bench
 mkdir -p data
 
 CMDLINE="-XX:SharedArchiveFile=spring-petclinic.dynamic.jsa -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+LoadCachedCode"
-CMDLINE="$CMDLINE -XX:CachedCodeFile=spring-petclinic.code.jsa -Xlog:init -Xlog:scc=error -Xmx2g"
+CMDLINE="$CMDLINE -XX:CachedCodeFile=spring-petclinic.code.jsa -Xlog:init -Xlog:aot+codecache=error -Xmx2g"
 CMDLINE="$CMDLINE -cp @petclinic-snapshot/target/unpacked/classpath -DautoQuit=true"
 CMDLINE="$CMDLINE -Dspring.aot.enabled=true org.springframework.samples.petclinic.PetClinicApplication"
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/AOTFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/AOTFlags.java
@@ -93,7 +93,7 @@ public class AOTFlags {
         pb = ProcessTools.createLimitedTestJavaProcessBuilder(
             "-XX:AOTCache=" + aotCacheFile,
             "-Xlog:cds",
-            "-Xlog:scc*",
+            "-Xlog:aot+codecache*",
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod");
         out.shouldContain("Using AOT-linked classes: true (static archive: has aot-linked classes)");
@@ -165,7 +165,7 @@ public class AOTFlags {
         pb = ProcessTools.createLimitedTestJavaProcessBuilder(
             "-XX:AOTCache=" + aotCacheFile,
             "-Xlog:cds",
-            "-Xlog:scc*",
+            "-Xlog:aot+codecache*",
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod");
         out.shouldContain("Using AOT-linked classes: false (static archive: no aot-linked classes)");

--- a/test/hotspot/jtreg/runtime/cds/appcds/applications/HelidonQuickStartSE.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/applications/HelidonQuickStartSE.java
@@ -130,7 +130,7 @@ public class HelidonQuickStartSE {
             };
 
             if (runMode.isProductionRun()) {
-                cmdLine = StringArrayUtils.concat("-Xlog:scc=error", cmdLine);
+                cmdLine = StringArrayUtils.concat("-Xlog:aot+codecache=error", cmdLine);
             }
             return cmdLine;
         }

--- a/test/hotspot/jtreg/runtime/cds/appcds/applications/MicronautFirstApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/applications/MicronautFirstApp.java
@@ -129,7 +129,7 @@ public class MicronautFirstApp {
             };
 
             if (runMode.isProductionRun()) {
-                cmdLine = StringArrayUtils.concat("-Xlog:scc=error", cmdLine);
+                cmdLine = StringArrayUtils.concat("-Xlog:aot+codecache=error", cmdLine);
             }
             return cmdLine;
         }

--- a/test/hotspot/jtreg/runtime/cds/appcds/applications/QuarkusGettingStarted.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/applications/QuarkusGettingStarted.java
@@ -129,7 +129,7 @@ public class QuarkusGettingStarted {
             };
 
             if (runMode.isProductionRun()) {
-                cmdLine = StringArrayUtils.concat("-Xlog:scc=error", cmdLine);
+                cmdLine = StringArrayUtils.concat("-Xlog:aot+codecache=error", cmdLine);
             }
             return cmdLine;
         }

--- a/test/hotspot/jtreg/runtime/cds/appcds/applications/SpringPetClinic.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/applications/SpringPetClinic.java
@@ -208,7 +208,7 @@ public class SpringPetClinic {
             }
 
             if (runMode.isProductionRun()) {
-                cmdLine = StringArrayUtils.concat("-Xlog:scc=error", cmdLine);
+                cmdLine = StringArrayUtils.concat("-Xlog:aot+codecache=error", cmdLine);
             }
  */
             return cmdLine;


### PR DESCRIPTION
Rename AOT Code classes and logging tags to match changes for mainline: [#24740](https://github.com/openjdk/jdk/pull/24740)

This is first part of changes in premain branch.  AOT code flags renaming and more code changes will be done in separate PRs.

Tested with premain-tier1