### PR TITLE
8355368: [hermetic-java-runtime] Update jcheck config for branch

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,10 +1,10 @@
 [general]
-project=jdk
+project=leyden
 jbs=JDK
 version=25
 
 [checks]
-error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists,copyright
+error=author,committer,reviewers,merge,executable,symlink,message,hg-tag,whitespace,problemlists,copyright
 warning=issuestitle,binary
 
 [repository]
@@ -23,14 +23,11 @@ ignore-tabs=.*\.gmk|Makefile
 message=Merge
 
 [checks "reviewers"]
-reviewers=1
+committers=1
 ignore=duke
 
 [checks "committer"]
 role=committer
-
-[checks "issues"]
-pattern=^([124-8][0-9]{6}): (\S.*)$
 
 [checks "problemlists"]
 dirs=test/jdk|test/langtools|test/lib-test|test/hotspot/jtreg|test/jaxp


### PR DESCRIPTION
The current config in place is for the `jdk` project which is wrong.
Moved it to project `leyden` and mark PRs as ready when at least one
leyden committer approves. Don't require bugs to be filed.

This should match the config the `premain` branch uses.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355368](https://bugs.openjdk.org/browse/JDK-8355368): [hermetic-java-runtime] Update jcheck config for branch (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Jiangli Zhou](https://openjdk.org/census#jiangli) (@jianglizhou - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/61/head:pull/61` \
`$ git checkout pull/61`

Update a local copy of the PR: \
`$ git checkout pull/61` \
`$ git pull https://git.openjdk.org/leyden.git pull/61/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 61`

View PR using the GUI difftool: \
`$ git pr show -t 61`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/61.diff">https://git.openjdk.org/leyden/pull/61.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/61#issuecomment-2823570610)
</details>
