### PR TITLE
8355352: [premain] rename AOT Code classes and logging tags

### DIFF
--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -128,7 +128,7 @@ ifneq ($(call check-jvm-feature, cds), true)
       classLoaderDataShared.cpp \
       classLoaderExt.cpp \
       precompiler.cpp \
-      SCCache.cpp \
+      aotCodeCache.cpp \
       systemDictionaryShared.cpp \
       trainingData.cpp
   JVM_EXCLUDE_PATTERNS += cds/

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -34,7 +34,7 @@
 #include "ci/ciArrayKlass.hpp"
 #include "ci/ciInstance.hpp"
 #include "ci/ciUtilities.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/gc_globals.hpp"
@@ -530,17 +530,19 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
 
     case T_LONG: {
       assert(patch_code == lir_patch_none, "no patching handled here");
-      if (SCCache::is_on_for_write()) {
-        // SCA needs relocation info for card table base
+      if (AOTCodeCache::is_on_for_write()) {
+        // AOT code needs relocation info for card table base
         address b = c->as_pointer();
         if (is_card_table_address(b)) {
           __ lea(dest->as_register_lo(), ExternalAddress(b));
           break;
         }
+#if INCLUDE_CDS
         if (AOTRuntimeConstants::contains(b)) {
           __ load_aotrc_address(dest->as_register_lo(), b);
           break;
         }
+#endif
       }
       __ mov(dest->as_register_lo(), (intptr_t)c->as_jlong());
       break;

--- a/src/hotspot/cpu/aarch64/gc/g1/g1BarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/g1/g1BarrierSetAssembler_aarch64.cpp
@@ -24,7 +24,7 @@
 
 #include "asm/macroAssembler.inline.hpp"
 #if INCLUDE_CDS
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #endif
 #include "gc/g1/g1BarrierSet.hpp"
 #include "gc/g1/g1BarrierSetAssembler.hpp"
@@ -214,7 +214,7 @@ static void generate_post_barrier_fast_path(MacroAssembler* masm,
   // AOT code needs to load the barrier grain shift from the aot
   // runtime constants area in the code cache otherwise we can compile
   // it as an immediate operand
-  if (SCCache::is_on_for_write()) {
+  if (AOTCodeCache::is_on_for_write()) {
     address grain_shift_address = (address)AOTRuntimeConstants::grain_shift_address();
     __ eor(tmp1, store_addr, new_val);
     __ lea(tmp2, ExternalAddress(grain_shift_address));
@@ -239,7 +239,7 @@ static void generate_post_barrier_fast_path(MacroAssembler* masm,
   // AOT code needs to load the barrier card shift from the aot
   // runtime constants area in the code cache otherwise we can compile
   // it as an immediate operand
-  if (SCCache::is_on_for_write()) {
+  if (AOTCodeCache::is_on_for_write()) {
     address card_shift_address = (address)AOTRuntimeConstants::card_shift_address();
     __ lea(tmp2, ExternalAddress(card_shift_address));
     __ ldrb(tmp2, tmp2);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -27,8 +27,8 @@
 #define CPU_AARCH64_MACROASSEMBLER_AARCH64_HPP
 
 #include "asm/assembler.inline.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/vmreg.hpp"
-#include "code/SCCache.hpp"
 #include "metaprogramming/enableIf.hpp"
 #include "oops/compressedOops.hpp"
 #include "oops/compressedKlass.hpp"
@@ -1316,7 +1316,7 @@ public:
 
   // Check if branches to the non nmethod section require a far jump
   static bool codestub_branch_needs_far_jump() {
-    if (SCCache::is_on_for_write()) {
+    if (AOTCodeCache::is_on_for_write()) {
       // To calculate far_codestub_branch_size correctly.
       return true;
     }

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -27,7 +27,7 @@
 #include "asm/macroAssembler.inline.hpp"
 #include "asm/register.hpp"
 #include "atomic_aarch64.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/oopMap.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
@@ -5888,7 +5888,7 @@ class StubGenerator: public StubCodeGenerator {
 
     address start = __ pc();
  
-    if (SCCache::load_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start)) {
+    if (AOTCodeCache::load_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start)) {
       return start;
     }
     const Register x     = r0;
@@ -5912,7 +5912,7 @@ class StubGenerator: public StubCodeGenerator {
     __ leave(); // required for proper stackwalking of RuntimeStub frame
     __ ret(lr);
 
-    SCCache::store_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start);
+    AOTCodeCache::store_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start);
     return start;
   }
 
@@ -5925,7 +5925,7 @@ class StubGenerator: public StubCodeGenerator {
     StubCodeMark mark(this, stub_id);
     address start = __ pc();
 
-    if (SCCache::load_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start)) {
+    if (AOTCodeCache::load_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start)) {
       return start;
     }
     const Register x     = r0;
@@ -5954,7 +5954,7 @@ class StubGenerator: public StubCodeGenerator {
     __ leave();
     __ ret(lr);
 
-    SCCache::store_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start);
+    AOTCodeCache::store_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start);
     return start;
   }
 
@@ -5965,7 +5965,7 @@ class StubGenerator: public StubCodeGenerator {
 
     address start = __ pc();
 
-    if (SCCache::load_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start)) {
+    if (AOTCodeCache::load_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start)) {
       return start;
     }
     const Register out     = r0;
@@ -5980,7 +5980,7 @@ class StubGenerator: public StubCodeGenerator {
     __ leave();
     __ ret(lr);
 
-    SCCache::store_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start);
+    AOTCodeCache::store_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start);
     return start;
   }
 

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -33,7 +33,7 @@
 #include "ci/ciArrayKlass.hpp"
 #include "ci/ciInstance.hpp"
 #include "ci/ciUtilities.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/oopMap.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/gc_globals.hpp"
@@ -533,17 +533,19 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
 
     case T_LONG: {
       assert(patch_code == lir_patch_none, "no patching handled here");
-      if (SCCache::is_on_for_write()) {
-        // SCA needs relocation info for card table base
+      if (AOTCodeCache::is_on_for_write()) {
+        // AOTCodeCache needs relocation info for card table base
         address b = c->as_pointer();
         if (is_card_table_address(b)) {
           __ lea(dest->as_register_lo(), ExternalAddress(b));
           break;
         }
+#if INCLUDE_CDS
         if (AOTRuntimeConstants::contains(b)) {
           __ load_aotrc_address(dest->as_register_lo(), b);
           break;
         }
+#endif
       }
       __ movptr(dest->as_register_lo(), (intptr_t)c->as_jlong());
       break;

--- a/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
@@ -23,9 +23,7 @@
  */
 
 #include "asm/macroAssembler.inline.hpp"
-#if INCLUDE_CDS
-#include "code/SCCache.hpp"
-#endif
+#include "code/aotCodeCache.hpp"
 #include "gc/g1/g1BarrierSet.hpp"
 #include "gc/g1/g1BarrierSetAssembler.hpp"
 #include "gc/g1/g1BarrierSetRuntime.hpp"
@@ -307,7 +305,7 @@ static void generate_post_barrier_fast_path(MacroAssembler* masm,
   // runtime constants area in the code cache otherwise we can compile
   // it as an immediate operand
 
-  if (SCCache::is_on_for_write()) {
+  if (AOTCodeCache::is_on_for_write()) {
     address grain_shift_addr = AOTRuntimeConstants::grain_shift_address();
     Register save = pick_different_reg(rcx, tmp, new_val, store_addr);
     __ push(save);
@@ -341,7 +339,7 @@ static void generate_post_barrier_fast_path(MacroAssembler* masm,
   // AOT code needs to load the barrier card shift from the aot
   // runtime constants area in the code cache otherwise we can compile
   // it as an immediate operand
-  if (SCCache::is_on_for_write()) {
+  if (AOTCodeCache::is_on_for_write()) {
     address card_shift_addr = AOTRuntimeConstants::card_shift_address();
     Register save = pick_different_reg(rcx, tmp);
     __ push(save);
@@ -360,8 +358,8 @@ static void generate_post_barrier_fast_path(MacroAssembler* masm,
   }
   // Do not use ExternalAddress to load 'byte_map_base', since 'byte_map_base' is NOT
   // a valid address and therefore is not properly handled by the relocation code.
-  if (SCCache::is_on_for_write()) {
-    // SCA needs relocation info for this address
+  if (AOTCodeCache::is_on_for_write()) {
+    // AOT code needs relocation info for this address
     __ lea(tmp2, ExternalAddress((address)ct->card_table()->byte_map_base()));   // tmp2 := card table base address
   } else {
     __ movptr(tmp2, (intptr_t)ct->card_table()->byte_map_base());   // tmp2 := card table base address
@@ -716,8 +714,8 @@ void G1BarrierSetAssembler::generate_c1_post_barrier_runtime_stub(StubAssembler*
   __ shrptr(card_addr, CardTable::card_shift());
   // Do not use ExternalAddress to load 'byte_map_base', since 'byte_map_base' is NOT
   // a valid address and therefore is not properly handled by the relocation code.
-  if (SCCache::is_on()) {
-    // SCA needs relocation info for this address
+  if (AOTCodeCache::is_on()) {
+    // AOT code needs relocation info for this address
     __ lea(cardtable, ExternalAddress((address)ct->card_table()->byte_map_base()));
   } else {
     __ movptr(cardtable, (intptr_t)ct->card_table()->byte_map_base());

--- a/src/hotspot/cpu/x86/gc/shared/cardTableBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/cardTableBarrierSetAssembler_x86.cpp
@@ -23,7 +23,7 @@
  */
 
 #include "asm/macroAssembler.inline.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
@@ -65,8 +65,8 @@ void CardTableBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembl
   __ shrptr(end, CardTable::card_shift());
   __ subptr(end, addr); // end --> cards count
 
-  if (SCCache::is_on_for_write()) {
-    // SCA needs relocation info for this address
+  if (AOTCodeCache::is_on_for_write()) {
+    // AOT code needs relocation info for this address
     __ lea(tmp, ExternalAddress((address)byte_map_base));
   } else {
     __ mov64(tmp, byte_map_base);
@@ -109,8 +109,8 @@ void CardTableBarrierSetAssembler::store_check(MacroAssembler* masm, Register ob
   // never need to be relocated. On 64bit however the value may be too
   // large for a 32bit displacement.
   intptr_t byte_map_base = (intptr_t)ct->byte_map_base();
-  if (SCCache::is_on_for_write()) {
-    // SCA needs relocation info for this address
+  if (AOTCodeCache::is_on_for_write()) {
+    // AOT code needs relocation info for this address
     ExternalAddress cardtable((address)byte_map_base);
     Address index(noreg, obj, Address::times_1);
     card_addr = __ as_Address(ArrayAddress(cardtable, index), rscratch1);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -24,7 +24,7 @@
 
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "compiler/compiler_globals.hpp"
 #include "compiler/disassembler.hpp"
@@ -760,7 +760,7 @@ void MacroAssembler::stop(const char* msg) {
   andq(rsp, -16); // align stack as required by ABI
   call(RuntimeAddress(CAST_FROM_FN_PTR(address, MacroAssembler::debug64)));
   hlt();
-  SCCache::add_C_string(msg);
+  AOTCodeCache::add_C_string(msg);
 }
 
 void MacroAssembler::warn(const char* msg) {
@@ -10896,8 +10896,8 @@ void MacroAssembler::restore_legacy_gprs() {
 void MacroAssembler::load_aotrc_address(Register reg, address a) {
 #if INCLUDE_CDS
   assert(AOTRuntimeConstants::contains(a), "address out of range for data area");
-  if (SCCache::is_on_for_write()) {
-    // all aotrc field addresses should be registered in the SCC address table
+  if (AOTCodeCache::is_on_for_write()) {
+    // all aotrc field addresses should be registered in the AOTCodeCache address table
     lea(reg, ExternalAddress(a));
   } else {
     mov64(reg, (uint64_t)a);

--- a/src/hotspot/cpu/x86/runtime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/runtime_x86_64.cpp
@@ -25,7 +25,7 @@
 #ifdef COMPILER2
 #include "asm/macroAssembler.hpp"
 #include "asm/macroAssembler.inline.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/vmreg.hpp"
 #include "interpreter/interpreter.hpp"
 #include "opto/runtime.hpp"
@@ -270,7 +270,7 @@ ExceptionBlob* OptoRuntime::generate_exception_blob() {
   CodeBuffer buffer(name, 2048, 1024);
 
   int pc_offset = 0;
-  if (SCCache::load_exception_blob(&buffer, &pc_offset)) {
+  if (AOTCodeCache::load_exception_blob(&buffer, &pc_offset)) {
     OopMapSet* oop_maps = new OopMapSet();
     oop_maps->add_gc_map(pc_offset, new OopMap(SimpleRuntimeFrame::framesize, 0));
 
@@ -367,7 +367,7 @@ ExceptionBlob* OptoRuntime::generate_exception_blob() {
   // Make sure all code is generated
   masm->flush();
 
-  SCCache::store_exception_blob(&buffer, pc_offset);
+  AOTCodeCache::store_exception_blob(&buffer, pc_offset);
   // Set exception blob
   return ExceptionBlob::create(&buffer, oop_maps, SimpleRuntimeFrame::framesize >> 1);
 }

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -25,7 +25,7 @@
 #include "asm/macroAssembler.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/vmIntrinsics.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/oopMap.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
@@ -3160,7 +3160,7 @@ address StubGenerator::generate_multiplyToLen() {
   StubCodeMark mark(this, stub_id);
   address start = __ pc();
 
-  if (SCCache::load_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start)) {
+  if (AOTCodeCache::load_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start)) {
     return start;
   }
 
@@ -3200,7 +3200,7 @@ address StubGenerator::generate_multiplyToLen() {
   __ leave(); // required for proper stackwalking of RuntimeStub frame
   __ ret(0);
 
-  SCCache::store_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start);
+  AOTCodeCache::store_stub(this, vmIntrinsics::_multiplyToLen, "multiplyToLen", start);
   return start;
 }
 
@@ -3274,7 +3274,7 @@ address StubGenerator::generate_squareToLen() {
   StubCodeMark mark(this, stub_id);
   address start = __ pc();
 
-  if (SCCache::load_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start)) {
+  if (AOTCodeCache::load_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start)) {
     return start;
   }
 
@@ -3305,7 +3305,7 @@ address StubGenerator::generate_squareToLen() {
   __ leave(); // required for proper stackwalking of RuntimeStub frame
   __ ret(0);
 
-  SCCache::store_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start);
+  AOTCodeCache::store_stub(this, vmIntrinsics::_squareToLen, "squareToLen", start);
   return start;
 }
 
@@ -3405,7 +3405,7 @@ address StubGenerator::generate_mulAdd() {
   StubCodeMark mark(this, stub_id);
   address start = __ pc();
 
-  if (SCCache::load_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start)) {
+  if (AOTCodeCache::load_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start)) {
     return start;
   }
 
@@ -3442,7 +3442,7 @@ address StubGenerator::generate_mulAdd() {
   __ leave(); // required for proper stackwalking of RuntimeStub frame
   __ ret(0);
 
-  SCCache::store_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start);
+  AOTCodeCache::store_stub(this, vmIntrinsics::_mulAdd, "mulAdd", start);
   return start;
 }
 

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -1850,7 +1850,7 @@ encode %{
 
   enc_class Java_To_Runtime(method meth) %{
     // No relocation needed
-    if (SCCache::is_on_for_write()) {
+    if (AOTCodeCache::is_on_for_write()) {
       // Created runtime_call_type relocation when caching code
       __ lea(r10, RuntimeAddress((address)$meth$$method));
     } else {

--- a/src/hotspot/share/adlc/main.cpp
+++ b/src/hotspot/share/adlc/main.cpp
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
   AD.addInclude(AD._CPP_file, "code/compiledIC.hpp");
   AD.addInclude(AD._CPP_file, "code/nativeInst.hpp");
   AD.addInclude(AD._CPP_file, "code/vmreg.inline.hpp");
-  AD.addInclude(AD._CPP_file, "code/SCCache.hpp");
+  AD.addInclude(AD._CPP_file, "code/aotCodeCache.hpp");
   AD.addInclude(AD._CPP_file, "gc/shared/collectedHeap.inline.hpp");
   AD.addInclude(AD._CPP_file, "oops/compressedOops.hpp");
   AD.addInclude(AD._CPP_file, "oops/markWord.hpp");
@@ -258,7 +258,7 @@ int main(int argc, char *argv[])
   AD.addInclude(AD._CPP_PEEPHOLE_file, "adfiles", get_basename(AD._HPP_file._name));
   AD.addInclude(AD._CPP_PIPELINE_file, "adfiles", get_basename(AD._HPP_file._name));
   AD.addInclude(AD._DFA_file, "adfiles", get_basename(AD._HPP_file._name));
-  AD.addInclude(AD._DFA_file, "code/SCCache.hpp");
+  AD.addInclude(AD._DFA_file, "code/aotCodeCache.hpp");
   AD.addInclude(AD._DFA_file, "oops/compressedOops.hpp");
   AD.addInclude(AD._DFA_file, "opto/cfgnode.hpp");  // Use PROB_MAX in predicate.
   AD.addInclude(AD._DFA_file, "opto/intrinsicnode.hpp");

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -90,7 +90,7 @@ public:
 // They are filled concurrently, and concatenated at the end.
 class CodeSection {
   friend class CodeBuffer;
-  friend class SCCReader;
+  friend class AOTCodeReader;
  public:
   typedef int csize_t;  // code size type; would be size_t except for history
 
@@ -516,7 +516,7 @@ typedef GrowableArray<SharedStubToInterpRequest> SharedStubToInterpRequests;
 class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
   friend class CodeSection;
   friend class StubCodeGenerator;
-  friend class SCCReader;
+  friend class AOTCodeReader;
 
  private:
   // CodeBuffers must be allocated on the stack except for a single

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -30,7 +30,7 @@
 #include "c1/c1_MacroAssembler.hpp"
 #include "c1/c1_Runtime1.hpp"
 #include "c1/c1_ValueType.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compilerDirectives.hpp"
 #include "interpreter/linkResolver.hpp"
@@ -54,7 +54,7 @@ bool Compiler::init_c1_runtime() {
   if (!Runtime1::initialize(buffer_blob)) {
     return false;
   }
-  SCCache::init_c1_table();
+  AOTCodeCache::init_c1_table();
   // initialize data structures
   ValueType::initialize();
   GraphBuilder::initialize();
@@ -254,21 +254,21 @@ bool Compiler::is_intrinsic_supported(vmIntrinsics::ID id) {
 
 void Compiler::compile_method(ciEnv* env, ciMethod* method, int entry_bci, bool install_code, DirectiveSet* directive) {
   CompileTask* task = env->task();
-  if (install_code && task->is_scc()) {
+  if (install_code && task->is_aot()) {
     assert(!task->preload(), "Pre-loading cached code is not implemeted for C1 code");
-    bool success = SCCache::load_nmethod(env, method, entry_bci, this, CompLevel(task->comp_level()));
+    bool success = AOTCodeCache::load_nmethod(env, method, entry_bci, this, CompLevel(task->comp_level()));
     if (success) {
       assert(task->is_success(), "sanity");
       return;
     }
-    SCCache::invalidate(task->scc_entry()); // mark scc_entry as not entrant
-    if (SCCache::is_code_load_thread_on() && !StoreCachedCode) {
-      // Bail out if failed to load cached code in SC thread
+    AOTCodeCache::invalidate(task->aot_code_entry()); // mark aot_code_entry as not entrant
+    if (AOTCodeCache::is_code_load_thread_on() && !StoreCachedCode) {
+      // Bail out if failed to load AOT code in AOT Code Caching thread
       // unless the code is updating.
-      env->record_failure("Failed to load cached code");
+      env->record_failure("Failed to load AOT code");
       return;
     }
-    task->clear_scc();
+    task->clear_aot();
   }
   BufferBlob* buffer_blob = CompilerThread::current()->get_buffer_blob();
   assert(buffer_blob != nullptr, "Must exist");

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -33,7 +33,7 @@
 #include "ci/ciInstance.hpp"
 #include "ci/ciObjArray.hpp"
 #include "ci/ciUtilities.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/compilerOracle.hpp"
 #include "gc/shared/barrierSet.hpp"
@@ -3193,13 +3193,13 @@ void LIRGenerator::increment_event_counter_impl(CodeEmitInfo* info,
       bailout("method counters allocation failed");
       return;
     }
-if (SCCache::is_on()) {
-    counter_holder = new_register(T_METADATA);
-    __ metadata2reg(counters_adr, counter_holder);
-} else {
-    counter_holder = new_pointer_register();
-    __ move(LIR_OprFact::intptrConst(counters_adr), counter_holder);
-}
+    if (AOTCodeCache::is_on()) {
+      counter_holder = new_register(T_METADATA);
+      __ metadata2reg(counters_adr, counter_holder);
+    } else {
+      counter_holder = new_pointer_register();
+      __ move(LIR_OprFact::intptrConst(counters_adr), counter_holder);
+    }
     offset = in_bytes(backedge ? MethodCounters::backedge_counter_offset() :
                                  MethodCounters::invocation_counter_offset());
   } else if (level == CompLevel_full_profile) {

--- a/src/hotspot/share/cds/aotLinkedClassBulkLoader.hpp
+++ b/src/hotspot/share/cds/aotLinkedClassBulkLoader.hpp
@@ -65,7 +65,7 @@ public:
   static void finish_loading_javabase_classes(TRAPS) NOT_CDS_RETURN;
   static void exit_on_exception(JavaThread* current);
   static void replay_training_at_init_for_preloaded_classes(TRAPS) NOT_CDS_RETURN;
-  static bool class_preloading_finished();
+  static bool class_preloading_finished() NOT_CDS_RETURN_(true);
   static void print_counters_on(outputStream* st) NOT_CDS_RETURN;
   static bool is_pending_aot_linked_class(Klass* k) NOT_CDS_RETURN_(false);
 };

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -43,7 +43,7 @@
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionaryShared.hpp"
 #include "classfile/vmClasses.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "interpreter/abstractInterpreter.hpp"
 #include "jvm.h"
 #include "logging/log.hpp"
@@ -330,8 +330,8 @@ void ArchiveBuilder::sort_klasses() {
 }
 
 address ArchiveBuilder::reserve_buffer() {
-  // SCCache::max_aot_code_size() accounts for cached code region.
-  size_t buffer_size = LP64_ONLY(CompressedClassSpaceSize) NOT_LP64(256 * M) + SCCache::max_aot_code_size();
+  // AOTCodeCache::max_aot_code_size() accounts for cached code region.
+  size_t buffer_size = LP64_ONLY(CompressedClassSpaceSize) NOT_LP64(256 * M) + AOTCodeCache::max_aot_code_size();
   ReservedSpace rs = MemoryReserver::reserve(buffer_size,
                                              MetaspaceShared::core_region_alignment(),
                                              os::vm_page_size());

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -32,7 +32,6 @@
 #include "classfile/classLoaderDataShared.hpp"
 #include "classfile/moduleEntry.hpp"
 #include "classfile/systemDictionaryShared.hpp"
-#include "code/SCCache.hpp"
 #include "include/jvm_io.h"
 #include "logging/log.hpp"
 #include "prims/jvmtiExport.hpp"

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -60,8 +60,8 @@
 #include "classfile/systemDictionaryShared.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/codeCache.hpp"
-#include "code/SCCache.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/precompiler.hpp"
 #include "gc/shared/gcVMOperations.hpp"
@@ -1098,8 +1098,8 @@ void MetaspaceShared::preload_and_dump_impl(StaticArchiveBuilder& builder, TRAPS
       {
         builder.start_cc_region();
         Precompiler::compile_cached_code(&builder, CHECK);
-        // Write the contents to cached code region and close SCCache before packing the region
-        SCCache::close();
+        // Write the contents to cached code region and close AOTCodeCache before packing the region
+        AOTCodeCache::close();
         builder.end_cc_region();
       }
       CDSConfig::disable_dumping_cached_code();
@@ -2100,7 +2100,7 @@ void MetaspaceShared::initialize_shared_spaces() {
   static_mapinfo->patch_heap_embedded_pointers();
   ArchiveHeapLoader::finish_initialization();
   Universe::load_archived_object_instances();
-  SCCache::initialize();
+  AOTCodeCache::initialize();
 
   // Close the mapinfo file
   static_mapinfo->close();
@@ -2155,7 +2155,7 @@ void MetaspaceShared::initialize_shared_spaces() {
 
     if (LoadCachedCode) {
       tty->print_cr("\n\nCached Code");
-      SCCache::print_on(tty);
+      AOTCodeCache::print_on(tty);
     }
 
     // collect shared symbols and strings

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -39,8 +39,8 @@
 
 class CompileTask;
 class OopMapSet;
-class SCCEntry;
-class SCCReader;
+class AOTCodeEntry;
+class AOTCodeReader;
 
 // ciEnv
 //
@@ -296,8 +296,8 @@ private:
 
   // Helper rountimes to factor out common code used by routines that register a method
   // i.e. register_aot_method() and register_method()
-  bool is_compilation_valid(JavaThread* thread, ciMethod* target, bool preload, bool install_code, CodeBuffer* code_buffer, SCCEntry* scc_entry);
-  void make_code_usable(JavaThread* thread, ciMethod* target, bool preload, int entry_bci, SCCEntry* scc_entry, nmethod* nm);
+  bool is_compilation_valid(JavaThread* thread, ciMethod* target, bool preload, bool install_code, CodeBuffer* code_buffer, AOTCodeEntry* aot_code_entry);
+  void make_code_usable(JavaThread* thread, ciMethod* target, bool preload, int entry_bci, AOTCodeEntry* aot_code_entry, nmethod* nm);
 
 public:
   enum {
@@ -387,7 +387,7 @@ public:
                            AsmRemarks& asm_remarks,
                            DbgStrings& dbg_strings,
 #endif /* PRODUCT */
-                           SCCReader* scc_reader);
+                           AOTCodeReader* aot_code_reader);
 
   // Register the result of a compilation.
   void register_method(ciMethod*                 target,
@@ -408,7 +408,7 @@ public:
                        bool                      has_scoped_access,
                        int                       immediate_oops_patched,
                        bool                      install_code,
-                       SCCEntry*                 entry = nullptr);
+                       AOTCodeEntry*             entry = nullptr);
 
   // Access to certain well known ciObjects.
 #define VM_CLASS_FUNC(name, ignore_s) \
@@ -499,11 +499,11 @@ public:
   void metadata_do(MetadataClosure* f) { _factory->metadata_do(f); }
 
 private:
-  SCCEntry* _scc_clinit_barriers_entry;
+  AOTCodeEntry* _aot_clinit_barriers_entry;
 
 public:
-  void  set_scc_clinit_barriers_entry(SCCEntry* entry) { _scc_clinit_barriers_entry = entry; }
-  SCCEntry* scc_clinit_barriers_entry()          const { return _scc_clinit_barriers_entry; }
+  void  set_aot_clinit_barriers_entry(AOTCodeEntry* entry) { _aot_clinit_barriers_entry = entry; }
+  AOTCodeEntry* aot_clinit_barriers_entry()          const { return _aot_clinit_barriers_entry; }
 
   // Replay support
 private:

--- a/src/hotspot/share/ci/ciField.cpp
+++ b/src/hotspot/share/ci/ciField.cpp
@@ -28,7 +28,7 @@
 #include "ci/ciUtilities.inline.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/vmClasses.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "interpreter/linkResolver.hpp"
 #include "oops/klass.inline.hpp"
@@ -315,7 +315,7 @@ ciConstant ciField::constant_value() {
   if (FoldStableValues && is_stable() && _constant_value.is_null_or_zero()) {
     return ciConstant();
   }
-  if (!SCCache::allow_const_field(_constant_value)) {
+  if (!AOTCodeCache::allow_const_field(_constant_value)) {
     return ciConstant();
   }
   return _constant_value;
@@ -331,7 +331,7 @@ ciConstant ciField::constant_value_of(ciObject* object) {
   if (FoldStableValues && is_stable() && field_value.is_null_or_zero()) {
     return ciConstant();
   }
-  if (!SCCache::allow_const_field(field_value)) {
+  if (!AOTCodeCache::allow_const_field(field_value)) {
     return ciConstant();
   }
   return field_value;

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1233,7 +1233,7 @@ int ciMethod::inline_instructions_size() {
   if (_inline_instructions_size == -1) {
     GUARDED_VM_ENTRY(
       nmethod* code = get_Method()->code();
-      if (code != nullptr && !code->is_scc() && (code->comp_level() == CompLevel_full_optimization)) {
+      if (code != nullptr && !code->is_aot() && (code->comp_level() == CompLevel_full_optimization)) {
         int isize = code->insts_end() - code->verified_entry_point() - code->skipped_instructions_size();
         _inline_instructions_size = isize > 0 ? isize : 0;
       } else {

--- a/src/hotspot/share/ci/ciObject.cpp
+++ b/src/hotspot/share/ci/ciObject.cpp
@@ -24,7 +24,7 @@
 
 #include "ci/ciObject.hpp"
 #include "ci/ciUtilities.inline.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/jniHandles.inline.hpp"
@@ -203,7 +203,7 @@ void ciObject::add_to_constant_value_cache(int off, ciConstant val) {
 // ------------------------------------------------------------------
 // ciObject::should_be_constant()
 bool ciObject::should_be_constant() {
-  if (ScavengeRootsInCode >= 2 && !(SCCache::is_on_for_write())) {
+  if (ScavengeRootsInCode >= 2 && !(AOTCodeCache::is_on_for_write())) {
     return true;  // force everybody to be a constant
   }
   if (is_null_object()) {
@@ -220,7 +220,7 @@ bool ciObject::should_be_constant() {
   }
   if ((klass()->is_subclass_of(env->MethodHandle_klass()) ||
        klass()->is_subclass_of(env->CallSite_klass())) &&
-      !(SCCache::is_on_for_write())) { // For now disable it when caching startup code.
+      !(AOTCodeCache::is_on_for_write())) { // For now disable it when caching startup code.
     // We want to treat these aggressively.
     return true;
   }

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -41,17 +41,17 @@
 #include "classfile/systemDictionary.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmIntrinsics.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/codeBlob.hpp"
 #include "code/codeCache.hpp"
 #include "code/oopRecorder.inline.hpp"
-#include "code/SCCache.hpp"
 #include "compiler/abstractCompiler.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compileTask.hpp"
 #include "gc/g1/g1BarrierSetRuntime.hpp"
 #include "gc/shared/gcConfig.hpp"
-#include "logging/log.hpp"
+#include "logging/logStream.hpp"
 #include "memory/memoryReserver.hpp"
 #include "memory/universe.hpp"
 #include "oops/klass.inline.hpp"
@@ -99,9 +99,9 @@
 #define O_BINARY 0     // otherwise do nothing.
 #endif
 
-const char* sccentry_kind_name[] = {
+const char* aot_code_entry_kind_name[] = {
 #define DECL_KIND_STRING(kind) XSTR(kind),
-  DO_SCCENTRY_KIND(DECL_KIND_STRING)
+  DO_AOTCODEENTRY_KIND(DECL_KIND_STRING)
 #undef DECL_KIND_STRING
 };
 
@@ -110,21 +110,21 @@ static elapsedTimer _t_totalRegister;
 static elapsedTimer _t_totalFind;
 static elapsedTimer _t_totalStore;
 
-SCCache* SCCache::_cache = nullptr;
+AOTCodeCache* AOTCodeCache::_cache = nullptr;
 
 static bool enable_timers() {
   return CITime || log_is_enabled(Info, init);
 }
 
 static void exit_vm_on_load_failure() {
-  // Treat SCC warnings as error when RequireSharedSpaces is on.
+  // Treat AOTCodeCache warnings as error when RequireSharedSpaces is on.
   if (RequireSharedSpaces) {
     vm_exit_during_initialization("Unable to use AOT Code Cache.", nullptr);
   }
 }
 
 static void exit_vm_on_store_failure() {
-  // Treat SCC warnings as error when RequireSharedSpaces is on.
+  // Treat AOTCodeCache warnings as error when RequireSharedSpaces is on.
   if (RequireSharedSpaces) {
     tty->print_cr("Unable to create startup cached code.");
     // Failure during AOT code caching, we don't want to dump core
@@ -132,11 +132,11 @@ static void exit_vm_on_store_failure() {
   }
 }
 
-uint SCCache::max_aot_code_size() {
+uint AOTCodeCache::max_aot_code_size() {
   return (uint)CachedCodeMaxSize;
 }
 
-void SCCache::initialize() {
+void AOTCodeCache::initialize() {
   if (LoadCachedCode && !UseSharedSpaces) {
     return;
   }
@@ -149,7 +149,7 @@ void SCCache::initialize() {
       FLAG_SET_DEFAULT(ClassInitBarrierMode, 1);
     }
   } else if (ClassInitBarrierMode > 0) {
-    log_info(scc, init)("Set ClassInitBarrierMode to 0 because StoreCachedCode and LoadCachedCode are false.");
+    log_info(aot, codecache, init)("Set ClassInitBarrierMode to 0 because StoreCachedCode and LoadCachedCode are false.");
     FLAG_SET_DEFAULT(ClassInitBarrierMode, 0);
   }
   if (LoadCachedCode || StoreCachedCode) {
@@ -165,7 +165,7 @@ void SCCache::initialize() {
   }
 }
 
-void SCCache::init2() {
+void AOTCodeCache::init2() {
   if (!is_on()) {
     return;
   }
@@ -175,7 +175,7 @@ void SCCache::init2() {
     address byte_map_base = ci_card_table_address_as<address>();
     if (is_on_for_write() && !external_word_Relocation::can_be_relocated(byte_map_base)) {
       // Bail out since we can't encode card table base address with relocation
-      log_warning(scc, init)("Can't create AOT Code Cache because card table base address is not relocatable: " INTPTR_FORMAT, p2i(byte_map_base));
+      log_warning(aot, codecache, init)("Can't create AOT Code Cache because card table base address is not relocatable: " INTPTR_FORMAT, p2i(byte_map_base));
       close();
       exit_vm_on_load_failure();
     }
@@ -196,18 +196,18 @@ void SCCache::init2() {
   init_early_stubs_table();
 }
 
-void SCCache::print_timers_on(outputStream* st) {
+void AOTCodeCache::print_timers_on(outputStream* st) {
   if (LoadCachedCode) {
-    st->print_cr ("    SC Load Time:         %7.3f s", _t_totalLoad.seconds());
+    st->print_cr ("    AOT Code Load Time:   %7.3f s", _t_totalLoad.seconds());
     st->print_cr ("      nmethod register:     %7.3f s", _t_totalRegister.seconds());
     st->print_cr ("      find cached code:     %7.3f s", _t_totalFind.seconds());
   }
   if (StoreCachedCode) {
-    st->print_cr ("    SC Store Time:        %7.3f s", _t_totalStore.seconds());
+    st->print_cr ("    AOT Code Store Time:  %7.3f s", _t_totalStore.seconds());
   }
 }
 
-bool SCCache::is_C3_on() {
+bool AOTCodeCache::is_C3_on() {
 #if INCLUDE_JVMCI
   if (UseJVMCICompiler) {
     return (StoreCachedCode || LoadCachedCode) && UseC2asC3;
@@ -216,18 +216,18 @@ bool SCCache::is_C3_on() {
   return false;
 }
 
-bool SCCache::is_code_load_thread_on() {
+bool AOTCodeCache::is_code_load_thread_on() {
   return UseCodeLoadThread && LoadCachedCode;
 }
 
-bool SCCache::gen_preload_code(ciMethod* m, int entry_bci) {
+bool AOTCodeCache::gen_preload_code(ciMethod* m, int entry_bci) {
   VM_ENTRY_MARK;
   return (entry_bci == InvocationEntryBci) && is_on() && _cache->gen_preload_code() &&
          CDSAccess::can_generate_cached_code(m->get_Method());
 }
 
 static void print_helper(nmethod* nm, outputStream* st) {
-  SCCache::iterate([&](SCCEntry* e) {
+  AOTCodeCache::iterate([&](AOTCodeEntry* e) {
     if (e->method() == nm->method()) {
       ResourceMark rm;
       stringStream ss;
@@ -246,44 +246,44 @@ static void print_helper(nmethod* nm, outputStream* st) {
   });
 }
 
-void SCCache::close() {
+void AOTCodeCache::close() {
   if (is_on()) {
-    if (SCCache::is_on_for_read()) {
+    if (AOTCodeCache::is_on_for_read()) {
       LogStreamHandle(Info, init) log;
       if (log.is_enabled()) {
         log.print_cr("AOT Code Cache statistics (when closed): ");
-        SCCache::print_statistics_on(&log);
+        AOTCodeCache::print_statistics_on(&log);
         log.cr();
-        SCCache::print_timers_on(&log);
+        AOTCodeCache::print_timers_on(&log);
 
-        LogStreamHandle(Info, scc, init) log1;
+        LogStreamHandle(Info, aot, codecache, init) log1;
         if (log1.is_enabled()) {
-          SCCache::print_unused_entries_on(&log1);
+          AOTCodeCache::print_unused_entries_on(&log1);
         }
 
-        LogStreamHandle(Info, scc, codecache) info_scc;
+        LogStreamHandle(Info, aot, codecache) aot_info;
         // need a lock to traverse the code cache
         MutexLocker locker(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-        if (info_scc.is_enabled()) {
+        if (aot_info.is_enabled()) {
           NMethodIterator iter(NMethodIterator::all);
           while (iter.next()) {
             nmethod* nm = iter.method();
             if (nm->is_in_use() && !nm->is_native_method() && !nm->is_osr_method()) {
-              info_scc.print("%5d:%c%c%c%d:", nm->compile_id(),
+              aot_info.print("%5d:%c%c%c%d:", nm->compile_id(),
                              (nm->method()->is_shared() ? 'S' : ' '),
-                             (nm->is_scc() ? 'A' : ' '),
+                             (nm->is_aot() ? 'A' : ' '),
                              (nm->preloaded() ? 'P' : ' '),
                              nm->comp_level());
-              print_helper(nm, &info_scc);
-              info_scc.print(": ");
-              CompileTask::print(&info_scc, nm, nullptr, true /*short_form*/);
+              print_helper(nm, &aot_info);
+              aot_info.print(": ");
+              CompileTask::print(&aot_info, nm, nullptr, true /*short_form*/);
 
-              LogStreamHandle(Debug, scc, codecache) debug_scc;
-              if (debug_scc.is_enabled()) {
+              LogStreamHandle(Debug, aot, codecache) aot_debug;
+              if (aot_debug.is_enabled()) {
                 MethodTrainingData* mtd = MethodTrainingData::find(methodHandle(Thread::current(), nm->method()));
                 if (mtd != nullptr) {
                   mtd->iterate_compiles([&](CompileTrainingData* ctd) {
-                    debug_scc.print("     CTD: "); ctd->print_on(&debug_scc); debug_scc.cr();
+                    aot_debug.print("     CTD: "); ctd->print_on(&aot_debug); aot_debug.cr();
                   });
                 }
               }
@@ -298,21 +298,21 @@ void SCCache::close() {
   }
 }
 
-void SCCache::invalidate(SCCEntry* entry) {
+void AOTCodeCache::invalidate(AOTCodeEntry* entry) {
   // This could be concurent execution
   if (entry != nullptr && is_on()) { // Request could come after cache is closed.
     _cache->invalidate_entry(entry);
   }
 }
 
-bool SCCache::is_loaded(SCCEntry* entry) {
+bool AOTCodeCache::is_loaded(AOTCodeEntry* entry) {
   if (is_on() && _cache->cache_buffer() != nullptr) {
     return (uint)((char*)entry - _cache->cache_buffer()) < _cache->load_size();
   }
   return false;
 }
 
-void SCCache::preload_code(JavaThread* thread) {
+void AOTCodeCache::preload_code(JavaThread* thread) {
   if ((ClassInitBarrierMode == 0) || !is_on_for_read()) {
     return;
   }
@@ -322,7 +322,7 @@ void SCCache::preload_code(JavaThread* thread) {
   _cache->preload_startup_code(thread);
 }
 
-SCCEntry* SCCache::find_code_entry(const methodHandle& method, uint comp_level) {
+AOTCodeEntry* AOTCodeCache::find_code_entry(const methodHandle& method, uint comp_level) {
   switch (comp_level) {
     case CompLevel_simple:
       if ((DisableCachedCode & (1 << 0)) != 0) {
@@ -342,7 +342,7 @@ SCCEntry* SCCache::find_code_entry(const methodHandle& method, uint comp_level) 
 
     default: return nullptr; // Level 1, 2, and 4 only
   }
-  TraceTime t1("SC total find code time", &_t_totalFind, enable_timers(), false);
+  TraceTime t1("Total time to find AOT code", &_t_totalFind, enable_timers(), false);
   if (is_on() && _cache->cache_buffer() != nullptr) {
     MethodData* md = method->method_data();
     uint decomp = (md == nullptr) ? 0 : md->decompile_count();
@@ -350,23 +350,23 @@ SCCEntry* SCCache::find_code_entry(const methodHandle& method, uint comp_level) 
     ResourceMark rm;
     const char* target_name = method->name_and_sig_as_C_string();
     uint hash = java_lang_String::hash_code((const jbyte*)target_name, (int)strlen(target_name));
-    SCCEntry* entry = _cache->find_entry(SCCEntry::Code, hash, comp_level, decomp);
+    AOTCodeEntry* entry = _cache->find_entry(AOTCodeEntry::Code, hash, comp_level, decomp);
     if (entry == nullptr) {
-      log_info(scc, nmethod)("Missing entry for '%s' (comp_level %d, decomp: %d, hash: " UINT32_FORMAT_X_0 ")", target_name, (uint)comp_level, decomp, hash);
+      log_info(aot, codecache, nmethod)("Missing entry for '%s' (comp_level %d, decomp: %d, hash: " UINT32_FORMAT_X_0 ")", target_name, (uint)comp_level, decomp, hash);
 #ifdef ASSERT
     } else {
       uint name_offset = entry->offset() + entry->name_offset();
       uint name_size   = entry->name_size(); // Includes '/0'
       const char* name = _cache->cache_buffer() + name_offset;
       if (strncmp(target_name, name, name_size) != 0) {
-        assert(false, "SCA: saved nmethod's name '%s' is different from '%s', hash: " UINT32_FORMAT_X_0, name, target_name, hash);
+        assert(false, "AOTCodeCache: saved nmethod's name '%s' is different from '%s', hash: " UINT32_FORMAT_X_0, name, target_name, hash);
       }
 #endif
     }
 
     DirectiveSet* directives = DirectivesStack::getMatchingDirective(method, nullptr);
     if (directives->IgnorePrecompiledOption) {
-      LogStreamHandle(Info, scc, compilation) log;
+      LogStreamHandle(Info, aot, codecache, compilation) log;
       if (log.is_enabled()) {
         log.print("Ignore cached code entry on level %d for ", comp_level);
         method->print_value_on(&log);
@@ -379,13 +379,13 @@ SCCEntry* SCCache::find_code_entry(const methodHandle& method, uint comp_level) 
   return nullptr;
 }
 
-void SCCache::add_C_string(const char* str) {
+void AOTCodeCache::add_C_string(const char* str) {
   if (is_on_for_write()) {
     _cache->add_new_C_string(str);
   }
 }
 
-bool SCCache::allow_const_field(ciConstant& value) {
+bool AOTCodeCache::allow_const_field(ciConstant& value) {
   return !is_on() || !StoreCachedCode // Restrict only when we generate cache
         // Can not trust primitive too   || !is_reference_type(value.basic_type())
         // May disable this too for now  || is_reference_type(value.basic_type()) && value.as_object()->should_be_constant()
@@ -393,8 +393,8 @@ bool SCCache::allow_const_field(ciConstant& value) {
 }
 
 
-bool SCCache::open_cache() {
-  SCCache* cache = new SCCache();
+bool AOTCodeCache::open_cache() {
+  AOTCodeCache* cache = new AOTCodeCache();
   if (cache->failed()) {
     delete cache;
     _cache = nullptr;
@@ -449,7 +449,7 @@ CachedCodeDirectory* CachedCodeDirectory::create() {
 
 #define DATA_ALIGNMENT HeapWordSize
 
-SCCache::SCCache() {
+AOTCodeCache::AOTCodeCache() {
   _load_header = nullptr;
   _for_read  = LoadCachedCode;
   _for_write = StoreCachedCode;
@@ -480,12 +480,12 @@ SCCache::SCCache() {
     // Read cache
     ReservedSpace rs = MemoryReserver::reserve(CDSAccess::get_cached_code_size(), mtCode);
     if (!rs.is_reserved()) {
-      log_warning(scc, init)("Failed to reserved %u bytes of memory for mapping cached code region in AOT Cache", (uint)CDSAccess::get_cached_code_size());
+      log_warning(aot, codecache, init)("Failed to reserved %u bytes of memory for mapping cached code region in AOT Cache", (uint)CDSAccess::get_cached_code_size());
       set_failed();
       return;
     }
     if (!CDSAccess::map_cached_code(rs)) {
-      log_warning(scc, init)("Failed to read/mmap cached code region in AOT Cache");
+      log_warning(aot, codecache, init)("Failed to read/mmap cached code region in AOT Cache");
       set_failed();
       return;
     }
@@ -495,14 +495,14 @@ SCCache::SCCache() {
     _load_size = _cached_code_directory->_aot_code_size;
     _load_buffer = _cached_code_directory->_aot_code_data;
     assert(is_aligned(_load_buffer, DATA_ALIGNMENT), "load_buffer is not aligned");
-    log_info(scc, init)("Mapped %u bytes at address " INTPTR_FORMAT " from AOT Code Cache", _load_size, p2i(_load_buffer));
+    log_info(aot, codecache, init)("Mapped %u bytes at address " INTPTR_FORMAT " from AOT Code Cache", _load_size, p2i(_load_buffer));
 
-    _load_header = (SCCHeader*)addr(0);
+    _load_header = (AOTCodeCache::Header*)addr(0);
     if (!_load_header->verify_config(_load_size)) {
       set_failed();
       return;
     }
-    log_info(scc, init)("Read header from AOT Code Cache");
+    log_info(aot, codecache, init)("Read header from AOT Code Cache");
     if (_load_header->has_meta_ptrs()) {
       assert(UseSharedSpaces, "should be verified already");
       _use_meta_ptrs = true; // Regardless UseMetadataPointers
@@ -517,52 +517,52 @@ SCCache::SCCache() {
     _C_store_buffer = NEW_C_HEAP_ARRAY(char, max_aot_code_size() + DATA_ALIGNMENT, mtCode);
     _store_buffer = align_up(_C_store_buffer, DATA_ALIGNMENT);
     // Entries allocated at the end of buffer in reverse (as on stack).
-    _store_entries = (SCCEntry*)align_up(_C_store_buffer + max_aot_code_size(), DATA_ALIGNMENT);
-    log_info(scc, init)("Allocated store buffer at address " INTPTR_FORMAT " of size " UINT32_FORMAT " bytes", p2i(_store_buffer), max_aot_code_size());
+    _store_entries = (AOTCodeEntry*)align_up(_C_store_buffer + max_aot_code_size(), DATA_ALIGNMENT);
+    log_info(aot, codecache, init)("Allocated store buffer at address " INTPTR_FORMAT " of size " UINT32_FORMAT " bytes", p2i(_store_buffer), max_aot_code_size());
   }
-  _table = new SCAddressTable();
+  _table = new AOTCodeAddressTable();
 }
 
-void SCCache::init_extrs_table() {
-  SCAddressTable* table = addr_table();
+void AOTCodeCache::init_extrs_table() {
+  AOTCodeAddressTable* table = addr_table();
   if (table != nullptr) {
     table->init_extrs();
   }
 }
-void SCCache::init_early_stubs_table() {
-  SCAddressTable* table = addr_table();
+void AOTCodeCache::init_early_stubs_table() {
+  AOTCodeAddressTable* table = addr_table();
   if (table != nullptr) {
     table->init_early_stubs();
   }
 }
-void SCCache::init_shared_blobs_table() {
-  SCAddressTable* table = addr_table();
+void AOTCodeCache::init_shared_blobs_table() {
+  AOTCodeAddressTable* table = addr_table();
   if (table != nullptr) {
     table->init_shared_blobs();
   }
 }
-void SCCache::init_stubs_table() {
-  SCAddressTable* table = addr_table();
+void AOTCodeCache::init_stubs_table() {
+  AOTCodeAddressTable* table = addr_table();
   if (table != nullptr) {
     table->init_stubs();
   }
 }
 
-void SCCache::init_opto_table() {
-  SCAddressTable* table = addr_table();
+void AOTCodeCache::init_opto_table() {
+  AOTCodeAddressTable* table = addr_table();
   if (table != nullptr) {
     table->init_opto();
   }
 }
 
-void SCCache::init_c1_table() {
-  SCAddressTable* table = addr_table();
+void AOTCodeCache::init_c1_table() {
+  AOTCodeAddressTable* table = addr_table();
   if (table != nullptr) {
     table->init_c1();
   }
 }
 
-void SCConfig::record(bool use_meta_ptrs) {
+void AOTCodeCache::Config::record(bool use_meta_ptrs) {
   _flags = 0;
   if (use_meta_ptrs) {
     _flags |= metadataPointers;
@@ -598,85 +598,85 @@ void SCConfig::record(bool use_meta_ptrs) {
   _gc                    = (uint)Universe::heap()->kind();
 }
 
-bool SCConfig::verify() const {
+bool AOTCodeCache::Config::verify() const {
 #ifdef ASSERT
   if ((_flags & debugVM) == 0) {
-    log_warning(scc, init)("Disable AOT Code: it was created by product VM, it can't be used by debug VM");
+    log_warning(aot, codecache, init)("Disable AOT Code: it was created by product VM, it can't be used by debug VM");
     return false;
   }
 #else
   if ((_flags & debugVM) != 0) {
-    log_warning(scc, init)("Disable AOT Code: it was created by debug VM, it can't be used by product VM");
+    log_warning(aot, codecache, init)("Disable AOT Code: it was created by debug VM, it can't be used by product VM");
     return false;
   }
 #endif
 
-  CollectedHeap::Name scc_gc = (CollectedHeap::Name)_gc;
-  if (scc_gc != Universe::heap()->kind()) {
-    log_warning(scc, init)("Disable AOT Code: it was created with different GC: %s vs current %s", GCConfig::hs_err_name(scc_gc), GCConfig::hs_err_name());
+  CollectedHeap::Name aot_gc = (CollectedHeap::Name)_gc;
+  if (aot_gc != Universe::heap()->kind()) {
+    log_warning(aot, codecache, init)("Disable AOT Code: it was created with different GC: %s vs current %s", GCConfig::hs_err_name(aot_gc), GCConfig::hs_err_name());
     return false;
   }
 
   if (((_flags & compressedOops) != 0) != UseCompressedOops) {
-    log_warning(scc, init)("Disable AOT Code: it was created with UseCompressedOops = %s", UseCompressedOops ? "false" : "true");
+    log_warning(aot, codecache, init)("Disable AOT Code: it was created with UseCompressedOops = %s", UseCompressedOops ? "false" : "true");
     return false;
   }
   if (((_flags & compressedClassPointers) != 0) != UseCompressedClassPointers) {
-    log_warning(scc, init)("Disable AOT Code: it was created with UseCompressedClassPointers = %s", UseCompressedClassPointers ? "false" : "true");
+    log_warning(aot, codecache, init)("Disable AOT Code: it was created with UseCompressedClassPointers = %s", UseCompressedClassPointers ? "false" : "true");
     return false;
   }
 
   if (((_flags & systemClassAssertions) != 0) != JavaAssertions::systemClassDefault()) {
-    log_warning(scc, init)("Disable AOT Code: it was created with JavaAssertions::systemClassDefault() = %s", JavaAssertions::systemClassDefault() ? "disabled" : "enabled");
+    log_warning(aot, codecache, init)("Disable AOT Code: it was created with JavaAssertions::systemClassDefault() = %s", JavaAssertions::systemClassDefault() ? "disabled" : "enabled");
     return false;
   }
   if (((_flags & userClassAssertions) != 0) != JavaAssertions::userClassDefault()) {
-    log_warning(scc, init)("Disable AOT Code: it was created with JavaAssertions::userClassDefault() = %s", JavaAssertions::userClassDefault() ? "disabled" : "enabled");
+    log_warning(aot, codecache, init)("Disable AOT Code: it was created with JavaAssertions::userClassDefault() = %s", JavaAssertions::userClassDefault() ? "disabled" : "enabled");
     return false;
   }
 
   if (((_flags & enableContendedPadding) != 0) != EnableContended) {
-    log_warning(scc, init)("Disable AOT Code: it was created with EnableContended = %s", EnableContended ? "false" : "true");
+    log_warning(aot, codecache, init)("Disable AOT Code: it was created with EnableContended = %s", EnableContended ? "false" : "true");
     return false;
   }
   if (((_flags & restrictContendedPadding) != 0) != RestrictContended) {
-    log_warning(scc, init)("Disable AOT Code: it was created with RestrictContended = %s", RestrictContended ? "false" : "true");
+    log_warning(aot, codecache, init)("Disable AOT Code: it was created with RestrictContended = %s", RestrictContended ? "false" : "true");
     return false;
   }
   if (_compressedOopShift != (uint)CompressedOops::shift()) {
-    log_warning(scc, init)("Disable AOT Code: it was created with CompressedOops::shift() = %d vs current %d", _compressedOopShift, CompressedOops::shift());
+    log_warning(aot, codecache, init)("Disable AOT Code: it was created with CompressedOops::shift() = %d vs current %d", _compressedOopShift, CompressedOops::shift());
     return false;
   }
   if (_compressedKlassShift != (uint)CompressedKlassPointers::shift()) {
-    log_warning(scc, init)("Disable AOT Code: it was created with CompressedKlassPointers::shift() = %d vs current %d", _compressedKlassShift, CompressedKlassPointers::shift());
+    log_warning(aot, codecache, init)("Disable AOT Code: it was created with CompressedKlassPointers::shift() = %d vs current %d", _compressedKlassShift, CompressedKlassPointers::shift());
     return false;
   }
   if (_contendedPaddingWidth != (uint)ContendedPaddingWidth) {
-    log_warning(scc, init)("Disable AOT Code: it was created with ContendedPaddingWidth = %d vs current %d", _contendedPaddingWidth, ContendedPaddingWidth);
+    log_warning(aot, codecache, init)("Disable AOT Code: it was created with ContendedPaddingWidth = %d vs current %d", _contendedPaddingWidth, ContendedPaddingWidth);
     return false;
   }
   if (_objectAlignment != (uint)ObjectAlignmentInBytes) {
-    log_warning(scc, init)("Disable AOT Code: it was created with ObjectAlignmentInBytes = %d vs current %d", _objectAlignment, ObjectAlignmentInBytes);
+    log_warning(aot, codecache, init)("Disable AOT Code: it was created with ObjectAlignmentInBytes = %d vs current %d", _objectAlignment, ObjectAlignmentInBytes);
     return false;
   }
   return true;
 }
 
-bool SCCHeader::verify_config(uint load_size) const {
-  if (_version != SCC_VERSION) {
-    log_warning(scc, init)("Disable AOT Code: different SCC version %d vs %d recorded in AOT Cache", SCC_VERSION, _version);
+bool AOTCodeCache::Header::verify_config(uint load_size) const {
+  if (_version != AOT_CODE_VERSION) {
+    log_warning(aot, codecache, init)("Disable AOT Code: different AOT Code version %d vs %d recorded in AOT Cache", AOT_CODE_VERSION, _version);
     return false;
   }
   if (_cache_size != load_size) {
-    log_warning(scc, init)("Disable AOT Code: different cached code size %d vs %d recorded in AOT Cache", load_size, _cache_size);
+    log_warning(aot, codecache, init)("Disable AOT Code: different cached code size %d vs %d recorded in AOT Cache", load_size, _cache_size);
     return false;
   }
   return true;
 }
 
-volatile int SCCache::_nmethod_readers = 0;
+volatile int AOTCodeCache::_nmethod_readers = 0;
 
-SCCache::~SCCache() {
+AOTCodeCache::~AOTCodeCache() {
   if (_closing) {
     return; // Already closed
   }
@@ -705,24 +705,24 @@ SCCache::~SCCache() {
   }
 }
 
-SCCache* SCCache::open_for_read() {
-  if (SCCache::is_on_for_read()) {
-    return SCCache::cache();
+AOTCodeCache* AOTCodeCache::open_for_read() {
+  if (AOTCodeCache::is_on_for_read()) {
+    return AOTCodeCache::cache();
   }
   return nullptr;
 }
 
-SCCache* SCCache::open_for_write() {
-  if (SCCache::is_on_for_write()) {
-    SCCache* cache = SCCache::cache();
+AOTCodeCache* AOTCodeCache::open_for_write() {
+  if (AOTCodeCache::is_on_for_write()) {
+    AOTCodeCache* cache = AOTCodeCache::cache();
     cache->clear_lookup_failed(); // Reset bit
     return cache;
   }
   return nullptr;
 }
 
-bool SCCache::is_address_in_aot_cache(address p) {
-  SCCache* cache = open_for_read();
+bool AOTCodeCache::is_address_in_aot_cache(address p) {
+  AOTCodeCache* cache = open_for_read();
   if (cache == nullptr) {
     return false;
   }
@@ -745,10 +745,10 @@ static void copy_bytes(const char* from, address to, uint size) {
     by_words = false;
     Copy::conjoint_jbytes(from, to, (size_t)size);
   }
-  log_trace(scc)("Copied %d bytes as %s from " INTPTR_FORMAT " to " INTPTR_FORMAT, size, (by_words ? "HeapWord" : "bytes"), p2i(from), p2i(to));
+  log_trace(aot, codecache)("Copied %d bytes as %s from " INTPTR_FORMAT " to " INTPTR_FORMAT, size, (by_words ? "HeapWord" : "bytes"), p2i(from), p2i(to));
 }
 
-void SCCReader::set_read_position(uint pos) {
+void AOTCodeReader::set_read_position(uint pos) {
   if (pos == _read_position) {
     return;
   }
@@ -756,7 +756,7 @@ void SCCReader::set_read_position(uint pos) {
   _read_position = pos;
 }
 
-bool SCCache::set_write_position(uint pos) {
+bool AOTCodeCache::set_write_position(uint pos) {
   if (pos == _write_position) {
     return true;
   }
@@ -770,7 +770,7 @@ bool SCCache::set_write_position(uint pos) {
 
 static char align_buffer[256] = { 0 };
 
-bool SCCache::align_write() {
+bool AOTCodeCache::align_write() {
   // We are not executing code from cache - we copy it by bytes first.
   // No need for big alignment (or at all).
   uint padding = DATA_ALIGNMENT - (_write_position & (DATA_ALIGNMENT - 1));
@@ -781,16 +781,16 @@ bool SCCache::align_write() {
   if (n != padding) {
     return false;
   }
-  log_trace(scc)("Adjust write alignment in AOT Code Cache");
+  log_trace(aot, codecache)("Adjust write alignment in AOT Code Cache");
   return true;
 }
 
 // Check to see if AOT code cache has required space to store "nbytes" of data
-address SCCache::reserve_bytes(uint nbytes) {
+address AOTCodeCache::reserve_bytes(uint nbytes) {
   assert(for_write(), "Code Cache file is not created");
   uint new_position = _write_position + nbytes;
   if (new_position >= (uint)((char*)_store_entries - _store_buffer)) {
-    log_warning(scc)("Failed to ensure %d bytes at offset %d in AOT Code Cache. Increase CachedCodeMaxSize.",
+    log_warning(aot, codecache)("Failed to ensure %d bytes at offset %d in AOT Code Cache. Increase CachedCodeMaxSize.",
                      nbytes, _write_position);
     set_failed();
     exit_vm_on_store_failure();
@@ -804,21 +804,21 @@ address SCCache::reserve_bytes(uint nbytes) {
   return buffer;
 }
 
-uint SCCache::write_bytes(const void* buffer, uint nbytes) {
+uint AOTCodeCache::write_bytes(const void* buffer, uint nbytes) {
   assert(for_write(), "Code Cache file is not created");
   if (nbytes == 0) {
     return 0;
   }
   uint new_position = _write_position + nbytes;
   if (new_position >= (uint)((char*)_store_entries - _store_buffer)) {
-    log_warning(scc)("Failed to write %d bytes at offset %d to AOT Code Cache. Increase CachedCodeMaxSize.",
+    log_warning(aot, codecache)("Failed to write %d bytes at offset %d to AOT Code Cache. Increase CachedCodeMaxSize.",
                      nbytes, _write_position);
     set_failed();
     exit_vm_on_store_failure();
     return 0;
   }
   copy_bytes((const char* )buffer, (address)(_store_buffer + _write_position), nbytes);
-  log_trace(scc)("Wrote %d bytes at offset %d to AOT Code Cache", nbytes, _write_position);
+  log_trace(aot, codecache)("Wrote %d bytes at offset %d to AOT Code Cache", nbytes, _write_position);
   _write_position += nbytes;
   if (_store_size < _write_position) {
     _store_size = _write_position;
@@ -826,14 +826,14 @@ uint SCCache::write_bytes(const void* buffer, uint nbytes) {
   return nbytes;
 }
 
-void SCCEntry::update_method_for_writing() {
+void AOTCodeEntry::update_method_for_writing() {
   if (_method != nullptr) {
     _method = CDSAccess::method_in_cached_code(_method);
   }
 }
 
-void SCCEntry::print(outputStream* st) const {
-  st->print_cr(" SCA entry " INTPTR_FORMAT " [kind: %d, id: " UINT32_FORMAT_X_0 ", offset: %d, size: %d, comp_level: %d, comp_id: %d, decompiled: %d, %s%s%s%s%s]",
+void AOTCodeEntry::print(outputStream* st) const {
+  st->print_cr(" AOT Code Cache entry " INTPTR_FORMAT " [kind: %d, id: " UINT32_FORMAT_X_0 ", offset: %d, size: %d, comp_level: %d, comp_id: %d, decompiled: %d, %s%s%s%s%s]",
                p2i(this), (int)_kind, _id, _offset, _size, _comp_level, _comp_id, _decompile,
                (_not_entrant? "not_entrant" : "entrant"),
                (_loaded ? ", loaded" : ""),
@@ -842,7 +842,7 @@ void SCCEntry::print(outputStream* st) const {
                (_ignore_decompile ? ", ignore_decomp" : ""));
 }
 
-void* SCCEntry::operator new(size_t x, SCCache* cache) {
+void* AOTCodeEntry::operator new(size_t x, AOTCodeCache* cache) {
   return (void*)(cache->add_entry());
 }
 
@@ -852,7 +852,7 @@ bool skip_preload(methodHandle mh) {
   }
   DirectiveSet* directives = DirectivesStack::getMatchingDirective(mh, nullptr);
   if (directives->DontPreloadOption) {
-    LogStreamHandle(Info, scc, init) log;
+    LogStreamHandle(Info, aot, codecache, init) log;
     if (log.is_enabled()) {
       log.print("Exclude preloading code for ");
       mh->print_value_on(&log);
@@ -862,7 +862,7 @@ bool skip_preload(methodHandle mh) {
   return false;
 }
 
-void SCCache::preload_startup_code(TRAPS) {
+void AOTCodeCache::preload_startup_code(TRAPS) {
   if (CompilationPolicy::compiler_count(CompLevel_full_optimization) == 0) {
     // Since we reuse the CompilerBroker API to install cached code, we're required to have a JIT compiler for the
     // level we want (that is CompLevel_full_optimization).
@@ -873,17 +873,17 @@ void SCCache::preload_startup_code(TRAPS) {
   if (_load_entries == nullptr) {
     // Read it
     _search_entries = (uint*)addr(_load_header->entries_offset()); // [id, index]
-    _load_entries = (SCCEntry*)(_search_entries + 2 * count);
-    log_info(scc, init)("Read %d entries table at offset %d from AOT Code Cache", count, _load_header->entries_offset());
+    _load_entries = (AOTCodeEntry*)(_search_entries + 2 * count);
+    log_info(aot, codecache, init)("Read %d entries table at offset %d from AOT Code Cache", count, _load_header->entries_offset());
   }
   uint preload_entries_count = _load_header->preload_entries_count();
   if (preload_entries_count > 0) {
     uint* entries_index = (uint*)addr(_load_header->preload_entries_offset());
-    log_info(scc, init)("Load %d preload entries from AOT Code Cache", preload_entries_count);
+    log_info(aot, codecache, init)("Load %d preload entries from AOT Code Cache", preload_entries_count);
     uint count = MIN2(preload_entries_count, SCLoadStop);
     for (uint i = SCLoadStart; i < count; i++) {
       uint index = entries_index[i];
-      SCCEntry* entry = &(_load_entries[index]);
+      AOTCodeEntry* entry = &(_load_entries[index]);
       if (entry->not_entrant()) {
         continue;
       }
@@ -897,33 +897,33 @@ void SCCache::preload_startup_code(TRAPS) {
         assert(!HAS_PENDING_EXCEPTION, "");
         mh->method_holder()->link_class(THREAD);
         if (HAS_PENDING_EXCEPTION) {
-          LogStreamHandle(Info, scc) log;
+          LogStreamHandle(Info, aot, codecache) log;
           if (log.is_enabled()) {
             ResourceMark rm;
             log.print("Linkage failed for %s: ", mh->method_holder()->external_name());
             THREAD->pending_exception()->print_value_on(&log);
-            if (log_is_enabled(Debug, scc)) {
+            if (log_is_enabled(Debug, aot, codecache)) {
               THREAD->pending_exception()->print_on(&log);
             }
           }
           CLEAR_PENDING_EXCEPTION;
         }
       }
-      if (mh->scc_entry() != nullptr) {
+      if (mh->aot_code_entry() != nullptr) {
         // Second C2 compilation of the same method could happen for
         // different reasons without marking first entry as not entrant.
         continue; // Keep old entry to avoid issues
       }
-      mh->set_scc_entry(entry);
+      mh->set_aot_code_entry(entry);
       CompileBroker::compile_method(mh, InvocationEntryBci, CompLevel_full_optimization, methodHandle(), 0, false, CompileTask::Reason_Preload, CHECK);
     }
   }
 }
 
-static bool check_entry(SCCEntry::Kind kind, uint id, uint comp_level, uint decomp, SCCEntry* entry) {
+static bool check_entry(AOTCodeEntry::Kind kind, uint id, uint comp_level, uint decomp, AOTCodeEntry* entry) {
   if (entry->kind() == kind) {
     assert(entry->id() == id, "sanity");
-    if (kind != SCCEntry::Code || (!entry->not_entrant() && !entry->has_clinit_barriers() &&
+    if (kind != AOTCodeEntry::Code || (!entry->not_entrant() && !entry->has_clinit_barriers() &&
                                   (entry->comp_level() == comp_level) &&
                                   (entry->ignore_decompile() || entry->decompile() == decomp))) {
       return true; // Found
@@ -932,14 +932,14 @@ static bool check_entry(SCCEntry::Kind kind, uint id, uint comp_level, uint deco
   return false;
 }
 
-SCCEntry* SCCache::find_entry(SCCEntry::Kind kind, uint id, uint comp_level, uint decomp) {
+AOTCodeEntry* AOTCodeCache::find_entry(AOTCodeEntry::Kind kind, uint id, uint comp_level, uint decomp) {
   assert(_for_read, "sanity");
   uint count = _load_header->entries_count();
   if (_load_entries == nullptr) {
     // Read it
     _search_entries = (uint*)addr(_load_header->entries_offset()); // [id, index]
-    _load_entries = (SCCEntry*)(_search_entries + 2 * count);
-    log_info(scc, init)("Read %d entries table at offset %d from AOT Code Cache", count, _load_header->entries_offset());
+    _load_entries = (AOTCodeEntry*)(_search_entries + 2 * count);
+    log_info(aot, codecache, init)("Read %d entries table at offset %d from AOT Code Cache", count, _load_header->entries_offset());
   }
   // Binary search
   int l = 0;
@@ -950,7 +950,7 @@ SCCEntry* SCCache::find_entry(SCCEntry::Kind kind, uint id, uint comp_level, uin
     uint is = _search_entries[ix];
     if (is == id) {
       int index = _search_entries[ix + 1];
-      SCCEntry* entry = &(_load_entries[index]);
+      AOTCodeEntry* entry = &(_load_entries[index]);
       if (check_entry(kind, id, comp_level, decomp, entry)) {
         return entry; // Found
       }
@@ -962,7 +962,7 @@ SCCEntry* SCCache::find_entry(SCCEntry::Kind kind, uint id, uint comp_level, uin
           break;
         }
         index = _search_entries[ix + 1];
-        SCCEntry* entry = &(_load_entries[index]);
+        AOTCodeEntry* entry = &(_load_entries[index]);
         if (check_entry(kind, id, comp_level, decomp, entry)) {
           return entry; // Found
         }
@@ -974,7 +974,7 @@ SCCEntry* SCCache::find_entry(SCCEntry::Kind kind, uint id, uint comp_level, uin
           break;
         }
         index = _search_entries[ix + 1];
-        SCCEntry* entry = &(_load_entries[index]);
+        AOTCodeEntry* entry = &(_load_entries[index]);
         if (check_entry(kind, id, comp_level, decomp, entry)) {
           return entry; // Found
         }
@@ -989,7 +989,7 @@ SCCEntry* SCCache::find_entry(SCCEntry::Kind kind, uint id, uint comp_level, uin
   return nullptr;
 }
 
-void SCCache::invalidate_entry(SCCEntry* entry) {
+void AOTCodeCache::invalidate_entry(AOTCodeEntry* entry) {
   assert(entry!= nullptr, "all entries should be read already");
   if (entry->not_entrant()) {
     return; // Someone invalidated it already
@@ -1022,7 +1022,7 @@ void SCCache::invalidate_entry(SCCEntry* entry) {
   {
     uint name_offset = entry->offset() + entry->name_offset();
     const char* name;
-    if (SCCache::is_loaded(entry)) {
+    if (AOTCodeCache::is_loaded(entry)) {
       name = _load_buffer + name_offset;
     } else {
       name = _store_buffer + name_offset;
@@ -1031,7 +1031,7 @@ void SCCache::invalidate_entry(SCCEntry* entry) {
     uint comp_id = entry->comp_id();
     uint decomp  = entry->decompile();
     bool clinit_brs = entry->has_clinit_barriers();
-    log_info(scc, nmethod)("Invalidated entry for '%s' (comp_id %d, comp_level %d, decomp: %d, hash: " UINT32_FORMAT_X_0 "%s)",
+    log_info(aot, codecache, nmethod)("Invalidated entry for '%s' (comp_id %d, comp_level %d, decomp: %d, hash: " UINT32_FORMAT_X_0 "%s)",
                            name, comp_id, level, decomp, entry->id(), (clinit_brs ? ", has clinit barriers" : ""));
   }
   if (entry->next() != nullptr) {
@@ -1049,7 +1049,7 @@ static int uint_cmp(const void *i, const void *j) {
 
 AOTCodeStats AOTCodeStats::add_cached_code_stats(AOTCodeStats stats1, AOTCodeStats stats2) {
   AOTCodeStats result;
-  for (int kind = SCCEntry::None; kind < SCCEntry::Kind_count; kind++) {
+  for (int kind = AOTCodeEntry::None; kind < AOTCodeEntry::Kind_count; kind++) {
     result.ccstats._kind_cnt[kind] = stats1.entry_count(kind) + stats2.entry_count(kind);
   }
 
@@ -1060,8 +1060,8 @@ AOTCodeStats AOTCodeStats::add_cached_code_stats(AOTCodeStats stats1, AOTCodeSta
   return result;
 }
 
-void SCCache::log_stats_on_exit() {
-  LogStreamHandle(Info, scc, exit) log;
+void AOTCodeCache::log_stats_on_exit() {
+  LogStreamHandle(Info, aot, codecache, exit) log;
   if (log.is_enabled()) {
     AOTCodeStats prev_stats;
     AOTCodeStats current_stats;
@@ -1084,13 +1084,13 @@ void SCCache::log_stats_on_exit() {
     }
     total_stats = AOTCodeStats::add_cached_code_stats(prev_stats, current_stats);
 
-    log.print_cr("Wrote %d SCCEntry entries(%u max size) to AOT Code Cache",
+    log.print_cr("Wrote %d AOTCodeEntry entries(%u max size) to AOT Code Cache",
                  total_stats.total_count(), max_size);
-    for (uint kind = SCCEntry::None; kind < SCCEntry::Kind_count; kind++) {
+    for (uint kind = AOTCodeEntry::None; kind < AOTCodeEntry::Kind_count; kind++) {
       if (total_stats.entry_count(kind) > 0) {
         log.print_cr("  %s: total=%u(old=%u+new=%u)",
-                     sccentry_kind_name[kind], total_stats.entry_count(kind), prev_stats.entry_count(kind), current_stats.entry_count(kind));
-        if (kind == SCCEntry::Code) {
+                     aot_code_entry_kind_name[kind], total_stats.entry_count(kind), prev_stats.entry_count(kind), current_stats.entry_count(kind));
+        if (kind == AOTCodeEntry::Code) {
           for (uint lvl = CompLevel_none; lvl < AOTCompLevel_count; lvl++) {
             if (total_stats.nmethod_count(lvl) > 0) {
               log.print_cr("    Tier %d: total=%u(old=%u+new=%u)",
@@ -1104,7 +1104,7 @@ void SCCache::log_stats_on_exit() {
   }
 }
 
-bool SCCache::finish_write() {
+bool AOTCodeCache::finish_write() {
   if (!align_write()) {
     return false;
   }
@@ -1126,12 +1126,12 @@ bool SCCache::finish_write() {
     _cached_code_directory = CachedCodeDirectory::create();
     assert(_cached_code_directory != nullptr, "Sanity check");
 
-    uint header_size = (uint)align_up(sizeof(SCCHeader),  DATA_ALIGNMENT);
+    uint header_size = (uint)align_up(sizeof(AOTCodeCache::Header),  DATA_ALIGNMENT);
     uint load_count = (_load_header != nullptr) ? _load_header->entries_count() : 0;
     uint code_count = store_count + load_count;
     uint search_count = code_count * 2;
     uint search_size = search_count * sizeof(uint);
-    uint entries_size = (uint)align_up(code_count * sizeof(SCCEntry), DATA_ALIGNMENT); // In bytes
+    uint entries_size = (uint)align_up(code_count * sizeof(AOTCodeEntry), DATA_ALIGNMENT); // In bytes
     uint preload_entries_cnt = 0;
     uint* preload_entries = NEW_C_HEAP_ARRAY(uint, code_count, mtCode);
     uint preload_entries_size = code_count * sizeof(uint);
@@ -1150,7 +1150,7 @@ bool SCCache::finish_write() {
     char* start = align_up(buffer, DATA_ALIGNMENT);
     char* current = start + header_size; // Skip header
 
-    SCCEntry* entries_address = _store_entries; // Pointer to latest entry
+    AOTCodeEntry* entries_address = _store_entries; // Pointer to latest entry
 
     // Add old entries first
     if (_for_read && (_load_header != nullptr)) {
@@ -1159,7 +1159,7 @@ bool SCCache::finish_write() {
           continue;
         }
         if (_load_entries[i].not_entrant()) {
-          log_info(scc, exit)("Not entrant load entry id: %d, decomp: %d, hash: " UINT32_FORMAT_X_0, i, _load_entries[i].decompile(), _load_entries[i].id());
+          log_info(aot, codecache, exit)("Not entrant load entry id: %d, decomp: %d, hash: " UINT32_FORMAT_X_0, i, _load_entries[i].decompile(), _load_entries[i].id());
           if (_load_entries[i].for_preload()) {
             // Skip not entrant preload code:
             // we can't pre-load code which may have failing dependencies.
@@ -1175,8 +1175,8 @@ bool SCCache::finish_write() {
           copy_bytes((_load_buffer + _load_entries[i].offset()), (address)current, size);
           _load_entries[i].set_offset(current - start); // New offset
           current += size;
-          uint n = write_bytes(&(_load_entries[i]), sizeof(SCCEntry));
-          if (n != sizeof(SCCEntry)) {
+          uint n = write_bytes(&(_load_entries[i]), sizeof(AOTCodeEntry));
+          if (n != sizeof(AOTCodeEntry)) {
             FREE_C_HEAP_ARRAY(char, buffer);
             FREE_C_HEAP_ARRAY(uint, search);
             return false;
@@ -1187,14 +1187,14 @@ bool SCCache::finish_write() {
         }
       }
     }
-    // SCCEntry entries were allocated in reverse in store buffer.
+    // AOTCodeEntry entries were allocated in reverse in store buffer.
     // Process them in reverse order to cache first code first.
     for (int i = store_count - 1; i >= 0; i--) {
       if (entries_address[i].load_fail()) {
         continue;
       }
       if (entries_address[i].not_entrant()) {
-        log_info(scc, exit)("Not entrant new entry comp_id: %d, comp_level: %d, decomp: %d, hash: " UINT32_FORMAT_X_0 "%s", entries_address[i].comp_id(), entries_address[i].comp_level(), entries_address[i].decompile(), entries_address[i].id(), (entries_address[i].has_clinit_barriers() ? ", has clinit barriers" : ""));
+        log_info(aot, codecache, exit)("Not entrant new entry comp_id: %d, comp_level: %d, decomp: %d, hash: " UINT32_FORMAT_X_0 "%s", entries_address[i].comp_id(), entries_address[i].comp_level(), entries_address[i].decompile(), entries_address[i].id(), (entries_address[i].has_clinit_barriers() ? ", has clinit barriers" : ""));
         if (entries_address[i].for_preload()) {
           // Skip not entrant preload code:
           // we can't pre-load code which may have failing dependencies.
@@ -1212,8 +1212,8 @@ bool SCCache::finish_write() {
         entries_address[i].set_offset(current - start); // New offset
         entries_address[i].update_method_for_writing();
         current += size;
-        uint n = write_bytes(&(entries_address[i]), sizeof(SCCEntry));
-        if (n != sizeof(SCCEntry)) {
+        uint n = write_bytes(&(entries_address[i]), sizeof(AOTCodeEntry));
+        if (n != sizeof(AOTCodeEntry)) {
           FREE_C_HEAP_ARRAY(char, buffer);
           FREE_C_HEAP_ARRAY(uint, search);
           return false;
@@ -1225,7 +1225,7 @@ bool SCCache::finish_write() {
     }
 
     if (entries_count == 0) {
-      log_info(scc, exit)("No entires written to AOT Code Cache");
+      log_info(aot, codecache, exit)("No entires written to AOT Code Cache");
       FREE_C_HEAP_ARRAY(char, buffer);
       FREE_C_HEAP_ARRAY(uint, search);
       return true; // Nothing to write
@@ -1242,7 +1242,7 @@ bool SCCache::finish_write() {
     if (preload_entries_size > 0) {
       copy_bytes((const char*)preload_entries, (address)current, preload_entries_size);
       current += preload_entries_size;
-      log_info(scc, exit)("Wrote %d preload entries to AOT Code Cache", preload_entries_cnt);
+      log_info(aot, codecache, exit)("Wrote %d preload entries to AOT Code Cache", preload_entries_cnt);
     }
     if (preload_entries != nullptr) {
       FREE_C_HEAP_ARRAY(uint, preload_entries);
@@ -1257,7 +1257,7 @@ bool SCCache::finish_write() {
     current += search_size;
 
     // Write entries
-    entries_size = entries_count * sizeof(SCCEntry); // New size
+    entries_size = entries_count * sizeof(AOTCodeEntry); // New size
     copy_bytes((_store_buffer + entries_offset), (address)current, entries_size);
     current += entries_size;
 
@@ -1267,27 +1267,27 @@ bool SCCache::finish_write() {
     assert(size <= total_size, "%d > %d", size , total_size);
 
     // Finalize header
-    SCCHeader* header = (SCCHeader*)start;
+    AOTCodeCache::Header* header = (AOTCodeCache::Header*)start;
     header->init(size,
                  (uint)strings_count, strings_offset,
                  entries_count, new_entries_offset,
                  preload_entries_cnt, preload_entries_offset,
                  _use_meta_ptrs);
-    log_info(scc, init)("Wrote SCCache header to AOT Code Cache");
-    log_info(scc, exit)("Wrote %d bytes of data to AOT Code Cache", size);
+    log_info(aot, codecache, init)("Wrote AOTCodeCache header to AOT Code Cache");
+    log_info(aot, codecache, exit)("Wrote %d bytes of data to AOT Code Cache", size);
 
     _cached_code_directory->set_aot_code_data(size, start);
   }
   return true;
 }
 
-bool SCCache::load_stub(StubCodeGenerator* cgen, vmIntrinsicID id, const char* name, address start) {
+bool AOTCodeCache::load_stub(StubCodeGenerator* cgen, vmIntrinsicID id, const char* name, address start) {
   assert(start == cgen->assembler()->pc(), "wrong buffer");
-  SCCache* cache = open_for_read();
+  AOTCodeCache* cache = open_for_read();
   if (cache == nullptr) {
     return false;
   }
-  SCCEntry* entry = cache->find_entry(SCCEntry::Stub, (uint)id);
+  AOTCodeEntry* entry = cache->find_entry(AOTCodeEntry::Stub, (uint)id);
   if (entry == nullptr) {
     return false;
   }
@@ -1297,27 +1297,27 @@ bool SCCache::load_stub(StubCodeGenerator* cgen, vmIntrinsicID id, const char* n
   uint name_size   = entry->name_size(); // Includes '/0'
   const char* saved_name = cache->addr(name_offset);
   if (strncmp(name, saved_name, (name_size - 1)) != 0) {
-    log_warning(scc)("Saved stub's name '%s' is different from '%s' for id:%d", saved_name, name, (int)id);
+    log_warning(aot, codecache)("Saved stub's name '%s' is different from '%s' for id:%d", saved_name, name, (int)id);
     cache->set_failed();
     exit_vm_on_load_failure();
     return false;
   }
-  log_info(scc,stubs)("Reading stub '%s' id:%d from AOT Code Cache", name, (int)id);
+  log_info(aot, codecache,stubs)("Reading stub '%s' id:%d from AOT Code Cache", name, (int)id);
   // Read code
   uint code_offset = entry->code_offset() + entry_position;
   uint code_size   = entry->code_size();
   copy_bytes(cache->addr(code_offset), start, code_size);
   cgen->assembler()->code_section()->set_end(start + code_size);
-  log_info(scc,stubs)("Read stub '%s' id:%d from AOT Code Cache", name, (int)id);
+  log_info(aot, codecache,stubs)("Read stub '%s' id:%d from AOT Code Cache", name, (int)id);
   return true;
 }
 
-bool SCCache::store_stub(StubCodeGenerator* cgen, vmIntrinsicID id, const char* name, address start) {
-  SCCache* cache = open_for_write();
+bool AOTCodeCache::store_stub(StubCodeGenerator* cgen, vmIntrinsicID id, const char* name, address start) {
+  AOTCodeCache* cache = open_for_write();
   if (cache == nullptr) {
     return false;
   }
-  log_info(scc, stubs)("Writing stub '%s' id:%d to AOT Code Cache", name, (int)id);
+  log_info(aot, codecache, stubs)("Writing stub '%s' id:%d to AOT Code Cache", name, (int)id);
   if (!cache->align_write()) {
     return false;
   }
@@ -1358,14 +1358,14 @@ bool SCCache::store_stub(StubCodeGenerator* cgen, vmIntrinsicID id, const char* 
     return false;
   }
   uint entry_size = cache->_write_position - entry_position;
-  SCCEntry* entry = new(cache) SCCEntry(entry_position, entry_size, name_offset, name_size,
+  AOTCodeEntry* entry = new(cache) AOTCodeEntry(entry_position, entry_size, name_offset, name_size,
                                         code_offset, code_size, 0, 0,
-                                        SCCEntry::Stub, (uint32_t)id);
-  log_info(scc, stubs)("Wrote stub '%s' id:%d to AOT Code Cache", name, (int)id);
+                                        AOTCodeEntry::Stub, (uint32_t)id);
+  log_info(aot, codecache, stubs)("Wrote stub '%s' id:%d to AOT Code Cache", name, (int)id);
   return true;
 }
 
-Klass* SCCReader::read_klass(const methodHandle& comp_method, bool shared) {
+Klass* AOTCodeReader::read_klass(const methodHandle& comp_method, bool shared) {
   uint code_offset = read_position();
   uint state = *(uint*)addr(code_offset);
   uint init_state = (state  & 1);
@@ -1379,21 +1379,21 @@ Klass* SCCReader::read_klass(const methodHandle& comp_method, bool shared) {
     if (!MetaspaceShared::is_in_shared_metaspace((address)k)) {
       // Something changed in CDS
       set_lookup_failed();
-      log_info(scc)("Lookup failed for shared klass: " INTPTR_FORMAT " is not in CDS ", p2i((address)k));
+      log_info(aot, codecache)("Lookup failed for shared klass: " INTPTR_FORMAT " is not in CDS ", p2i((address)k));
       return nullptr;
     }
     assert(k->is_klass(), "sanity");
     ResourceMark rm;
     if (k->is_instance_klass() && !InstanceKlass::cast(k)->is_loaded()) {
       set_lookup_failed();
-      log_info(scc)("%d '%s' (L%d): Lookup failed for klass %s: not loaded",
+      log_info(aot, codecache)("%d '%s' (L%d): Lookup failed for klass %s: not loaded",
                        compile_id(), comp_method->name_and_sig_as_C_string(), comp_level(), k->external_name());
       return nullptr;
     } else
     // Allow not initialized klass which was uninitialized during code caching or for preload
     if (k->is_instance_klass() && !InstanceKlass::cast(k)->is_initialized() && (init_state == 1) && !_preload) {
       set_lookup_failed();
-      log_info(scc)("%d '%s' (L%d): Lookup failed for klass %s: not initialized",
+      log_info(aot, codecache)("%d '%s' (L%d): Lookup failed for klass %s: not initialized",
                        compile_id(), comp_method->name_and_sig_as_C_string(), comp_level(), k->external_name());
       return nullptr;
     }
@@ -1405,13 +1405,13 @@ Klass* SCCReader::read_klass(const methodHandle& comp_method, bool shared) {
 //      guarantee(JavaThread::current()->pending_exception() == nullptr, "");
       if (ak == nullptr) {
         set_lookup_failed();
-        log_info(scc)("%d (L%d): %d-dimension array klass lookup failed: %s",
+        log_info(aot, codecache)("%d (L%d): %d-dimension array klass lookup failed: %s",
                          compile_id(), comp_level(), array_dim, k->external_name());
       }
-      log_info(scc)("%d (L%d): Klass lookup: %s (object array)", compile_id(), comp_level(), k->external_name());
+      log_info(aot, codecache)("%d (L%d): Klass lookup: %s (object array)", compile_id(), comp_level(), k->external_name());
       return ak;
     } else {
-      log_info(scc)("%d (L%d): Shared klass lookup: %s",
+      log_info(aot, codecache)("%d (L%d): Shared klass lookup: %s",
                     compile_id(), comp_level(), k->external_name());
       return k;
     }
@@ -1424,7 +1424,7 @@ Klass* SCCReader::read_klass(const methodHandle& comp_method, bool shared) {
   TempNewSymbol klass_sym = SymbolTable::probe(&(dest[0]), name_length);
   if (klass_sym == nullptr) {
     set_lookup_failed();
-    log_info(scc)("%d (L%d): Probe failed for class %s",
+    log_info(aot, codecache)("%d (L%d): Probe failed for class %s",
                      compile_id(), comp_level(), &(dest[0]));
     return nullptr;
   }
@@ -1442,19 +1442,19 @@ Klass* SCCReader::read_klass(const methodHandle& comp_method, bool shared) {
     // Allow not initialized klass which was uninitialized during code caching
     if (k->is_instance_klass() && !InstanceKlass::cast(k)->is_initialized() && (init_state == 1)) {
       set_lookup_failed();
-      log_info(scc)("%d (L%d): Lookup failed for klass %s: not initialized", compile_id(), comp_level(), &(dest[0]));
+      log_info(aot, codecache)("%d (L%d): Lookup failed for klass %s: not initialized", compile_id(), comp_level(), &(dest[0]));
       return nullptr;
     }
-    log_info(scc)("%d (L%d): Klass lookup %s", compile_id(), comp_level(), k->external_name());
+    log_info(aot, codecache)("%d (L%d): Klass lookup %s", compile_id(), comp_level(), k->external_name());
   } else {
     set_lookup_failed();
-    log_info(scc)("%d (L%d): Lookup failed for class %s", compile_id(), comp_level(), &(dest[0]));
+    log_info(aot, codecache)("%d (L%d): Lookup failed for class %s", compile_id(), comp_level(), &(dest[0]));
     return nullptr;
   }
   return k;
 }
 
-Method* SCCReader::read_method(const methodHandle& comp_method, bool shared) {
+Method* AOTCodeReader::read_method(const methodHandle& comp_method, bool shared) {
   uint code_offset = read_position();
   if (_cache->use_meta_ptrs() && shared) {
     uint method_offset = *(uint*)addr(code_offset);
@@ -1464,7 +1464,7 @@ Method* SCCReader::read_method(const methodHandle& comp_method, bool shared) {
     if (!MetaspaceShared::is_in_shared_metaspace((address)m)) {
       // Something changed in CDS
       set_lookup_failed();
-      log_info(scc)("Lookup failed for shared method: " INTPTR_FORMAT " is not in CDS ", p2i((address)m));
+      log_info(aot, codecache)("Lookup failed for shared method: " INTPTR_FORMAT " is not in CDS ", p2i((address)m));
       return nullptr;
     }
     assert(m->is_method(), "sanity");
@@ -1472,26 +1472,26 @@ Method* SCCReader::read_method(const methodHandle& comp_method, bool shared) {
     Klass* k = m->method_holder();
     if (!k->is_instance_klass()) {
       set_lookup_failed();
-      log_info(scc)("%d '%s' (L%d): Lookup failed for holder %s: not instance klass",
+      log_info(aot, codecache)("%d '%s' (L%d): Lookup failed for holder %s: not instance klass",
                     compile_id(), comp_method->name_and_sig_as_C_string(), comp_level(), k->external_name());
       return nullptr;
     } else if (!MetaspaceShared::is_in_shared_metaspace((address)k)) {
       set_lookup_failed();
-      log_info(scc)("%d '%s' (L%d): Lookup failed for holder %s: not in CDS",
+      log_info(aot, codecache)("%d '%s' (L%d): Lookup failed for holder %s: not in CDS",
                     compile_id(), comp_method->name_and_sig_as_C_string(), comp_level(), k->external_name());
       return nullptr;
     } else if (!InstanceKlass::cast(k)->is_loaded()) {
       set_lookup_failed();
-      log_info(scc)("%d '%s' (L%d): Lookup failed for holder %s: not loaded",
+      log_info(aot, codecache)("%d '%s' (L%d): Lookup failed for holder %s: not loaded",
                     compile_id(), comp_method->name_and_sig_as_C_string(), comp_level(), k->external_name());
       return nullptr;
     } else if (!InstanceKlass::cast(k)->is_linked()) {
       set_lookup_failed();
-      log_info(scc)("%d '%s' (L%d): Lookup failed for holder %s: not linked%s",
+      log_info(aot, codecache)("%d '%s' (L%d): Lookup failed for holder %s: not linked%s",
                     compile_id(), comp_method->name_and_sig_as_C_string(), comp_level(), k->external_name(), (_preload ? " for code preload" : ""));
       return nullptr;
     }
-    log_info(scc)("%d (L%d): Shared method lookup: %s",
+    log_info(aot, codecache)("%d (L%d): Shared method lookup: %s",
                   compile_id(), comp_level(), m->name_and_sig_as_C_string());
     return m;
   }
@@ -1508,7 +1508,7 @@ Method* SCCReader::read_method(const methodHandle& comp_method, bool shared) {
   TempNewSymbol klass_sym = SymbolTable::probe(&(dest[0]), holder_length);
   if (klass_sym == nullptr) {
     set_lookup_failed();
-    log_info(scc)("%d (L%d): Probe failed for class %s", compile_id(), comp_level(), &(dest[0]));
+    log_info(aot, codecache)("%d (L%d): Probe failed for class %s", compile_id(), comp_level(), &(dest[0]));
     return nullptr;
   }
   // Use class loader of compiled method.
@@ -1524,19 +1524,19 @@ Method* SCCReader::read_method(const methodHandle& comp_method, bool shared) {
   if (k != nullptr) {
     if (!k->is_instance_klass()) {
       set_lookup_failed();
-      log_info(scc)("%d (L%d): Lookup failed for holder %s: not instance klass",
+      log_info(aot, codecache)("%d (L%d): Lookup failed for holder %s: not instance klass",
                        compile_id(), comp_level(), &(dest[0]));
       return nullptr;
     } else if (!InstanceKlass::cast(k)->is_linked()) {
       set_lookup_failed();
-      log_info(scc)("%d (L%d): Lookup failed for holder %s: not linked",
+      log_info(aot, codecache)("%d (L%d): Lookup failed for holder %s: not linked",
                        compile_id(), comp_level(), &(dest[0]));
       return nullptr;
     }
-    log_info(scc)("%d (L%d): Holder lookup: %s", compile_id(), comp_level(), k->external_name());
+    log_info(aot, codecache)("%d (L%d): Holder lookup: %s", compile_id(), comp_level(), k->external_name());
   } else {
     set_lookup_failed();
-    log_info(scc)("%d (L%d): Lookup failed for holder %s",
+    log_info(aot, codecache)("%d (L%d): Lookup failed for holder %s",
                   compile_id(), comp_level(), &(dest[0]));
     return nullptr;
   }
@@ -1545,30 +1545,30 @@ Method* SCCReader::read_method(const methodHandle& comp_method, bool shared) {
   TempNewSymbol sign_sym = SymbolTable::probe(&(dest[pos]), signat_length);
   if (name_sym == nullptr) {
     set_lookup_failed();
-    log_info(scc)("%d (L%d): Probe failed for method name %s",
+    log_info(aot, codecache)("%d (L%d): Probe failed for method name %s",
                      compile_id(), comp_level(), &(dest[holder_length + 1]));
     return nullptr;
   }
   if (sign_sym == nullptr) {
     set_lookup_failed();
-    log_info(scc)("%d (L%d): Probe failed for method signature %s",
+    log_info(aot, codecache)("%d (L%d): Probe failed for method signature %s",
                      compile_id(), comp_level(), &(dest[pos]));
     return nullptr;
   }
   Method* m = InstanceKlass::cast(k)->find_method(name_sym, sign_sym);
   if (m != nullptr) {
     ResourceMark rm;
-    log_info(scc)("%d (L%d): Method lookup: %s", compile_id(), comp_level(), m->name_and_sig_as_C_string());
+    log_info(aot, codecache)("%d (L%d): Method lookup: %s", compile_id(), comp_level(), m->name_and_sig_as_C_string());
   } else {
     set_lookup_failed();
-    log_info(scc)("%d (L%d): Lookup failed for method %s::%s%s",
+    log_info(aot, codecache)("%d (L%d): Lookup failed for method %s::%s%s",
                      compile_id(), comp_level(), &(dest[0]), &(dest[holder_length + 1]), &(dest[pos]));
     return nullptr;
   }
   return m;
 }
 
-bool SCCache::write_klass(Klass* klass) {
+bool AOTCodeCache::write_klass(Klass* klass) {
   bool can_use_meta_ptrs = _use_meta_ptrs;
   uint array_dim = 0;
   if (klass->is_objArray_klass()) {
@@ -1613,7 +1613,7 @@ bool SCCache::write_klass(Klass* klass) {
     if (n != sizeof(uint)) {
       return false;
     }
-    log_info(scc)("%d (L%d): Wrote shared klass: %s%s%s @ 0x%08x", compile_id(), comp_level(), klass->external_name(),
+    log_info(aot, codecache)("%d (L%d): Wrote shared klass: %s%s%s @ 0x%08x", compile_id(), comp_level(), klass->external_name(),
                   (!klass->is_instance_klass() ? "" : (init_state == 1 ? " (initialized)" : " (not-initialized)")),
                   (array_dim > 0 ? " (object array)" : ""),
                   klass_offset);
@@ -1626,7 +1626,7 @@ bool SCCache::write_klass(Klass* klass) {
     return false;
   }
   _for_preload = false;
-  log_info(scc,cds)("%d (L%d): Not shared klass: %s", compile_id(), comp_level(), klass->external_name());
+  log_info(aot, codecache,cds)("%d (L%d): Not shared klass: %s", compile_id(), comp_level(), klass->external_name());
   if (klass->is_hidden()) { // Skip such nmethod
     set_lookup_failed();
     return false;
@@ -1647,7 +1647,7 @@ bool SCCache::write_klass(Klass* klass) {
   char* dest = NEW_RESOURCE_ARRAY(char, total_length);
   name->as_C_string(dest, total_length);
   dest[total_length - 1] = '\0';
-  LogTarget(Info, scc, loader) log;
+  LogTarget(Info, aot, codecache, loader) log;
   if (log.is_enabled()) {
     LogStream ls(log);
     oop loader = klass->class_loader();
@@ -1674,14 +1674,14 @@ bool SCCache::write_klass(Klass* klass) {
   if (n != (uint)total_length) {
     return false;
   }
-  log_info(scc)("%d (L%d): Wrote klass: %s%s%s",
+  log_info(aot, codecache)("%d (L%d): Wrote klass: %s%s%s",
                 compile_id(), comp_level(),
                 dest, (!klass->is_instance_klass() ? "" : (init_state == 1 ? " (initialized)" : " (not-initialized)")),
                 (array_dim > 0 ? " (object array)" : ""));
   return true;
 }
 
-bool SCCache::write_method(Method* method) {
+bool AOTCodeCache::write_method(Method* method) {
   bool can_use_meta_ptrs = _use_meta_ptrs;
   Klass* klass = method->method_holder();
   if (klass->is_instance_klass()) {
@@ -1714,7 +1714,7 @@ bool SCCache::write_method(Method* method) {
     if (n != sizeof(uint)) {
       return false;
     }
-    log_info(scc)("%d (L%d): Wrote shared method: %s @ 0x%08x", compile_id(), comp_level(), method->name_and_sig_as_C_string(), method_offset);
+    log_info(aot, codecache)("%d (L%d): Wrote shared method: %s @ 0x%08x", compile_id(), comp_level(), method->name_and_sig_as_C_string(), method_offset);
     return true;
   }
   // Bailout if code has clinit barriers:
@@ -1724,7 +1724,7 @@ bool SCCache::write_method(Method* method) {
     return false;
   }
   _for_preload = false;
-  log_info(scc,cds)("%d (L%d): Not shared method: %s", compile_id(), comp_level(), method->name_and_sig_as_C_string());
+  log_info(aot, codecache,cds)("%d (L%d): Not shared method: %s", compile_id(), comp_level(), method->name_and_sig_as_C_string());
   if (method->is_hidden()) { // Skip such nmethod
     set_lookup_failed();
     return false;
@@ -1753,7 +1753,7 @@ bool SCCache::write_method(Method* method) {
   signat->as_C_string(&(dest[pos]), (total_length - pos));
   dest[total_length - 1] = '\0';
 
-  LogTarget(Info, scc, loader) log;
+  LogTarget(Info, aot, codecache, loader) log;
   if (log.is_enabled()) {
     LogStream ls(log);
     oop loader = klass->class_loader();
@@ -1791,12 +1791,12 @@ bool SCCache::write_method(Method* method) {
   }
   dest[holder_length] = ' ';
   dest[holder_length + 1 + name_length] = ' ';
-  log_info(scc)("%d (L%d): Wrote method: %s", compile_id(), comp_level(), dest);
+  log_info(aot, codecache)("%d (L%d): Wrote method: %s", compile_id(), comp_level(), dest);
   return true;
 }
 
 // Repair the pc relative information in the code after load
-bool SCCReader::read_relocations(CodeBuffer* buffer, CodeBuffer* orig_buffer,
+bool AOTCodeReader::read_relocations(CodeBuffer* buffer, CodeBuffer* orig_buffer,
                                  OopRecorder* oop_recorder, ciMethod* target) {
   bool success = true;
   for (int i = 0; i < (int)CodeBuffer::SECT_LIMIT; i++) {
@@ -1826,7 +1826,7 @@ bool SCCReader::read_relocations(CodeBuffer* buffer, CodeBuffer* orig_buffer,
     uint* reloc_data = (uint*)addr(code_offset);
     code_offset += data_size;
     set_read_position(code_offset);
-    LogStreamHandle(Info, scc, reloc) log;
+    LogStreamHandle(Info, aot, codecache, reloc) log;
     if (log.is_enabled()) {
       log.print_cr("======== read code section %d relocations [%d]:", i, reloc_count);
     }
@@ -1949,20 +1949,20 @@ bool SCCReader::read_relocations(CodeBuffer* buffer, CodeBuffer* orig_buffer,
   return success;
 }
 
-bool SCCReader::read_code(CodeBuffer* buffer, CodeBuffer* orig_buffer, uint code_offset) {
+bool AOTCodeReader::read_code(CodeBuffer* buffer, CodeBuffer* orig_buffer, uint code_offset) {
   assert(code_offset == align_up(code_offset, DATA_ALIGNMENT), "%d not aligned to %d", code_offset, DATA_ALIGNMENT);
-  SCCodeSection* scc_cs = (SCCodeSection*)addr(code_offset);
+  AOTCodeSection* aot_cs = (AOTCodeSection*)addr(code_offset);
   for (int i = 0; i < (int)CodeBuffer::SECT_LIMIT; i++) {
     CodeSection* cs = buffer->code_section(i);
     // Read original section size and address.
-    uint orig_size = scc_cs[i]._size;
-    log_debug(scc)("======== read code section %d [%d]:", i, orig_size);
+    uint orig_size = aot_cs[i]._size;
+    log_debug(aot, codecache)("======== read code section %d [%d]:", i, orig_size);
     uint orig_size_align = align_up(orig_size, DATA_ALIGNMENT);
     if (i != (int)CodeBuffer::SECT_INSTS) {
       buffer->initialize_section_size(cs, orig_size_align);
     }
     if (orig_size_align > (uint)cs->capacity()) { // Will not fit
-      log_info(scc)("%d (L%d): original code section %d size %d > current capacity %d",
+      log_info(aot, codecache)("%d (L%d): original code section %d size %d > current capacity %d",
                        compile_id(), comp_level(), i, orig_size, cs->capacity());
       return false;
     }
@@ -1970,7 +1970,7 @@ bool SCCReader::read_code(CodeBuffer* buffer, CodeBuffer* orig_buffer, uint code
       assert(cs->size() == 0, "should match");
       continue;  // skip trivial section
     }
-    address orig_start = scc_cs[i]._origin_address;
+    address orig_start = aot_cs[i]._origin_address;
 
     // Populate fake original buffer (no code allocation in CodeCache).
     // It is used for relocations to calculate sections addesses delta.
@@ -1980,43 +1980,43 @@ bool SCCReader::read_code(CodeBuffer* buffer, CodeBuffer* orig_buffer, uint code
 
     // Load code to new buffer.
     address code_start = cs->start();
-    copy_bytes(addr(scc_cs[i]._offset + code_offset), code_start, orig_size_align);
+    copy_bytes(addr(aot_cs[i]._offset + code_offset), code_start, orig_size_align);
     cs->set_end(code_start + orig_size);
   }
 
   return true;
 }
 
-bool SCCache::load_adapter(CodeBuffer* buffer, uint32_t id, const char* name, uint32_t offsets[4]) {
+bool AOTCodeCache::load_adapter(CodeBuffer* buffer, uint32_t id, const char* name, uint32_t offsets[4]) {
 #ifdef ASSERT
-  LogStreamHandle(Debug, scc, stubs) log;
+  LogStreamHandle(Debug, aot, codecache, stubs) log;
   if (log.is_enabled()) {
     FlagSetting fs(PrintRelocations, true);
     buffer->print_on(&log);
   }
 #endif
-  SCCache* cache = open_for_read();
+  AOTCodeCache* cache = open_for_read();
   if (cache == nullptr) {
     return false;
   }
-  log_info(scc, stubs)("Looking up adapter %s (0x%x) in AOT Code Cache", name, id);
-  SCCEntry* entry = cache->find_entry(SCCEntry::Adapter, id);
+  log_info(aot, codecache, stubs)("Looking up adapter %s (0x%x) in AOT Code Cache", name, id);
+  AOTCodeEntry* entry = cache->find_entry(AOTCodeEntry::Adapter, id);
   if (entry == nullptr) {
     return false;
   }
-  SCCReader reader(cache, entry, nullptr);
+  AOTCodeReader reader(cache, entry, nullptr);
   return reader.compile_adapter(buffer, name, offsets);
 }
-bool SCCReader::compile_adapter(CodeBuffer* buffer, const char* name, uint32_t offsets[4]) {
+bool AOTCodeReader::compile_adapter(CodeBuffer* buffer, const char* name, uint32_t offsets[4]) {
   uint entry_position = _entry->offset();
   // Read name
   uint name_offset = entry_position + _entry->name_offset();
   uint name_size = _entry->name_size(); // Includes '/0'
   const char* stored_name = addr(name_offset);
-  log_info(scc, stubs)("%d (L%d): Reading adapter '%s' from AOT Code Cache",
+  log_info(aot, codecache, stubs)("%d (L%d): Reading adapter '%s' from AOT Code Cache",
                        compile_id(), comp_level(), name);
   if (strncmp(stored_name, name, (name_size - 1)) != 0) {
-    log_warning(scc)("%d (L%d): Saved adapter's name '%s' is different from '%s'",
+    log_warning(aot, codecache)("%d (L%d): Saved adapter's name '%s' is different from '%s'",
                      compile_id(), comp_level(), stored_name, name);
     // n.b. this is not fatal -- we have just seen a hash id clash
     // so no need to call cache->set_failed()
@@ -2043,14 +2043,14 @@ bool SCCReader::compile_adapter(CodeBuffer* buffer, const char* name, uint32_t o
   for (int i = 0; i < offsets_count; i++) {
     uint32_t arg = *(uint32_t*)addr(offset);
     offset += sizeof(uint32_t);
-    log_debug(scc, stubs)("%d (L%d): Reading adapter '%s'  offsets[%d] == 0x%x from AOT Code Cache",
+    log_debug(aot, codecache, stubs)("%d (L%d): Reading adapter '%s'  offsets[%d] == 0x%x from AOT Code Cache",
                          compile_id(), comp_level(), stored_name, i, arg);
     offsets[i] = arg;
   }
-  log_debug(scc, stubs)("%d (L%d): Read adapter '%s' with '%d' args from AOT Code Cache",
+  log_debug(aot, codecache, stubs)("%d (L%d): Read adapter '%s' with '%d' args from AOT Code Cache",
                        compile_id(), comp_level(), stored_name, offsets_count);
 #ifdef ASSERT
-  LogStreamHandle(Debug, scc, stubs) log;
+  LogStreamHandle(Debug, aot, codecache, stubs) log;
   if (log.is_enabled()) {
     FlagSetting fs(PrintRelocations, true);
     buffer->print_on(&log);
@@ -2058,31 +2058,31 @@ bool SCCReader::compile_adapter(CodeBuffer* buffer, const char* name, uint32_t o
   }
 #endif
   // mark entry as loaded
-  ((SCCEntry *)_entry)->set_loaded();
+  ((AOTCodeEntry *)_entry)->set_loaded();
   return true;
 }
 
-bool SCCache::load_exception_blob(CodeBuffer* buffer, int* pc_offset) {
+bool AOTCodeCache::load_exception_blob(CodeBuffer* buffer, int* pc_offset) {
 #ifdef ASSERT
-  LogStreamHandle(Debug, scc, nmethod) log;
+  LogStreamHandle(Debug, aot, codecache, nmethod) log;
   if (log.is_enabled()) {
     FlagSetting fs(PrintRelocations, true);
     buffer->print_on(&log);
   }
 #endif
-  SCCache* cache = open_for_read();
+  AOTCodeCache* cache = open_for_read();
   if (cache == nullptr) {
     return false;
   }
-  SCCEntry* entry = cache->find_entry(SCCEntry::Blob, 999);
+  AOTCodeEntry* entry = cache->find_entry(AOTCodeEntry::Blob, 999);
   if (entry == nullptr) {
     return false;
   }
-  SCCReader reader(cache, entry, nullptr);
+  AOTCodeReader reader(cache, entry, nullptr);
   return reader.compile_blob(buffer, pc_offset);
 }
 
-bool SCCReader::compile_blob(CodeBuffer* buffer, int* pc_offset) {
+bool AOTCodeReader::compile_blob(CodeBuffer* buffer, int* pc_offset) {
   uint entry_position = _entry->offset();
 
   // Read pc_offset
@@ -2093,13 +2093,13 @@ bool SCCReader::compile_blob(CodeBuffer* buffer, int* pc_offset) {
   uint name_size = _entry->name_size(); // Includes '/0'
   const char* name = addr(name_offset);
 
-  log_info(scc, stubs)("%d (L%d): Reading blob '%s' with pc_offset %d from AOT Code Cache",
+  log_info(aot, codecache, stubs)("%d (L%d): Reading blob '%s' with pc_offset %d from AOT Code Cache",
                        compile_id(), comp_level(), name, *pc_offset);
 
   if (strncmp(buffer->name(), name, (name_size - 1)) != 0) {
-    log_warning(scc)("%d (L%d): Saved blob's name '%s' is different from '%s'",
-                     compile_id(), comp_level(), name, buffer->name());
-    ((SCCache*)_cache)->set_failed();
+    log_warning(aot, codecache)("%d (L%d): Saved blob's name '%s' is different from '%s'",
+                                compile_id(), comp_level(), name, buffer->name());
+    ((AOTCodeCache*)_cache)->set_failed();
     exit_vm_on_load_failure();
     return false;
   }
@@ -2120,10 +2120,10 @@ bool SCCReader::compile_blob(CodeBuffer* buffer, int* pc_offset) {
     return false;
   }
 
-  log_info(scc, stubs)("%d (L%d): Read blob '%s' from AOT Code Cache",
+  log_info(aot, codecache, stubs)("%d (L%d): Read blob '%s' from AOT Code Cache",
                        compile_id(), comp_level(), name);
 #ifdef ASSERT
-  LogStreamHandle(Debug, scc, nmethod) log;
+  LogStreamHandle(Debug, aot, codecache, nmethod) log;
   if (log.is_enabled()) {
     FlagSetting fs(PrintRelocations, true);
     buffer->print_on(&log);
@@ -2133,7 +2133,7 @@ bool SCCReader::compile_blob(CodeBuffer* buffer, int* pc_offset) {
   return true;
 }
 
-bool SCCache::write_relocations(CodeBuffer* buffer, uint& all_reloc_size) {
+bool AOTCodeCache::write_relocations(CodeBuffer* buffer, uint& all_reloc_size) {
   uint all_reloc_count = 0;
   for (int i = 0; i < (int)CodeBuffer::SECT_LIMIT; i++) {
     CodeSection* cs = buffer->code_section(i);
@@ -2168,7 +2168,7 @@ bool SCCache::write_relocations(CodeBuffer* buffer, uint& all_reloc_size) {
       success = false;
       break;
     }
-    LogStreamHandle(Info, scc, reloc) log;
+    LogStreamHandle(Info, aot, codecache, reloc) log;
     if (log.is_enabled()) {
       log.print_cr("======== write code section %d relocations [%d]:", i, reloc_count);
     }
@@ -2305,15 +2305,15 @@ bool SCCache::write_relocations(CodeBuffer* buffer, uint& all_reloc_size) {
   return success;
 }
 
-bool SCCache::store_adapter(CodeBuffer* buffer, uint32_t id, const char* name, uint32_t offsets[4]) {
+bool AOTCodeCache::store_adapter(CodeBuffer* buffer, uint32_t id, const char* name, uint32_t offsets[4]) {
   assert(CDSConfig::is_dumping_adapters(), "must be");
-  SCCache* cache = open_for_write();
+  AOTCodeCache* cache = open_for_write();
   if (cache == nullptr) {
     return false;
   }
-  log_info(scc, stubs)("Writing adapter '%s' (0x%x) to AOT Code Cache", name, id);
+  log_info(aot, codecache, stubs)("Writing adapter '%s' (0x%x) to AOT Code Cache", name, id);
 #ifdef ASSERT
-  LogStreamHandle(Debug, scc, stubs) log;
+  LogStreamHandle(Debug, aot, codecache, stubs) log;
   if (log.is_enabled()) {
     FlagSetting fs(PrintRelocations, true);
     buffer->print_on(&log);
@@ -2356,42 +2356,42 @@ bool SCCache::store_adapter(CodeBuffer* buffer, uint32_t id, const char* name, u
   }
   for (int i = 0; i < 4; i++) {
     uint32_t arg = offsets[i];
-    log_debug(scc, stubs)("Writing adapter '%s' (0x%x) offsets[%d] == 0x%x to AOT Code Cache", name, id, i, arg);
+    log_debug(aot, codecache, stubs)("Writing adapter '%s' (0x%x) offsets[%d] == 0x%x to AOT Code Cache", name, id, i, arg);
     n = cache->write_bytes(&arg, sizeof(uint32_t));
     if (n != sizeof(uint32_t)) {
       return false;
     }
   }
   uint entry_size = cache->_write_position - entry_position;
-  SCCEntry* entry = new (cache) SCCEntry(entry_position, entry_size, name_offset, name_size,
+  AOTCodeEntry* entry = new (cache) AOTCodeEntry(entry_position, entry_size, name_offset, name_size,
                                          code_offset, code_size, reloc_offset, reloc_size,
-                                         SCCEntry::Adapter, id);
-  log_info(scc, stubs)("Wrote adapter '%s' (0x%x) to AOT Code Cache", name, id);
+                                         AOTCodeEntry::Adapter, id);
+  log_info(aot, codecache, stubs)("Wrote adapter '%s' (0x%x) to AOT Code Cache", name, id);
   return true;
 }
 
-bool SCCache::write_code(CodeBuffer* buffer, uint& code_size) {
+bool AOTCodeCache::write_code(CodeBuffer* buffer, uint& code_size) {
   assert(_write_position == align_up(_write_position, DATA_ALIGNMENT), "%d not aligned to %d", _write_position, DATA_ALIGNMENT);
   //assert(buffer->blob() != nullptr, "sanity");
   uint code_offset = _write_position;
   uint cb_total_size = (uint)buffer->total_content_size();
   // Write information about Code sections first.
-  SCCodeSection scc_cs[CodeBuffer::SECT_LIMIT];
-  uint scc_cs_size = (uint)(sizeof(SCCodeSection) * CodeBuffer::SECT_LIMIT);
-  uint offset = align_up(scc_cs_size, DATA_ALIGNMENT);
+  AOTCodeSection aot_cs[CodeBuffer::SECT_LIMIT];
+  uint aot_cs_size = (uint)(sizeof(AOTCodeSection) * CodeBuffer::SECT_LIMIT);
+  uint offset = align_up(aot_cs_size, DATA_ALIGNMENT);
   uint total_size = 0;
   for (int i = 0; i < (int)CodeBuffer::SECT_LIMIT; i++) {
     const CodeSection* cs = buffer->code_section(i);
     assert(cs->mark() == nullptr, "CodeSection::_mark is not implemented");
     uint cs_size = (uint)cs->size();
-    scc_cs[i]._size = cs_size;
-    scc_cs[i]._origin_address = (cs_size == 0) ? nullptr : cs->start();
-    scc_cs[i]._offset = (cs_size == 0) ? 0 : (offset + total_size);
+    aot_cs[i]._size = cs_size;
+    aot_cs[i]._origin_address = (cs_size == 0) ? nullptr : cs->start();
+    aot_cs[i]._offset = (cs_size == 0) ? 0 : (offset + total_size);
     assert(cs->mark() == nullptr, "CodeSection::_mark is not implemented");
     total_size += align_up(cs_size, DATA_ALIGNMENT);
   }
-  uint n = write_bytes(scc_cs, scc_cs_size);
-  if (n != scc_cs_size) {
+  uint n = write_bytes(aot_cs, aot_cs_size);
+  if (n != aot_cs_size) {
     return false;
   }
   if (!align_write()) {
@@ -2404,7 +2404,7 @@ bool SCCache::write_code(CodeBuffer* buffer, uint& code_size) {
     if (cs_size == 0) {
       continue;  // skip trivial section
     }
-    assert((_write_position - code_offset) == scc_cs[i]._offset, "%d != %d", _write_position, scc_cs[i]._offset);
+    assert((_write_position - code_offset) == aot_cs[i]._offset, "%d != %d", _write_position, aot_cs[i]._offset);
     // Write code
     n = write_bytes(cs->start(), cs_size);
     if (n != cs_size) {
@@ -2419,15 +2419,15 @@ bool SCCache::write_code(CodeBuffer* buffer, uint& code_size) {
   return true;
 }
 
-bool SCCache::store_exception_blob(CodeBuffer* buffer, int pc_offset) {
-  SCCache* cache = open_for_write();
+bool AOTCodeCache::store_exception_blob(CodeBuffer* buffer, int pc_offset) {
+  AOTCodeCache* cache = open_for_write();
   if (cache == nullptr) {
     return false;
   }
-  log_info(scc, stubs)("Writing blob '%s' to AOT Code Cache", buffer->name());
+  log_info(aot, codecache, stubs)("Writing blob '%s' to AOT Code Cache", buffer->name());
 
 #ifdef ASSERT
-  LogStreamHandle(Debug, scc, nmethod) log;
+  LogStreamHandle(Debug, aot, codecache, nmethod) log;
   if (log.is_enabled()) {
     FlagSetting fs(PrintRelocations, true);
     buffer->print_on(&log);
@@ -2473,21 +2473,21 @@ bool SCCache::store_exception_blob(CodeBuffer* buffer, int pc_offset) {
   }
 
   uint entry_size = cache->_write_position - entry_position;
-  SCCEntry* entry = new(cache) SCCEntry(entry_position, entry_size, name_offset, name_size,
+  AOTCodeEntry* entry = new(cache) AOTCodeEntry(entry_position, entry_size, name_offset, name_size,
                                         code_offset, code_size, reloc_offset, reloc_size,
-                                        SCCEntry::Blob, (uint32_t)999);
-  log_info(scc, stubs)("Wrote stub '%s' to AOT Code Cache", name);
+                                        AOTCodeEntry::Blob, (uint32_t)999);
+  log_info(aot, codecache, stubs)("Wrote stub '%s' to AOT Code Cache", name);
   return true;
 }
 
-DebugInformationRecorder* SCCReader::read_debug_info(OopRecorder* oop_recorder) {
+DebugInformationRecorder* AOTCodeReader::read_debug_info(OopRecorder* oop_recorder) {
   uint code_offset = align_up(read_position(), DATA_ALIGNMENT);
   int data_size  = *(int*)addr(code_offset);
   code_offset   += sizeof(int);
   int pcs_length = *(int*)addr(code_offset);
   code_offset   += sizeof(int);
 
-  log_debug(scc)("======== read DebugInfo [%d, %d]:", data_size, pcs_length);
+  log_debug(aot, codecache)("======== read DebugInfo [%d, %d]:", data_size, pcs_length);
 
   // Aligned initial sizes
   int data_size_align  = align_up(data_size, DATA_ALIGNMENT);
@@ -2506,7 +2506,7 @@ DebugInformationRecorder* SCCReader::read_debug_info(OopRecorder* oop_recorder) 
   return recorder;
 }
 
-bool SCCache::write_debug_info(DebugInformationRecorder* recorder) {
+bool AOTCodeCache::write_debug_info(DebugInformationRecorder* recorder) {
   if (!align_write()) {
     return false;
   }
@@ -2533,12 +2533,12 @@ bool SCCache::write_debug_info(DebugInformationRecorder* recorder) {
   return true;
 }
 
-OopMapSet* SCCReader::read_oop_maps() {
+OopMapSet* AOTCodeReader::read_oop_maps() {
   uint code_offset = read_position();
   int om_count = *(int*)addr(code_offset);
   code_offset += sizeof(int);
 
-  log_debug(scc)("======== read oop maps [%d]:", om_count);
+  log_debug(aot, codecache)("======== read oop maps [%d]:", om_count);
 
   OopMapSet* oop_maps = new OopMapSet(om_count);
   for (int i = 0; i < (int)om_count; i++) {
@@ -2568,7 +2568,7 @@ OopMapSet* SCCReader::read_oop_maps() {
   return oop_maps;
 }
 
-bool SCCache::write_oop_maps(OopMapSet* oop_maps) {
+bool AOTCodeCache::write_oop_maps(OopMapSet* oop_maps) {
   uint om_count = oop_maps->size();
   uint n = write_bytes(&om_count, sizeof(int));
   if (n != sizeof(int)) {
@@ -2593,7 +2593,7 @@ bool SCCache::write_oop_maps(OopMapSet* oop_maps) {
   return true;
 }
 
-oop SCCReader::read_oop(JavaThread* thread, const methodHandle& comp_method) {
+oop AOTCodeReader::read_oop(JavaThread* thread, const methodHandle& comp_method) {
   uint code_offset = read_position();
   oop obj = nullptr;
   DataKind kind = *(DataKind*)addr(code_offset);
@@ -2611,7 +2611,7 @@ oop SCCReader::read_oop(JavaThread* thread, const methodHandle& comp_method) {
     obj = k->java_mirror();
     if (obj == nullptr) {
       set_lookup_failed();
-      log_info(scc)("Lookup failed for java_mirror of klass %s", k->external_name());
+      log_info(aot, codecache)("Lookup failed for java_mirror of klass %s", k->external_name());
       return nullptr;
     }
   } else if (kind == DataKind::Primitive) {
@@ -2621,7 +2621,7 @@ oop SCCReader::read_oop(JavaThread* thread, const methodHandle& comp_method) {
     set_read_position(code_offset);
     BasicType bt = (BasicType)t;
     obj = java_lang_Class::primitive_mirror(bt);
-    log_info(scc)("%d (L%d): Read primitive type klass: %s", compile_id(), comp_level(), type2name(bt));
+    log_info(aot, codecache)("%d (L%d): Read primitive type klass: %s", compile_id(), comp_level(), type2name(bt));
   } else if (kind == DataKind::String_Shared) {
     code_offset = read_position();
     int k = *(int*)addr(code_offset);
@@ -2638,18 +2638,18 @@ oop SCCReader::read_oop(JavaThread* thread, const methodHandle& comp_method) {
     obj = StringTable::intern(&(dest[0]), thread);
     if (obj == nullptr) {
       set_lookup_failed();
-      log_info(scc)("%d (L%d): Lookup failed for String %s",
+      log_info(aot, codecache)("%d (L%d): Lookup failed for String %s",
                        compile_id(), comp_level(), &(dest[0]));
       return nullptr;
     }
     assert(java_lang_String::is_instance(obj), "must be string");
-    log_info(scc)("%d (L%d): Read String: %s", compile_id(), comp_level(), dest);
+    log_info(aot, codecache)("%d (L%d): Read String: %s", compile_id(), comp_level(), dest);
   } else if (kind == DataKind::SysLoader) {
     obj = SystemDictionary::java_system_loader();
-    log_info(scc)("%d (L%d): Read java_system_loader", compile_id(), comp_level());
+    log_info(aot, codecache)("%d (L%d): Read java_system_loader", compile_id(), comp_level());
   } else if (kind == DataKind::PlaLoader) {
     obj = SystemDictionary::java_platform_loader();
-    log_info(scc)("%d (L%d): Read java_platform_loader", compile_id(), comp_level());
+    log_info(aot, codecache)("%d (L%d): Read java_platform_loader", compile_id(), comp_level());
   } else if (kind == DataKind::MH_Oop_Shared) {
     code_offset = read_position();
     int k = *(int*)addr(code_offset);
@@ -2658,19 +2658,19 @@ oop SCCReader::read_oop(JavaThread* thread, const methodHandle& comp_method) {
     obj = CDSAccess::get_archived_object(k);
   } else {
     set_lookup_failed();
-    log_info(scc)("%d (L%d): Unknown oop's kind: %d",
+    log_info(aot, codecache)("%d (L%d): Unknown oop's kind: %d",
                      compile_id(), comp_level(), (int)kind);
     return nullptr;
   }
   return obj;
 }
 
-bool SCCReader::read_oops(OopRecorder* oop_recorder, ciMethod* target) {
+bool AOTCodeReader::read_oops(OopRecorder* oop_recorder, ciMethod* target) {
   uint code_offset = read_position();
   int oop_count = *(int*)addr(code_offset);
   code_offset += sizeof(int);
   set_read_position(code_offset);
-  log_debug(scc)("======== read oops [%d]:", oop_count);
+  log_debug(aot, codecache)("======== read oops [%d]:", oop_count);
   if (oop_count == 0) {
     return true;
   }
@@ -2688,7 +2688,7 @@ bool SCCReader::read_oops(OopRecorder* oop_recorder, ciMethod* target) {
       } else {
         oop_recorder->allocate_oop_index(jo);
       }
-      LogStreamHandle(Debug, scc, oops) log;
+      LogStreamHandle(Debug, aot, codecache, oops) log;
       if (log.is_enabled()) {
         log.print("%d: " INTPTR_FORMAT " ", i, p2i(jo));
         if (jo == (jobject)Universe::non_oop_word()) {
@@ -2705,7 +2705,7 @@ bool SCCReader::read_oops(OopRecorder* oop_recorder, ciMethod* target) {
   return true;
 }
 
-Metadata* SCCReader::read_metadata(const methodHandle& comp_method) {
+Metadata* AOTCodeReader::read_metadata(const methodHandle& comp_method) {
   uint code_offset = read_position();
   Metadata* m = nullptr;
   DataKind kind = *(DataKind*)addr(code_offset);
@@ -2731,25 +2731,25 @@ Metadata* SCCReader::read_metadata(const methodHandle& comp_method) {
       m = method->get_method_counters(Thread::current());
       if (m == nullptr) {
         set_lookup_failed();
-        log_info(scc)("%d (L%d): Failed to get MethodCounters", compile_id(), comp_level());
+        log_info(aot, codecache)("%d (L%d): Failed to get MethodCounters", compile_id(), comp_level());
       } else {
-        log_info(scc)("%d (L%d): Read MethodCounters : " INTPTR_FORMAT, compile_id(), comp_level(), p2i(m));
+        log_info(aot, codecache)("%d (L%d): Read MethodCounters : " INTPTR_FORMAT, compile_id(), comp_level(), p2i(m));
       }
     }
   } else {
     set_lookup_failed();
-    log_info(scc)("%d (L%d): Unknown metadata's kind: %d", compile_id(), comp_level(), (int)kind);
+    log_info(aot, codecache)("%d (L%d): Unknown metadata's kind: %d", compile_id(), comp_level(), (int)kind);
   }
   return m;
 }
 
-bool SCCReader::read_metadata(OopRecorder* oop_recorder, ciMethod* target) {
+bool AOTCodeReader::read_metadata(OopRecorder* oop_recorder, ciMethod* target) {
   uint code_offset = read_position();
   int metadata_count = *(int*)addr(code_offset);
   code_offset += sizeof(int);
   set_read_position(code_offset);
 
-  log_debug(scc)("======== read metadata [%d]:", metadata_count);
+  log_debug(aot, codecache)("======== read metadata [%d]:", metadata_count);
 
   if (metadata_count == 0) {
     return true;
@@ -2768,7 +2768,7 @@ bool SCCReader::read_metadata(OopRecorder* oop_recorder, ciMethod* target) {
       } else {
         oop_recorder->allocate_metadata_index(m);
       }
-      LogTarget(Debug, scc, metadata) log;
+      LogTarget(Debug, aot, codecache, metadata) log;
       if (log.is_enabled()) {
         LogStream ls(log);
         ls.print("%d: " INTPTR_FORMAT " ", i, p2i(m));
@@ -2786,12 +2786,12 @@ bool SCCReader::read_metadata(OopRecorder* oop_recorder, ciMethod* target) {
   return true;
 }
 
-bool SCCache::write_oop(jobject& jo) {
+bool AOTCodeCache::write_oop(jobject& jo) {
   oop obj = JNIHandles::resolve(jo);
   return write_oop(obj);
 }
 
-bool SCCache::write_oop(oop obj) {
+bool AOTCodeCache::write_oop(oop obj) {
   DataKind kind;
   uint n = 0;
   if (obj == nullptr) {
@@ -2818,7 +2818,7 @@ bool SCCache::write_oop(oop obj) {
       if (n != sizeof(int)) {
         return false;
       }
-      log_info(scc)("%d (L%d): Write primitive type klass: %s", compile_id(), comp_level(), type2name((BasicType)bt));
+      log_info(aot, codecache)("%d (L%d): Write primitive type klass: %s", compile_id(), comp_level(), type2name((BasicType)bt));
     } else {
       Klass* klass = java_lang_Class::as_Klass(obj);
       if (!write_klass(klass)) {
@@ -2857,16 +2857,16 @@ bool SCCache::write_oop(oop obj) {
     if (n != (uint)length) {
       return false;
     }
-    log_info(scc)("%d (L%d): Write String: %s", compile_id(), comp_level(), string);
+    log_info(aot, codecache)("%d (L%d): Write String: %s", compile_id(), comp_level(), string);
   } else if (java_lang_Module::is_instance(obj)) {
     fatal("Module object unimplemented");
   } else if (java_lang_ClassLoader::is_instance(obj)) {
     if (obj == SystemDictionary::java_system_loader()) {
       kind = DataKind::SysLoader;
-      log_info(scc)("%d (L%d): Write ClassLoader: java_system_loader", compile_id(), comp_level());
+      log_info(aot, codecache)("%d (L%d): Write ClassLoader: java_system_loader", compile_id(), comp_level());
     } else if (obj == SystemDictionary::java_platform_loader()) {
       kind = DataKind::PlaLoader;
-      log_info(scc)("%d (L%d): Write ClassLoader: java_platform_loader", compile_id(), comp_level());
+      log_info(aot, codecache)("%d (L%d): Write ClassLoader: java_platform_loader", compile_id(), comp_level());
     } else {
       fatal("ClassLoader object unimplemented");
       return false;
@@ -2891,24 +2891,24 @@ bool SCCache::write_oop(oop obj) {
     }
     // Unhandled oop - bailout
     set_lookup_failed();
-    log_info(scc, nmethod)("%d (L%d): Unhandled obj: " PTR_FORMAT " : %s",
+    log_info(aot, codecache, nmethod)("%d (L%d): Unhandled obj: " PTR_FORMAT " : %s",
                               compile_id(), comp_level(), p2i(obj), obj->klass()->external_name());
     return false;
   }
   return true;
 }
 
-bool SCCache::write_oops(OopRecorder* oop_recorder) {
+bool AOTCodeCache::write_oops(OopRecorder* oop_recorder) {
   int oop_count = oop_recorder->oop_count();
   uint n = write_bytes(&oop_count, sizeof(int));
   if (n != sizeof(int)) {
     return false;
   }
-  log_debug(scc)("======== write oops [%d]:", oop_count);
+  log_debug(aot, codecache)("======== write oops [%d]:", oop_count);
 
   for (int i = 1; i < oop_count; i++) { // skip first virtual nullptr
     jobject jo = oop_recorder->oop_at(i);
-    LogStreamHandle(Info, scc, oops) log;
+    LogStreamHandle(Info, aot, codecache, oops) log;
     if (log.is_enabled()) {
       log.print("%d: " INTPTR_FORMAT " ", i, p2i(jo));
       if (jo == (jobject)Universe::non_oop_word()) {
@@ -2927,7 +2927,7 @@ bool SCCache::write_oops(OopRecorder* oop_recorder) {
   return true;
 }
 
-bool SCCache::write_metadata(Metadata* m) {
+bool AOTCodeCache::write_metadata(Metadata* m) {
   uint n = 0;
   if (m == nullptr) {
     DataKind kind = DataKind::Null;
@@ -2958,7 +2958,7 @@ bool SCCache::write_metadata(Metadata* m) {
     if (!write_method(((MethodCounters*)m)->method())) {
       return false;
     }
-    log_info(scc)("%d (L%d): Write MethodCounters : " INTPTR_FORMAT, compile_id(), comp_level(), p2i(m));
+    log_info(aot, codecache)("%d (L%d): Write MethodCounters : " INTPTR_FORMAT, compile_id(), comp_level(), p2i(m));
   } else { // Not supported
     fatal("metadata : " INTPTR_FORMAT " unimplemented", p2i(m));
     return false;
@@ -2966,18 +2966,18 @@ bool SCCache::write_metadata(Metadata* m) {
   return true;
 }
 
-bool SCCache::write_metadata(OopRecorder* oop_recorder) {
+bool AOTCodeCache::write_metadata(OopRecorder* oop_recorder) {
   int metadata_count = oop_recorder->metadata_count();
   uint n = write_bytes(&metadata_count, sizeof(int));
   if (n != sizeof(int)) {
     return false;
   }
 
-  log_debug(scc)("======== write metadata [%d]:", metadata_count);
+  log_debug(aot, codecache)("======== write metadata [%d]:", metadata_count);
 
   for (int i = 1; i < metadata_count; i++) { // skip first virtual nullptr
     Metadata* m = oop_recorder->metadata_at(i);
-    LogStreamHandle(Debug, scc, metadata) log;
+    LogStreamHandle(Debug, aot, codecache, metadata) log;
     if (log.is_enabled()) {
       log.print("%d: " INTPTR_FORMAT " ", i, p2i(m));
       if (m == (Metadata*)Universe::non_oop_word()) {
@@ -2996,11 +2996,11 @@ bool SCCache::write_metadata(OopRecorder* oop_recorder) {
   return true;
 }
 
-bool SCCReader::read_dependencies(Dependencies* dependencies) {
+bool AOTCodeReader::read_dependencies(Dependencies* dependencies) {
   uint code_offset = read_position();
   int dependencies_size = *(int*)addr(code_offset);
 
-  log_debug(scc)("======== read dependencies [%d]:", dependencies_size);
+  log_debug(aot, codecache)("======== read dependencies [%d]:", dependencies_size);
 
   code_offset += sizeof(int);
   code_offset = align_up(code_offset, DATA_ALIGNMENT);
@@ -3012,19 +3012,19 @@ bool SCCReader::read_dependencies(Dependencies* dependencies) {
   return true;
 }
 
-bool SCCache::load_nmethod(ciEnv* env, ciMethod* target, int entry_bci, AbstractCompiler* compiler, CompLevel comp_level) {
+bool AOTCodeCache::load_nmethod(ciEnv* env, ciMethod* target, int entry_bci, AbstractCompiler* compiler, CompLevel comp_level) {
   assert(entry_bci == InvocationEntryBci, "unexpected entry_bci=%d", entry_bci);
-  TraceTime t1("SC total load time", &_t_totalLoad, enable_timers(), false);
+  TraceTime t1("Total time to load AOT code", &_t_totalLoad, enable_timers(), false);
   CompileTask* task = env->task();
   task->mark_aot_load_start(os::elapsed_counter());
-  SCCEntry* entry = task->scc_entry();
+  AOTCodeEntry* entry = task->aot_code_entry();
   bool preload = task->preload();
   assert(entry != nullptr, "sanity");
-  SCCache* cache = open_for_read();
+  AOTCodeCache* cache = open_for_read();
   if (cache == nullptr) {
     return false;
   }
-  if (log_is_enabled(Info, scc, nmethod)) {
+  if (log_is_enabled(Info, aot, codecache, nmethod)) {
     uint decomp = (target->method_data() == nullptr) ? 0 : target->method_data()->decompile_count();
     VM_ENTRY_MARK;
     ResourceMark rm;
@@ -3032,7 +3032,7 @@ bool SCCache::load_nmethod(ciEnv* env, ciMethod* target, int entry_bci, Abstract
     const char* target_name = method->name_and_sig_as_C_string();
     uint hash = java_lang_String::hash_code((const jbyte*)target_name, (int)strlen(target_name));
     bool clinit_brs = entry->has_clinit_barriers();
-    log_info(scc, nmethod)("%d (L%d): %s nmethod '%s' (decomp: %d, hash: " UINT32_FORMAT_X_0 "%s%s)",
+    log_info(aot, codecache, nmethod)("%d (L%d): %s nmethod '%s' (decomp: %d, hash: " UINT32_FORMAT_X_0 "%s%s)",
                            task->compile_id(), task->comp_level(), (preload ? "Preloading" : "Reading"),
                            target_name, decomp, hash, (clinit_brs ? ", has clinit barriers" : ""),
                            (entry->ignore_decompile() ? ", ignore_decomp" : ""));
@@ -3043,7 +3043,7 @@ bool SCCache::load_nmethod(ciEnv* env, ciMethod* target, int entry_bci, Abstract
     return false;
   }
 
-  SCCReader reader(cache, entry, task);
+  AOTCodeReader reader(cache, entry, task);
   bool success = reader.compile_nmethod(env, target, compiler);
   if (success) {
     task->set_num_inlined_bytecodes(entry->num_inlined_bytecodes());
@@ -3054,7 +3054,7 @@ bool SCCache::load_nmethod(ciEnv* env, ciMethod* target, int entry_bci, Abstract
   return success;
 }
 
-SCCReader::SCCReader(SCCache* cache, SCCEntry* entry, CompileTask* task) {
+AOTCodeReader::AOTCodeReader(AOTCodeCache* cache, AOTCodeEntry* entry, CompileTask* task) {
   _cache = cache;
   _entry   = entry;
   _load_buffer = cache->cache_buffer();
@@ -3071,7 +3071,7 @@ SCCReader::SCCReader(SCCache* cache, SCCEntry* entry, CompileTask* task) {
   _lookup_failed = false;
 }
 
-bool SCCReader::read_oop_metadata_list(JavaThread* thread, ciMethod* target, GrowableArray<Handle> &oop_list, GrowableArray<Metadata*> &metadata_list, OopRecorder* oop_recorder) {
+bool AOTCodeReader::read_oop_metadata_list(JavaThread* thread, ciMethod* target, GrowableArray<Handle> &oop_list, GrowableArray<Metadata*> &metadata_list, OopRecorder* oop_recorder) {
   methodHandle comp_method(JavaThread::current(), target->get_Method());
   JavaThread* current = JavaThread::current();
   uint offset = read_position();
@@ -3093,7 +3093,7 @@ bool SCCReader::read_oop_metadata_list(JavaThread* thread, ciMethod* target, Gro
         oop_recorder->allocate_oop_index(jo);
       }
     }
-    LogStreamHandle(Debug, scc, oops) log;
+    LogStreamHandle(Debug, aot, codecache, oops) log;
     if (log.is_enabled()) {
       log.print("%d: " INTPTR_FORMAT " ", i, p2i(obj));
       if (obj == Universe::non_oop_word()) {
@@ -3124,7 +3124,7 @@ bool SCCReader::read_oop_metadata_list(JavaThread* thread, ciMethod* target, Gro
         oop_recorder->allocate_metadata_index(m);
       }
     }
-    LogTarget(Debug, scc, metadata) log;
+    LogTarget(Debug, aot, codecache, metadata) log;
     if (log.is_enabled()) {
       LogStream ls(log);
       ls.print("%d: " INTPTR_FORMAT " ", i, p2i(m));
@@ -3141,7 +3141,7 @@ bool SCCReader::read_oop_metadata_list(JavaThread* thread, ciMethod* target, Gro
   return true;
 }
 
-ImmutableOopMapSet* SCCReader::read_oop_map_set() {
+ImmutableOopMapSet* AOTCodeReader::read_oop_map_set() {
   uint offset = read_position();
   int size = *(int *)addr(offset);
   offset += sizeof(int);
@@ -3151,13 +3151,13 @@ ImmutableOopMapSet* SCCReader::read_oop_map_set() {
   return oopmaps;
 }
 
-bool SCCReader::compile_nmethod(ciEnv* env, ciMethod* target, AbstractCompiler* compiler) {
+bool AOTCodeReader::compile_nmethod(ciEnv* env, ciMethod* target, AbstractCompiler* compiler) {
   CompileTask* task = env->task();
-  SCCEntry *scc_entry = (SCCEntry*)_entry;
+  AOTCodeEntry *aot_code_entry = (AOTCodeEntry*)_entry;
   nmethod* nm = nullptr;
 
-  uint entry_position = scc_entry->offset();
-  uint archived_nm_offset = entry_position + scc_entry->code_offset();
+  uint entry_position = aot_code_entry->offset();
+  uint archived_nm_offset = entry_position + aot_code_entry->code_offset();
   nmethod* archived_nm = (nmethod*)addr(archived_nm_offset);
   set_read_position(archived_nm_offset + archived_nm->size());
 
@@ -3229,7 +3229,7 @@ bool SCCReader::compile_nmethod(ciEnv* env, ciMethod* target, AbstractCompiler* 
     return false;
   }
 
-  TraceTime t1("SC total nmethod register time", &_t_totalRegister, enable_timers(), false);
+  TraceTime t1("Total time to register AOT nmethod", &_t_totalRegister, enable_timers(), false);
   env->register_aot_method(THREAD,
                            target,
                            compiler,
@@ -3246,13 +3246,13 @@ bool SCCReader::compile_nmethod(ciEnv* env, ciMethod* target, AbstractCompiler* 
                            this);
   bool success = task->is_success();
   if (success) {
-    scc_entry->set_loaded();
+    aot_code_entry->set_loaded();
   }
   return success;
 }
 
-void SCCReader::apply_relocations(nmethod* nm, GrowableArray<Handle> &oop_list, GrowableArray<Metadata*> &metadata_list) {
-  LogStreamHandle(Info, scc, reloc) log;
+void AOTCodeReader::apply_relocations(nmethod* nm, GrowableArray<Handle> &oop_list, GrowableArray<Metadata*> &metadata_list) {
+  LogStreamHandle(Info, aot, codecache, reloc) log;
   uint buffer_offset = read_position();
   int count = *(int*)addr(buffer_offset);
   buffer_offset += sizeof(int);
@@ -3335,12 +3335,12 @@ void SCCReader::apply_relocations(nmethod* nm, GrowableArray<Handle> &oop_list, 
       }
       case relocInfo::internal_word_type: {
         internal_word_Relocation* r = (internal_word_Relocation*)iter.reloc();
-        r->fix_relocation_after_aot_load(scc_entry()->dumptime_content_start_addr(), nm->content_begin());
+        r->fix_relocation_after_aot_load(aot_code_entry()->dumptime_content_start_addr(), nm->content_begin());
         break;
       }
       case relocInfo::section_word_type: {
         section_word_Relocation* r = (section_word_Relocation*)iter.reloc();
-        r->fix_relocation_after_aot_load(scc_entry()->dumptime_content_start_addr(), nm->content_begin());
+        r->fix_relocation_after_aot_load(aot_code_entry()->dumptime_content_start_addr(), nm->content_begin());
         break;
       }
       case relocInfo::poll_type:
@@ -3363,7 +3363,7 @@ void SCCReader::apply_relocations(nmethod* nm, GrowableArray<Handle> &oop_list, 
   assert(j == count, "must be");
 }
 
-SCCEntry* SCCache::store_nmethod(nmethod* nm, AbstractCompiler* compiler, bool for_preload) {
+AOTCodeEntry* AOTCodeCache::store_nmethod(nmethod* nm, AbstractCompiler* compiler, bool for_preload) {
   if (!CDSConfig::is_dumping_cached_code()) {
     return nullptr; // The metadata and heap in the CDS image haven't been finalized yet.
   }
@@ -3381,20 +3381,20 @@ SCCEntry* SCCache::store_nmethod(nmethod* nm, AbstractCompiler* compiler, bool f
   }
   assert(comp_level == CompLevel_simple || comp_level == CompLevel_limited_profile || comp_level == CompLevel_full_optimization, "must be");
 
-  TraceTime t1("SC total store time", &_t_totalStore, enable_timers(), false);
-  SCCache* cache = open_for_write();
+  TraceTime t1("Total time to store AOT code", &_t_totalStore, enable_timers(), false);
+  AOTCodeCache* cache = open_for_write();
   if (cache == nullptr) {
     return nullptr; // Cache file is closed
   }
-  SCCEntry* entry = nullptr;
+  AOTCodeEntry* entry = nullptr;
   entry = cache->write_nmethod(nm, for_preload);
   if (entry == nullptr) {
-    log_info(scc, nmethod)("%d (L%d): nmethod store attempt failed", nm->compile_id(), comp_level);
+    log_info(aot, codecache, nmethod)("%d (L%d): nmethod store attempt failed", nm->compile_id(), comp_level);
   }
   return entry;
 }
 
-bool SCCache::write_oops(nmethod* nm) {
+bool AOTCodeCache::write_oops(nmethod* nm) {
   int count = nm->oops_count()-1;
   if (!write_bytes(&count, sizeof(int))) {
     return false;
@@ -3407,7 +3407,7 @@ bool SCCache::write_oops(nmethod* nm) {
   return true;
 }
 
-bool SCCache::write_metadata(nmethod* nm) {
+bool AOTCodeCache::write_metadata(nmethod* nm) {
   int count = nm->metadata_count()-1;
   if (!write_bytes(&count, sizeof(int))) {
     return false;
@@ -3420,7 +3420,7 @@ bool SCCache::write_metadata(nmethod* nm) {
   return true;
 }
 
-bool SCCache::write_oop_map_set(nmethod* nm) {
+bool AOTCodeCache::write_oop_map_set(nmethod* nm) {
   ImmutableOopMapSet* oopmaps = nm->oop_maps();
   int oopmaps_size = oopmaps->nr_of_bytes();
   if (!write_bytes(&oopmaps_size, sizeof(int))) {
@@ -3433,7 +3433,7 @@ bool SCCache::write_oop_map_set(nmethod* nm) {
   return true;
 }
 
-SCCEntry* SCCache::write_nmethod(nmethod* nm, bool for_preload) {
+AOTCodeEntry* AOTCodeCache::write_nmethod(nmethod* nm, bool for_preload) {
   assert(!nm->has_clinit_barriers() || _gen_preload_code, "sanity");
   uint comp_id = nm->compile_id();
   uint comp_level = nm->comp_level();
@@ -3444,12 +3444,12 @@ SCCEntry* SCCache::write_nmethod(nmethod* nm, bool for_preload) {
   bool builtin_loader = holder->class_loader_data()->is_builtin_class_loader_data();
   if (!builtin_loader) {
     ResourceMark rm;
-    log_info(scc, nmethod)("%d (L%d): Skip method '%s' loaded by custom class loader %s", comp_id, (int)comp_level, method->name_and_sig_as_C_string(), holder->class_loader_data()->loader_name());
+    log_info(aot, codecache, nmethod)("%d (L%d): Skip method '%s' loaded by custom class loader %s", comp_id, (int)comp_level, method->name_and_sig_as_C_string(), holder->class_loader_data()->loader_name());
     return nullptr;
   }
   if (for_preload && !(method_in_cds && klass_in_cds)) {
     ResourceMark rm;
-    log_info(scc, nmethod)("%d (L%d): Skip method '%s' for preload: not in CDS", comp_id, (int)comp_level, method->name_and_sig_as_C_string());
+    log_info(aot, codecache, nmethod)("%d (L%d): Skip method '%s' for preload: not in CDS", comp_id, (int)comp_level, method->name_and_sig_as_C_string());
     return nullptr;
   }
   assert(!for_preload || method_in_cds, "sanity");
@@ -3480,12 +3480,12 @@ SCCEntry* SCCache::write_nmethod(nmethod* nm, bool for_preload) {
   {
     ResourceMark rm;
     const char* name = method->name_and_sig_as_C_string();
-    log_info(scc, nmethod)("%d (L%d): Writing nmethod '%s' (comp level: %d, decomp: %d%s%s) to AOT Code Cache",
+    log_info(aot, codecache, nmethod)("%d (L%d): Writing nmethod '%s' (comp level: %d, decomp: %d%s%s) to AOT Code Cache",
                            comp_id, (int)comp_level, name, comp_level, decomp,
                            (ignore_decompile ? ", ignore_decomp" : ""),
                            (nm->has_clinit_barriers() ? ", has clinit barriers" : ""));
 
-    LogStreamHandle(Info, scc, loader) log;
+    LogStreamHandle(Info, aot, codecache, loader) log;
     if (log.is_enabled()) {
       oop loader = holder->class_loader();
       oop domain = holder->protection_domain();
@@ -3531,7 +3531,7 @@ SCCEntry* SCCache::write_nmethod(nmethod* nm, bool for_preload) {
   }
   uint count = 0;
   bool result = nm->asm_remarks().iterate([&] (uint offset, const char* str) -> bool {
-    log_info(scc, nmethod)("asm remark offset=%d, str=%s", offset, str);
+    log_info(aot, codecache, nmethod)("asm remark offset=%d, str=%s", offset, str);
     n = write_bytes(&offset, sizeof(uint));
     if (n != sizeof(uint)) {
       return false;
@@ -3555,7 +3555,7 @@ SCCEntry* SCCache::write_nmethod(nmethod* nm, bool for_preload) {
   }
   count = 0;
   result = nm->dbg_strings().iterate([&] (const char* str) -> bool {
-    log_info(scc, nmethod)("dbg string=%s", str);
+    log_info(aot, codecache, nmethod)("dbg string=%s", str);
     n = write_bytes(str, (uint)strlen(str) + 1);
     if (n != strlen(str) + 1) {
       return false;
@@ -3620,9 +3620,9 @@ SCCEntry* SCCache::write_nmethod(nmethod* nm, bool for_preload) {
   }
 
   uint entry_size = _write_position - entry_position;
-  SCCEntry* entry = new (this) SCCEntry(entry_position, entry_size, name_offset, name_size,
+  AOTCodeEntry* entry = new (this) AOTCodeEntry(entry_position, entry_size, name_offset, name_size,
                                         archived_nm_offset, 0, 0, 0,
-                                        SCCEntry::Code, hash, nm->content_begin(), comp_level, comp_id, decomp,
+                                        AOTCodeEntry::Code, hash, nm->content_begin(), comp_level, comp_id, decomp,
                                         nm->has_clinit_barriers(), for_preload, ignore_decompile);
   if (method_in_cds) {
     entry->set_method(method);
@@ -3636,7 +3636,7 @@ SCCEntry* SCCache::write_nmethod(nmethod* nm, bool for_preload) {
   {
     ResourceMark rm;
     const char* name = nm->method()->name_and_sig_as_C_string();
-    log_info(scc, nmethod)("%d (L%d): Wrote nmethod '%s'%s to AOT Code Cache",
+    log_info(aot, codecache, nmethod)("%d (L%d): Wrote nmethod '%s'%s to AOT Code Cache",
                            comp_id, (int)comp_level, name, (for_preload ? " (for preload)" : ""));
   }
   if (VerifyCachedCode) {
@@ -3645,8 +3645,8 @@ SCCEntry* SCCache::write_nmethod(nmethod* nm, bool for_preload) {
   return entry;
 }
 
-bool SCCache::write_nmethod_loadtime_relocations(JavaThread* thread, nmethod* nm, GrowableArray<Handle>& oop_list, GrowableArray<Metadata*>& metadata_list) {
-  LogStreamHandle(Info, scc, reloc) log;
+bool AOTCodeCache::write_nmethod_loadtime_relocations(JavaThread* thread, nmethod* nm, GrowableArray<Handle>& oop_list, GrowableArray<Metadata*>& metadata_list) {
+  LogStreamHandle(Info, aot, codecache, reloc) log;
   GrowableArray<uint> reloc_data;
   // Collect additional data
   RelocIterator iter(nm);
@@ -3758,7 +3758,7 @@ bool SCCache::write_nmethod_loadtime_relocations(JavaThread* thread, nmethod* nm
   return true; //success;
 }
 
-bool SCCache::write_nmethod_reloc_immediates(GrowableArray<Handle>& oop_list, GrowableArray<Metadata*>& metadata_list) {
+bool AOTCodeCache::write_nmethod_reloc_immediates(GrowableArray<Handle>& oop_list, GrowableArray<Metadata*>& metadata_list) {
   int count = oop_list.length();
   if (!write_bytes(&count, sizeof(int))) {
     return false;
@@ -3791,8 +3791,8 @@ static void print_helper1(outputStream* st, const char* name, int count) {
   }
 }
 
-void SCCache::print_statistics_on(outputStream* st) {
-  SCCache* cache = open_for_read();
+void AOTCodeCache::print_statistics_on(outputStream* st) {
+  AOTCodeCache* cache = open_for_read();
   if (cache != nullptr) {
     ReadingMark rdmk;
     if (rdmk.failed()) {
@@ -3802,26 +3802,26 @@ void SCCache::print_statistics_on(outputStream* st) {
 
     uint count = cache->_load_header->entries_count();
     uint* search_entries = (uint*)cache->addr(cache->_load_header->entries_offset()); // [id, index]
-    SCCEntry* load_entries = (SCCEntry*)(search_entries + 2 * count);
+    AOTCodeEntry* load_entries = (AOTCodeEntry*)(search_entries + 2 * count);
 
     AOTCodeStats stats;
     for (uint i = 0; i < count; i++) {
       stats.collect_all_stats(&load_entries[i]);
     }
 
-    for (uint kind = SCCEntry::None; kind < SCCEntry::Kind_count; kind++) {
+    for (uint kind = AOTCodeEntry::None; kind < AOTCodeEntry::Kind_count; kind++) {
       if (stats.entry_count(kind) > 0) {
-        st->print("  %s:", sccentry_kind_name[kind]);
+        st->print("  %s:", aot_code_entry_kind_name[kind]);
         print_helper1(st, "total", stats.entry_count(kind));
         print_helper1(st, "loaded", stats.entry_loaded_count(kind));
         print_helper1(st, "invalidated", stats.entry_invalidated_count(kind));
         print_helper1(st, "failed", stats.entry_load_failed_count(kind));
         st->cr();
       }
-      if (kind == SCCEntry::Code) {
+      if (kind == AOTCodeEntry::Code) {
         for (uint lvl = CompLevel_none; lvl < AOTCompLevel_count; lvl++) {
           if (stats.nmethod_count(lvl) > 0) {
-            st->print("    SC T%d", lvl);
+            st->print("    AOT Code T%d", lvl);
             print_helper1(st, "total", stats.nmethod_count(lvl));
             print_helper1(st, "loaded", stats.nmethod_loaded_count(lvl));
             print_helper1(st, "invalidated", stats.nmethod_invalidated_count(lvl));
@@ -3839,8 +3839,8 @@ void SCCache::print_statistics_on(outputStream* st) {
   }
 }
 
-void SCCache::print_on(outputStream* st) {
-  SCCache* cache = open_for_read();
+void AOTCodeCache::print_on(outputStream* st) {
+  AOTCodeCache* cache = open_for_read();
   if (cache != nullptr) {
     ReadingMark rdmk;
     if (rdmk.failed()) {
@@ -3850,11 +3850,11 @@ void SCCache::print_on(outputStream* st) {
 
     uint count = cache->_load_header->entries_count();
     uint* search_entries = (uint*)cache->addr(cache->_load_header->entries_offset()); // [id, index]
-    SCCEntry* load_entries = (SCCEntry*)(search_entries + 2 * count);
+    AOTCodeEntry* load_entries = (AOTCodeEntry*)(search_entries + 2 * count);
 
     for (uint i = 0; i < count; i++) {
       int index = search_entries[2*i + 1];
-      SCCEntry* entry = &(load_entries[index]);
+      AOTCodeEntry* entry = &(load_entries[index]);
 
       st->print_cr("%4u: %4u: K%u L%u offset=%u decompile=%u size=%u code_size=%u%s%s%s%s",
                 i, index, entry->kind(), entry->comp_level(), entry->offset(),
@@ -3864,7 +3864,7 @@ void SCCache::print_on(outputStream* st) {
                 entry->is_loaded()           ? " loaded"              : "",
                 entry->not_entrant()         ? " not_entrant"         : "");
       st->print_raw("         ");
-      SCCReader reader(cache, entry, nullptr);
+      AOTCodeReader reader(cache, entry, nullptr);
       reader.print_on(st);
     }
   } else {
@@ -3872,10 +3872,10 @@ void SCCache::print_on(outputStream* st) {
   }
 }
 
-void SCCache::print_unused_entries_on(outputStream* st) {
-  LogStreamHandle(Info, scc, init) info;
+void AOTCodeCache::print_unused_entries_on(outputStream* st) {
+  LogStreamHandle(Info, aot, codecache, init) info;
   if (info.is_enabled()) {
-    SCCache::iterate([&](SCCEntry* entry) {
+    AOTCodeCache::iterate([&](AOTCodeEntry* entry) {
       if (entry->is_code() && !entry->is_loaded()) {
         MethodTrainingData* mtd = MethodTrainingData::find(methodHandle(Thread::current(), entry->method()));
         if (mtd != nullptr) {
@@ -3893,7 +3893,7 @@ void SCCache::print_unused_entries_on(outputStream* st) {
                     } else if ((uint)nm->comp_level() >= entry->comp_level()) {
                       return; // already online compiled and superseded by a more optimal method
                     }
-                    info.print("SCC entry not loaded: ");
+                    info.print("AOT Code Cache entry not loaded: ");
                     ctd->print_on(&info);
                     info.cr();
                   }
@@ -3903,7 +3903,7 @@ void SCCache::print_unused_entries_on(outputStream* st) {
               // not yet initialized
             }
           } else {
-            info.print("SCC entry doesn't have a holder: ");
+            info.print("AOT Code Cache entry doesn't have a holder: ");
             mtd->print_on(&info);
             info.cr();
           }
@@ -3913,7 +3913,7 @@ void SCCache::print_unused_entries_on(outputStream* st) {
   }
 }
 
-void SCCReader::print_on(outputStream* st) {
+void AOTCodeReader::print_on(outputStream* st) {
   uint entry_position = _entry->offset();
   set_read_position(entry_position);
 
@@ -3947,7 +3947,7 @@ void SCCReader::print_on(outputStream* st) {
 #define _C1_blobs_base (_blobs_base + _blobs_max)
 #define _C2_blobs_base (_C1_blobs_base + _C1_blobs_max)
 #if (_C2_blobs_base >= _all_max)
-#error SCAddress table ranges need adjusting
+#error AOTCodeAddressTable ranges need adjusting
 #endif
 #define _c_str_base _all_max
 
@@ -3958,7 +3958,7 @@ void SCCReader::print_on(outputStream* st) {
   }
 
 static bool initializing_extrs = false;
-void SCAddressTable::init_extrs() {
+void AOTCodeAddressTable::init_extrs() {
   if (_extrs_complete || initializing_extrs) return; // Done already
   initializing_extrs = true;
   _extrs_addr = NEW_C_HEAP_ARRAY(address, _extrs_max, mtCode);
@@ -4081,22 +4081,22 @@ void SCAddressTable::init_extrs() {
   }
 
   _extrs_complete = true;
-  log_info(scc,init)("External addresses recorded");
+  log_info(aot, codecache,init)("External addresses recorded");
 }
 
 static bool initializing_early_stubs = false;
-void SCAddressTable::init_early_stubs() {
+void AOTCodeAddressTable::init_early_stubs() {
   if (_complete || initializing_early_stubs) return; // Done already
   initializing_early_stubs = true;
   _stubs_addr = NEW_C_HEAP_ARRAY(address, _stubs_max, mtCode);
   _stubs_length = 0;
   SET_ADDRESS(_stubs, StubRoutines::forward_exception_entry());
   _early_stubs_complete = true;
-  log_info(scc,init)("early stubs recorded");
+  log_info(aot, codecache,init)("early stubs recorded");
 }
 
 static bool initializing_shared_blobs = false;
-void SCAddressTable::init_shared_blobs() {
+void AOTCodeAddressTable::init_shared_blobs() {
   if (_complete || initializing_shared_blobs) return; // Done already
   initializing_shared_blobs = true;
   _blobs_addr = NEW_C_HEAP_ARRAY(address, _all_blobs_max, mtCode);
@@ -4123,11 +4123,11 @@ void SCAddressTable::init_shared_blobs() {
 #endif
 
   assert(_blobs_length <= _blobs_max, "increase _blobs_max to %d", _blobs_length);
-  log_info(scc,init)("Early shared blobs recorded");
+  log_info(aot, codecache,init)("Early shared blobs recorded");
 }
 
 static bool initializing_stubs = false;
-void SCAddressTable::init_stubs() {
+void AOTCodeAddressTable::init_stubs() {
   if (_complete || initializing_stubs) return; // Done already
   initializing_stubs = true;
   // final blobs
@@ -4140,7 +4140,7 @@ void SCAddressTable::init_stubs() {
   assert(_blobs_length <= _blobs_max, "increase _blobs_max to %d", _blobs_length);
 
   _shared_blobs_complete = true;
-  log_info(scc,init)("All shared blobs recorded");
+  log_info(aot, codecache,init)("All shared blobs recorded");
 
   // Stubs
   SET_ADDRESS(_stubs, StubRoutines::method_entry_barrier());
@@ -4305,10 +4305,10 @@ void SCAddressTable::init_stubs() {
 #endif
 
   _complete = true;
-  log_info(scc,init)("Stubs recorded");
+  log_info(aot, codecache,init)("Stubs recorded");
 }
 
-void SCAddressTable::init_opto() {
+void AOTCodeAddressTable::init_opto() {
 #ifdef COMPILER2
   // OptoRuntime Blobs
   SET_ADDRESS(_C2_blobs, OptoRuntime::uncommon_trap_blob()->entry_point());
@@ -4339,20 +4339,20 @@ void SCAddressTable::init_opto() {
 
   assert(_C2_blobs_length <= _C2_blobs_max, "increase _C2_blobs_max to %d", _C2_blobs_length);
   _opto_complete = true;
-  log_info(scc,init)("OptoRuntime Blobs recorded");
+  log_info(aot, codecache,init)("OptoRuntime Blobs recorded");
 }
 
-void SCAddressTable::init_c1() {
+void AOTCodeAddressTable::init_c1() {
 #ifdef COMPILER1
   // Runtime1 Blobs
   for (int i = 0; i < (int)(C1StubId::NUM_STUBIDS); i++) {
     C1StubId id = (C1StubId)i;
     if (Runtime1::blob_for(id) == nullptr) {
-      log_info(scc, init)("C1 blob %s is missing", Runtime1::name_for(id));
+      log_info(aot, codecache, init)("C1 blob %s is missing", Runtime1::name_for(id));
       continue;
     }
     if (Runtime1::entry_for(id) == nullptr) {
-      log_info(scc, init)("C1 blob %s is missing entry", Runtime1::name_for(id));
+      log_info(aot, codecache, init)("C1 blob %s is missing entry", Runtime1::name_for(id));
       continue;
     }
     address entry = Runtime1::entry_for(id);
@@ -4390,12 +4390,12 @@ void SCAddressTable::init_c1() {
 
   assert(_C1_blobs_length <= _C1_blobs_max, "increase _C1_blobs_max to %d", _C1_blobs_length);
   _c1_complete = true;
-  log_info(scc,init)("Runtime1 Blobs recorded");
+  log_info(aot, codecache,init)("Runtime1 Blobs recorded");
 }
 
 #undef SET_ADDRESS
 
-SCAddressTable::~SCAddressTable() {
+AOTCodeAddressTable::~AOTCodeAddressTable() {
   if (_extrs_addr != nullptr) {
     FREE_C_HEAP_ARRAY(address, _extrs_addr);
   }
@@ -4420,7 +4420,7 @@ static int _C_strings_len[MAX_STR_COUNT] = {0};
 static int _C_strings_hash[MAX_STR_COUNT] = {0};
 static int _C_strings_used = 0;
 
-void SCCache::load_strings() {
+void AOTCodeCache::load_strings() {
   uint strings_count  = _load_header->strings_count();
   if (strings_count == 0) {
     return;
@@ -4450,10 +4450,10 @@ void SCCache::load_strings() {
   assert((uint)(p - _C_strings_buf) <= strings_size, "(" INTPTR_FORMAT " - " INTPTR_FORMAT ") = %d > %d ", p2i(p), p2i(_C_strings_buf), (uint)(p - _C_strings_buf), strings_size);
   _C_strings_count = strings_count;
   _C_strings_used  = strings_count;
-  log_info(scc, init)("Load %d C strings at offset %d from AOT Code Cache", _C_strings_count, strings_offset);
+  log_info(aot, codecache, init)("Load %d C strings at offset %d from AOT Code Cache", _C_strings_count, strings_offset);
 }
 
-int SCCache::store_strings() {
+int AOTCodeCache::store_strings() {
   uint offset = _write_position;
   uint length = 0;
   if (_C_strings_used > 0) {
@@ -4481,18 +4481,18 @@ int SCCache::store_strings() {
         return -1;
       }
     }
-    log_info(scc, exit)("Wrote %d C strings of total length %d at offset %d to AOT Code Cache",
+    log_info(aot, codecache, exit)("Wrote %d C strings of total length %d at offset %d to AOT Code Cache",
                         _C_strings_used, length, offset);
   }
   return _C_strings_used;
 }
 
-void SCCache::add_new_C_string(const char* str) {
+void AOTCodeCache::add_new_C_string(const char* str) {
   assert(for_write(), "only when storing code");
   _table->add_C_string(str);
 }
 
-void SCAddressTable::add_C_string(const char* str) {
+void AOTCodeAddressTable::add_C_string(const char* str) {
   if (str != nullptr && _extrs_complete) {
     // Check previous strings address
     for (int i = 0; i < _C_strings_count; i++) {
@@ -4502,20 +4502,20 @@ void SCAddressTable::add_C_string(const char* str) {
     }
     // Add new one
     if (_C_strings_count < MAX_STR_COUNT) {
-      log_trace(scc)("add_C_string: [%d] " INTPTR_FORMAT " %s", _C_strings_count, p2i(str), str);
+      log_trace(aot, codecache)("add_C_string: [%d] " INTPTR_FORMAT " %s", _C_strings_count, p2i(str), str);
       _C_strings_id[_C_strings_count] = -1; // Init
       _C_strings[_C_strings_count++] = str;
     } else {
       if (Thread::current()->is_Compiler_thread()) {
         CompileTask* task = ciEnv::current()->task();
-        log_info(scc)("%d (L%d): Number of C strings > max %d %s",
+        log_info(aot, codecache)("%d (L%d): Number of C strings > max %d %s",
                       task->compile_id(), task->comp_level(), MAX_STR_COUNT, str);
       }
     }
   }
 }
 
-int SCAddressTable::id_for_C_string(address str) {
+int AOTCodeAddressTable::id_for_C_string(address str) {
   for (int i = 0; i < _C_strings_count; i++) {
     if (_C_strings[i] == (const char*)str) { // found
       int id = _C_strings_id[i];
@@ -4544,7 +4544,7 @@ int SCAddressTable::id_for_C_string(address str) {
   return -1;
 }
 
-address SCAddressTable::address_for_C_string(int idx) {
+address AOTCodeAddressTable::address_for_C_string(int idx) {
   assert(idx < _C_strings_count, "sanity");
   return (address)_C_strings[idx];
 }
@@ -4558,9 +4558,9 @@ int search_address(address addr, address* table, uint length) {
   return -1;
 }
 
-address SCAddressTable::address_for_id(int idx) {
+address AOTCodeAddressTable::address_for_id(int idx) {
   if (!_extrs_complete) {
-    fatal("SCA extrs table is not complete");
+    fatal("AOT Code Cache VM runtime addresses table is not complete");
   }
   if (idx == -1) {
     return (address)-1;
@@ -4571,7 +4571,7 @@ address SCAddressTable::address_for_id(int idx) {
     return (address)os::init + idx;
   }
   if (idx < 0) {
-    fatal("Incorrect id %d for SCA table", id);
+    fatal("Incorrect id %d for AOT Code Cache addresses table", id);
   }
   // no need to compare unsigned id against 0
   if (/* id >= _extrs_base && */ id < _extrs_length) {
@@ -4592,17 +4592,17 @@ address SCAddressTable::address_for_id(int idx) {
   if (id >= _c_str_base && id < (_c_str_base + (uint)_C_strings_count)) {
     return address_for_C_string(id - _c_str_base);
   }
-  fatal("Incorrect id %d for SCA table", id);
+  fatal("Incorrect id %d for AOT Code Cache addresses table", id);
   return nullptr;
 }
 
-int SCAddressTable::id_for_address(address addr, RelocIterator reloc, CodeBuffer* buffer) {
+int AOTCodeAddressTable::id_for_address(address addr, RelocIterator reloc, CodeBuffer* buffer) {
+  if (!_extrs_complete) {
+    fatal("AOT Code Cache VM runtime addresses table is not complete");
+  }
   int id = -1;
   if (addr == (address)-1) { // Static call stub has jump to itself
     return id;
-  }
-  if (!_extrs_complete) {
-    fatal("SCA table is not complete");
   }
   // Seach for C string
   id = id_for_C_string(addr);
@@ -4618,7 +4618,7 @@ int SCAddressTable::id_for_address(address addr, RelocIterator reloc, CodeBuffer
         desc = StubCodeDesc::desc_for(addr + frame::pc_return_offset);
       }
       const char* sub_name = (desc != nullptr) ? desc->name() : "<unknown>";
-      fatal("Address " INTPTR_FORMAT " for Stub:%s is missing in SCA table", p2i(addr), sub_name);
+      fatal("Address " INTPTR_FORMAT " for Stub:%s is missing in AOT Code Cache addresses table", p2i(addr), sub_name);
     } else {
       return _stubs_base + id;
     }
@@ -4639,7 +4639,7 @@ int SCAddressTable::id_for_address(address addr, RelocIterator reloc, CodeBuffer
         id = search_address(addr, _C2_blobs_addr, _C2_blobs_length);
       }
       if (id < 0) {
-        fatal("Address " INTPTR_FORMAT " for Blob:%s is missing in SCA table", p2i(addr), cb->name());
+        fatal("Address " INTPTR_FORMAT " for Blob:%s is missing in AOT Code Cache addresses table", p2i(addr), cb->name());
       } else {
         return id_base + id;
       }
@@ -4662,12 +4662,12 @@ int SCAddressTable::id_for_address(address addr, RelocIterator reloc, CodeBuffer
               compile_id = task->compile_id();
               comp_level = task->comp_level();
             }
-            log_info(scc)("%d (L%d): Address " INTPTR_FORMAT " (offset %d) for runtime target '%s' is missing in SCA table",
+            log_info(aot, codecache)("%d (L%d): Address " INTPTR_FORMAT " (offset %d) for runtime target '%s' is missing in AOT Code Cache addresses table",
                           compile_id, comp_level, p2i(addr), dist, (const char*)addr);
             assert(dist > (uint)(_all_max + MAX_STR_COUNT), "change encoding of distance");
             return dist;
           }
-          fatal("Address " INTPTR_FORMAT " for runtime target '%s+%d' is missing in SCA table", p2i(addr), func_name, offset);
+          fatal("Address " INTPTR_FORMAT " for runtime target '%s+%d' is missing in AOT Code Cache addresses table", p2i(addr), func_name, offset);
         } else {
           os::print_location(tty, p2i(addr), true);
           reloc.print_current_on(tty);
@@ -4675,7 +4675,7 @@ int SCAddressTable::id_for_address(address addr, RelocIterator reloc, CodeBuffer
           buffer->print_on(tty);
           buffer->decode();
 #endif // !PRODUCT
-          fatal("Address " INTPTR_FORMAT " for <unknown> is missing in SCA table", p2i(addr));
+          fatal("Address " INTPTR_FORMAT " for <unknown> is missing in AOT Code Cache addresses table", p2i(addr));
         }
       } else {
         return _extrs_base + id;
@@ -4716,7 +4716,7 @@ address AOTRuntimeConstants::_field_addresses_list[] = {
 };
 
 
-void SCCache::wait_for_no_nmethod_readers() {
+void AOTCodeCache::wait_for_no_nmethod_readers() {
   while (true) {
     int cur = Atomic::load(&_nmethod_readers);
     int upd = -(cur + 1);
@@ -4733,7 +4733,7 @@ void SCCache::wait_for_no_nmethod_readers() {
   }
 }
 
-SCCache::ReadingMark::ReadingMark() {
+AOTCodeCache::ReadingMark::ReadingMark() {
   while (true) {
     int cur = Atomic::load(&_nmethod_readers);
     if (cur < 0) {
@@ -4749,7 +4749,7 @@ SCCache::ReadingMark::ReadingMark() {
   }
 }
 
-SCCache::ReadingMark::~ReadingMark() {
+AOTCodeCache::ReadingMark::~ReadingMark() {
   if (_failed) {
     return;
   }

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef SHARE_CODE_SCCACHE_HPP
-#define SHARE_CODE_SCCACHE_HPP
+#ifndef SHARE_CODE_AOTCODECACHE_HPP
+#define SHARE_CODE_AOTCODECACHE_HPP
 
 #include "compiler/compilerDefinitions.hpp"
 #include "memory/allocation.hpp"
@@ -32,11 +32,11 @@
 #include "utilities/exceptions.hpp"
 
 /*
- * Startup Code Cache (SCC) collects compiled code and metadata during
- * an application training runs.
- * In following "deployment" runs this code can me loaded into
- * Code Cache as normal nmethods skipping JIT compilation.
- * In additoin special compiled code is generated with class initialization
+ * AOT Code Cache collects code from Code Cache and corresponding metadata
+ * during application training run.
+ * In following "production" runs this code and data can me loaded into
+ * Code Cache skipping its generation.
+ * Additionaly special compiled code "preload" is generated with class initialization
  * barriers which can be called on first Java method invocation.
  */
 
@@ -65,89 +65,12 @@ class OopMapSet;
 class OopRecorder;
 class outputStream;
 class RelocIterator;
-class SCCache;
+class AOTCodeCache;
 class StubCodeGenerator;
 
 enum class vmIntrinsicID : int;
 
-class SCConfig {
-  uint _compressedOopShift;
-  uint _compressedKlassShift;
-  uint _contendedPaddingWidth;
-  uint _objectAlignment;
-  uint _gc;
-  enum Flags {
-    none                     = 0,
-    metadataPointers         = 1,
-    debugVM                  = 2,
-    compressedOops           = 4,
-    compressedClassPointers  = 8,
-    useTLAB                  = 16,
-    systemClassAssertions    = 32,
-    userClassAssertions      = 64,
-    enableContendedPadding   = 128,
-    restrictContendedPadding = 256,
-  };
-  uint _flags;
-
-public:
-  void record(bool use_meta_ptrs);
-  bool verify() const;
-
-  bool has_meta_ptrs()  const { return (_flags & metadataPointers) != 0; }
-};
-
-// Code Cache file header
-class SCCHeader : public CHeapObj<mtCode> {
-private:
-  // Here should be version and other verification fields
-  enum {
-    SCC_VERSION = 1
-  };
-  uint _version;           // SCC version (should match when reading code cache)
-  uint _cache_size;        // cache size in bytes
-  uint _strings_count;
-  uint _strings_offset;    // offset to recorded C strings
-  uint _entries_count;     // number of recorded entries in cache
-  uint _entries_offset;    // offset of SCCEntry array describing entries
-  uint _preload_entries_count; // entries for pre-loading code
-  uint _preload_entries_offset;
-  SCConfig _config;
-
-public:
-  void init(uint cache_size,
-            uint strings_count, uint strings_offset,
-            uint entries_count, uint entries_offset,
-            uint preload_entries_count, uint preload_entries_offset,
-            bool use_meta_ptrs) {
-    _version        = SCC_VERSION;
-    _cache_size     = cache_size;
-    _strings_count  = strings_count;
-    _strings_offset = strings_offset;
-    _entries_count  = entries_count;
-    _entries_offset = entries_offset;
-    _preload_entries_count  = preload_entries_count;
-    _preload_entries_offset = preload_entries_offset;
-
-    _config.record(use_meta_ptrs);
-  }
-
-  uint cache_size()     const { return _cache_size; }
-  uint strings_count()  const { return _strings_count; }
-  uint strings_offset() const { return _strings_offset; }
-  uint entries_count()  const { return _entries_count; }
-  uint entries_offset() const { return _entries_offset; }
-  uint preload_entries_count()  const { return _preload_entries_count; }
-  uint preload_entries_offset() const { return _preload_entries_offset; }
-  bool has_meta_ptrs()  const { return _config.has_meta_ptrs(); }
-
-  bool verify_config(uint load_size)  const;
-  bool verify_vm_config() const { // Called after Universe initialized
-    return _config.verify();
-  }
-};
-
-#define DO_SCCENTRY_KIND(Fn) \
+#define DO_AOTCODEENTRY_KIND(Fn) \
   Fn(None) \
   Fn(Adapter) \
   Fn(Stub) \
@@ -155,17 +78,17 @@ public:
   Fn(Code) \
 
 // Code Cache's entry contain information from CodeBuffer
-class SCCEntry {
+class AOTCodeEntry {
 public:
   enum Kind : s1 {
 #define DECL_KIND_ENUM(kind) kind,
-    DO_SCCENTRY_KIND(DECL_KIND_ENUM)
+    DO_AOTCODEENTRY_KIND(DECL_KIND_ENUM)
 #undef DECL_KIND_ENUM
     Kind_count
   };
 
 private:
-  SCCEntry* _next;
+  AOTCodeEntry* _next;
   Method*   _method;
   Kind   _kind;        //
   uint   _id;          // vmIntrinsic::ID for stub or name's hash for nmethod
@@ -192,7 +115,7 @@ private:
                             // during "assembly" phase without running application
   address _dumptime_content_start_addr;
 public:
-  SCCEntry(uint offset, uint size, uint name_offset, uint name_size,
+  AOTCodeEntry(uint offset, uint size, uint name_offset, uint name_size,
            uint code_offset, uint code_size,
            uint reloc_offset, uint reloc_size,
            Kind kind, uint id,
@@ -230,7 +153,7 @@ public:
     _load_fail    = false;
     _ignore_decompile = ignore_decompile;
   }
-  void* operator new(size_t x, SCCache* cache);
+  void* operator new(size_t x, AOTCodeCache* cache);
   // Delete is a NOP
   void operator delete( void *ptr ) {}
 
@@ -239,8 +162,8 @@ public:
   bool is_blob() { return _kind == Blob; }
   bool is_code() { return _kind == Code; }
 
-  SCCEntry* next()    const { return _next; }
-  void set_next(SCCEntry* next) { _next = next; }
+  AOTCodeEntry* next()    const { return _next; }
+  void set_next(AOTCodeEntry* next) { _next = next; }
 
   Method*   method()  const { return _method; }
   void set_method(Method* method) { _method = method; }
@@ -286,7 +209,7 @@ public:
 };
 
 // Addresses of stubs, blobs and runtime finctions called from compiled code.
-class SCAddressTable : public CHeapObj<mtCode> {
+class AOTCodeAddressTable : public CHeapObj<mtCode> {
 private:
   address* _extrs_addr;
   address* _stubs_addr;
@@ -307,7 +230,7 @@ private:
   bool _c1_complete;
 
 public:
-  SCAddressTable() {
+  AOTCodeAddressTable() {
     _extrs_addr = nullptr;
     _stubs_addr = nullptr;
     _blobs_addr = nullptr;
@@ -318,7 +241,7 @@ public:
     _opto_complete = false;
     _c1_complete = false;
   }
-  ~SCAddressTable();
+  ~AOTCodeAddressTable();
   void init_extrs();
   void init_early_stubs();
   void init_shared_blobs();
@@ -334,7 +257,7 @@ public:
   bool c1_complete() const { return _c1_complete; }
 };
 
-struct SCCodeSection {
+struct AOTCodeSection {
 public:
   address _origin_address;
   uint _size;
@@ -357,14 +280,13 @@ enum class DataKind: int {
   MH_Oop_Shared = 11
 };
 
-class SCCache;
-
-class SCCReader { // Concurent per compilation request
+// Concurent AOT code reader
+class AOTCodeReader {
 private:
-  const SCCache*  _cache;
-  const SCCEntry* _entry;
-  const char*     _load_buffer; // Loaded cached code buffer
-  uint  _read_position;            // Position in _load_buffer
+  const AOTCodeCache* _cache;
+  const AOTCodeEntry* _entry;
+  const char*         _load_buffer; // Loaded cached code buffer
+  uint  _read_position;             // Position in _load_buffer
   uint  read_position() const { return _read_position; }
   void  set_read_position(uint pos);
   const char* addr(uint offset) const { return _load_buffer + offset; }
@@ -381,11 +303,11 @@ private:
   bool lookup_failed()   const { return _lookup_failed; }
 
 public:
-  SCCReader(SCCache* cache, SCCEntry* entry, CompileTask* task);
+  AOTCodeReader(AOTCodeCache* cache, AOTCodeEntry* entry, CompileTask* task);
 
-  SCCEntry* scc_entry() { return (SCCEntry*)_entry; }
+  AOTCodeEntry* aot_code_entry() { return (AOTCodeEntry*)_entry; }
 
-  // convenience method to convert offset in SCCEntry data to its address
+  // convenience method to convert offset in AOTCodeEntry data to its address
   bool compile_nmethod(ciEnv* env, ciMethod* target, AbstractCompiler* compiler);
   bool compile_blob(CodeBuffer* buffer, int* pc_offset);
 
@@ -413,9 +335,89 @@ public:
   void print_on(outputStream* st);
 };
 
-class SCCache : public CHeapObj<mtCode> {
+class AOTCodeCache : public CHeapObj<mtCode> {
+
+// Classes used to describe AOT code cache.
+protected:
+class Config {
+    uint _compressedOopShift;
+    uint _compressedKlassShift;
+    uint _contendedPaddingWidth;
+    uint _objectAlignment;
+    uint _gc;
+    enum Flags {
+      none                     = 0,
+      metadataPointers         = 1,
+      debugVM                  = 2,
+      compressedOops           = 4,
+      compressedClassPointers  = 8,
+      useTLAB                  = 16,
+      systemClassAssertions    = 32,
+      userClassAssertions      = 64,
+      enableContendedPadding   = 128,
+      restrictContendedPadding = 256,
+    };
+    uint _flags;
+
+  public:
+    void record(bool use_meta_ptrs);
+    bool verify() const;
+
+    bool has_meta_ptrs()  const { return (_flags & metadataPointers) != 0; }
+  };
+
+  class Header : public CHeapObj<mtCode> {
+  private:
+    // Here should be version and other verification fields
+    enum {
+      AOT_CODE_VERSION = 1
+    };
+    uint _version;           // AOT code version (should match when reading code cache)
+    uint _cache_size;        // cache size in bytes
+    uint _strings_count;     // number of recorded C strings
+    uint _strings_offset;    // offset to recorded C strings
+    uint _entries_count;     // number of recorded entries in cache
+    uint _entries_offset;    // offset of AOTCodeEntry array describing entries
+    uint _preload_entries_count; // entries for pre-loading code
+    uint _preload_entries_offset;
+    Config _config;
+
+  public:
+    void init(uint cache_size,
+              uint strings_count, uint strings_offset,
+              uint entries_count, uint entries_offset,
+              uint preload_entries_count, uint preload_entries_offset,
+              bool use_meta_ptrs) {
+      _version        = AOT_CODE_VERSION;
+      _cache_size     = cache_size;
+      _strings_count  = strings_count;
+      _strings_offset = strings_offset;
+      _entries_count  = entries_count;
+      _entries_offset = entries_offset;
+      _preload_entries_count  = preload_entries_count;
+      _preload_entries_offset = preload_entries_offset;
+
+      _config.record(use_meta_ptrs);
+    }
+
+    uint cache_size()     const { return _cache_size; }
+    uint strings_count()  const { return _strings_count; }
+    uint strings_offset() const { return _strings_offset; }
+    uint entries_count()  const { return _entries_count; }
+    uint entries_offset() const { return _entries_offset; }
+    uint preload_entries_count()  const { return _preload_entries_count; }
+    uint preload_entries_offset() const { return _preload_entries_offset; }
+    bool has_meta_ptrs()  const { return _config.has_meta_ptrs(); }
+
+    bool verify_config(uint load_size)  const;
+    bool verify_vm_config() const { // Called after Universe initialized
+      return _config.verify();
+    }
+  };
+
+// Continue with AOTCodeCache class definition.
 private:
-  SCCHeader*  _load_header;
+  Header*     _load_header;
   char*       _load_buffer;    // Aligned buffer for loading cached code
   char*       _store_buffer;   // Aligned buffer for storing cached code
   char*       _C_store_buffer; // Original unaligned buffer
@@ -432,28 +434,28 @@ private:
   bool _closing;               // Closing cache file
   bool _failed;                // Failed read/write to/from cache (cache is broken?)
 
-  SCAddressTable* _table;
+  AOTCodeAddressTable* _table;
 
-  SCCEntry* _load_entries;     // Used when reading cache
-  uint*     _search_entries;   // sorted by ID table [id, index]
-  SCCEntry* _store_entries;    // Used when writing cache
-  const char* _C_strings_buf;  // Loaded buffer for _C_strings[] table
-  uint      _store_entries_cnt;
+  AOTCodeEntry* _load_entries;     // Used when reading cache
+  uint*         _search_entries;   // sorted by ID table [id, index]
+  AOTCodeEntry* _store_entries;    // Used when writing cache
+  const char*   _C_strings_buf;    // Loaded buffer for _C_strings[] table
+  uint          _store_entries_cnt;
 
   uint _compile_id;
   uint _comp_level;
   uint compile_id() const { return _compile_id; }
   uint comp_level() const { return _comp_level; }
 
-  static SCCache* open_for_read();
-  static SCCache* open_for_write();
+  static AOTCodeCache* open_for_read();
+  static AOTCodeCache* open_for_write();
 
   bool set_write_position(uint pos);
   bool align_write();
   uint write_bytes(const void* buffer, uint nbytes);
   const char* addr(uint offset) const { return _load_buffer + offset; }
 
-  static SCAddressTable* addr_table() {
+  static AOTCodeAddressTable* addr_table() {
     return is_on() && (cache()->_table != nullptr) ? cache()->_table : nullptr;
   }
 
@@ -464,7 +466,7 @@ private:
 
   address reserve_bytes(uint nbytes);
 
-  SCCEntry* write_nmethod(nmethod* nm, bool for_preload);
+  AOTCodeEntry* write_nmethod(nmethod* nm, bool for_preload);
 
   // States:
   //   S >= 0: allow new readers, S readers are currently active
@@ -486,8 +488,8 @@ private:
   };
 
 public:
-  SCCache();
-  ~SCCache();
+  AOTCodeCache();
+  ~AOTCodeCache();
 
   const char* cache_buffer() const { return _load_buffer; }
   bool failed() const { return _failed; }
@@ -519,15 +521,15 @@ public:
 
   void add_new_C_string(const char* str);
 
-  SCCEntry* add_entry() {
+  AOTCodeEntry* add_entry() {
     _store_entries_cnt++;
     _store_entries -= 1;
     return _store_entries;
   }
   void preload_startup_code(TRAPS);
 
-  SCCEntry* find_entry(SCCEntry::Kind kind, uint id, uint comp_level = 0, uint decomp = 0);
-  void invalidate_entry(SCCEntry* entry);
+  AOTCodeEntry* find_entry(AOTCodeEntry::Kind kind, uint id, uint comp_level = 0, uint decomp = 0);
+  void invalidate_entry(AOTCodeEntry* entry);
 
   bool finish_write();
 
@@ -568,7 +570,7 @@ public:
   static bool store_adapter(CodeBuffer* buffer, uint32_t id, const char* basic_sig, uint32_t offsets[4]) NOT_CDS_RETURN_(false);
 
   static bool load_nmethod(ciEnv* env, ciMethod* target, int entry_bci, AbstractCompiler* compiler, CompLevel comp_level) NOT_CDS_RETURN_(false);
-  static SCCEntry* store_nmethod(nmethod* nm, AbstractCompiler* compiler, bool for_preload) NOT_CDS_RETURN_(nullptr);
+  static AOTCodeEntry* store_nmethod(nmethod* nm, AbstractCompiler* compiler, bool for_preload) NOT_CDS_RETURN_(nullptr);
 
   static uint store_entries_cnt() {
     if (is_on_for_write()) {
@@ -580,7 +582,7 @@ public:
 // Static access
 
 private:
-  static SCCache*  _cache;
+  static AOTCodeCache*  _cache;
 
   static bool open_cache();
   static bool verify_vm_config() {
@@ -590,7 +592,7 @@ private:
     return true;
   }
 public:
-  static SCCache* cache() { return _cache; }
+  static AOTCodeCache* cache() { return _cache; }
   static void initialize() NOT_CDS_RETURN;
   static void init2() NOT_CDS_RETURN;
   static void close() NOT_CDS_RETURN;
@@ -599,16 +601,16 @@ public:
   static bool is_code_load_thread_on() NOT_CDS_RETURN_(false);
   static bool is_on_for_read()  { return is_on() && _cache->for_read(); }
   static bool is_on_for_write() { return is_on() && _cache->for_write(); }
-  static bool gen_preload_code(ciMethod* m, int entry_bci);
+  static bool gen_preload_code(ciMethod* m, int entry_bci) NOT_CDS_RETURN_(false);
   static bool allow_const_field(ciConstant& value) NOT_CDS_RETURN_(false);
-  static void invalidate(SCCEntry* entry) NOT_CDS_RETURN;
-  static bool is_loaded(SCCEntry* entry);
-  static SCCEntry* find_code_entry(const methodHandle& method, uint comp_level);
-  static void preload_code(JavaThread* thread);
+  static void invalidate(AOTCodeEntry* entry) NOT_CDS_RETURN;
+  static bool is_loaded(AOTCodeEntry* entry);
+  static AOTCodeEntry* find_code_entry(const methodHandle& method, uint comp_level);
+  static void preload_code(JavaThread* thread) NOT_CDS_RETURN;
 
   template<typename Function>
   static void iterate(Function function) { // lambda enabled API
-    SCCache* cache = open_for_read();
+    AOTCodeCache* cache = open_for_read();
     if (cache != nullptr) {
       ReadingMark rdmk;
       if (rdmk.failed()) {
@@ -618,11 +620,11 @@ public:
 
       uint count = cache->_load_header->entries_count();
       uint* search_entries = (uint*)cache->addr(cache->_load_header->entries_offset()); // [id, index]
-      SCCEntry* load_entries = (SCCEntry*)(search_entries + 2 * count);
+      AOTCodeEntry* load_entries = (AOTCodeEntry*)(search_entries + 2 * count);
 
       for (uint i = 0; i < count; i++) {
         int index = search_entries[2*i + 1];
-        SCCEntry* entry = &(load_entries[index]);
+        AOTCodeEntry* entry = &(load_entries[index]);
         function(entry);
       }
     }
@@ -642,12 +644,12 @@ const int AOTCompLevel_count = CompLevel_count + 1; // 6 levels indexed from 0 t
 struct AOTCodeStats {
 private:
   struct {
-    uint _kind_cnt[SCCEntry::Kind_count];
+    uint _kind_cnt[AOTCodeEntry::Kind_count];
     uint _nmethod_cnt[AOTCompLevel_count];
     uint _clinit_barriers_cnt;
   } ccstats; // ccstats = cached code stats
 
-  void check_kind(uint kind) { assert(kind >= SCCEntry::None && kind < SCCEntry::Kind_count, "Invalid SCCEntry kind %d", kind); }
+  void check_kind(uint kind) { assert(kind >= AOTCodeEntry::None && kind < AOTCodeEntry::Kind_count, "Invalid AOTCodeEntry kind %d", kind); }
   void check_complevel(uint lvl) { assert(lvl >= CompLevel_none && lvl < AOTCompLevel_count, "Invalid compilation level %d", lvl); }
 
 public:
@@ -656,7 +658,7 @@ public:
   void inc_preload_cnt() { ccstats._nmethod_cnt[AOTCompLevel_count-1] += 1; }
   void inc_clinit_barriers_cnt() { ccstats._clinit_barriers_cnt += 1; }
 
-  void collect_entry_stats(SCCEntry* entry) {
+  void collect_entry_stats(AOTCodeEntry* entry) {
     inc_entry_cnt(entry->kind());
     if (entry->is_code()) {
       entry->for_preload() ? inc_nmethod_cnt(AOTCompLevel_count-1)
@@ -674,7 +676,7 @@ public:
 
   uint total_count() {
     uint total = 0;
-    for (int kind = SCCEntry::None; kind < SCCEntry::Kind_count; kind++) {
+    for (int kind = AOTCodeEntry::None; kind < AOTCodeEntry::Kind_count; kind++) {
       total += ccstats._kind_cnt[kind];
     }
     return total;
@@ -689,7 +691,7 @@ private:
       uint _loaded_cnt;
       uint _invalidated_cnt;
       uint _load_failed_cnt;
-    } _entry_kinds[SCCEntry::Kind_count],
+    } _entry_kinds[AOTCodeEntry::Kind_count],
       _nmethods[AOTCompLevel_count];
   } rs; // rs = runtime stats
 
@@ -710,7 +712,7 @@ public:
   uint nmethod_invalidated_count(uint lvl) { check_complevel(lvl); return rs._nmethods[lvl]._invalidated_cnt; }
   uint nmethod_load_failed_count(uint lvl) { check_complevel(lvl); return rs._nmethods[lvl]._load_failed_cnt; }
 
-  void inc_loaded_cnt(SCCEntry* entry) {
+  void inc_loaded_cnt(AOTCodeEntry* entry) {
     inc_entry_loaded_cnt(entry->kind());
     if (entry->is_code()) {
       entry->for_preload() ? inc_nmethod_loaded_cnt(AOTCompLevel_count-1)
@@ -718,7 +720,7 @@ public:
     }
   }
 
-  void inc_invalidated_cnt(SCCEntry* entry) {
+  void inc_invalidated_cnt(AOTCodeEntry* entry) {
     inc_entry_invalidated_cnt(entry->kind());
     if (entry->is_code()) {
       entry->for_preload() ? inc_nmethod_invalidated_cnt(AOTCompLevel_count-1)
@@ -726,7 +728,7 @@ public:
     }
   }
 
-  void inc_load_failed_cnt(SCCEntry* entry) {
+  void inc_load_failed_cnt(AOTCodeEntry* entry) {
     inc_entry_load_failed_cnt(entry->kind());
     if (entry->is_code()) {
       entry->for_preload() ? inc_nmethod_load_failed_cnt(AOTCompLevel_count-1)
@@ -734,7 +736,7 @@ public:
     }
   }
 
-  void collect_entry_runtime_stats(SCCEntry* entry) {
+  void collect_entry_runtime_stats(AOTCodeEntry* entry) {
     if (entry->is_loaded()) {
       inc_loaded_cnt(entry);
     }
@@ -746,7 +748,7 @@ public:
     }
   }
 
-  void collect_all_stats(SCCEntry* entry) {
+  void collect_all_stats(AOTCodeEntry* entry) {
     collect_entry_stats(entry);
     collect_entry_runtime_stats(entry);
   }
@@ -758,16 +760,18 @@ public:
 
 // code cache internal runtime constants area used by AOT code
 class AOTRuntimeConstants {
- friend class SCCache;
+ friend class AOTCodeCache;
+ private:
   uint _grain_shift;
   uint _card_shift;
   static address _field_addresses_list[];
   static AOTRuntimeConstants _aot_runtime_constants;
   // private constructor for unique singleton
   AOTRuntimeConstants() { }
-  // private for use by friend class SCCache
+  // private for use by friend class AOTCodeCache
   static void initialize_from_runtime();
  public:
+#if INCLUDE_CDS
   static bool contains(address adr) {
     address base = (address)&_aot_runtime_constants;
     address hi = base + sizeof(AOTRuntimeConstants);
@@ -778,6 +782,12 @@ class AOTRuntimeConstants {
   static address* field_addresses_list() {
     return _field_addresses_list;
   }
+#else
+  static bool contains(address adr)      { return false; }
+  static address grain_shift_address()   { return nullptr; }
+  static address card_shift_address()    { return nullptr; }
+  static address* field_addresses_list() { return nullptr; }
+#endif
 };
 
-#endif // SHARE_CODE_SCCACHE_HPP
+#endif // SHARE_CODE_AOTCODECACHE_HPP

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -22,7 +22,6 @@
  *
  */
 
-#include "code/SCCache.hpp"
 #include "code/codeBlob.hpp"
 #include "code/codeCache.hpp"
 #include "code/relocInfo.hpp"
@@ -188,7 +187,7 @@ void CodeBlob::purge() {
     os::free(_mutable_data);
     _mutable_data = blob_end(); // Valid not null address
   }
-  if (_oop_maps != nullptr && !SCCache::is_address_in_aot_cache((address)_oop_maps)) {
+  if (_oop_maps != nullptr && !AOTCodeCache::is_address_in_aot_cache((address)_oop_maps)) {
     delete _oop_maps;
     _oop_maps = nullptr;
   }

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -26,7 +26,7 @@
 #define SHARE_CODE_CODEBLOB_HPP
 
 #include "asm/codeBuffer.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compilerDefinitions.hpp"
 #include "compiler/oopMap.hpp"
 #include "runtime/javaFrameAnchor.hpp"
@@ -157,7 +157,7 @@ protected:
 public:
 
   ~CodeBlob() {
-    assert(_oop_maps == nullptr || SCCache::is_address_in_aot_cache((address)_oop_maps), "Not flushed");
+    assert(_oop_maps == nullptr || AOTCodeCache::is_address_in_aot_cache((address)_oop_maps), "Not flushed");
   }
 
   // Returns the space needed for CodeBlob

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -31,7 +31,6 @@
 #include "code/dependencyContext.hpp"
 #include "code/nmethod.hpp"
 #include "code/pcDesc.hpp"
-#include "code/SCCache.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compilerDefinitions.inline.hpp"
@@ -1557,7 +1556,7 @@ void CodeCache::print_nmethod_statistics_on(outputStream* st) {
     }
     assert(!nm->preloaded() || nm->comp_level() == CompLevel_full_optimization, "");
 
-    int idx1 = nm->is_scc() ? 1 : 0;
+    int idx1 = nm->is_aot() ? 1 : 0;
     int idx2 = nm->comp_level() + (nm->preloaded() ? 1 : 0);
     int idx3 = (nm->is_in_use()      ? 0 :
                (nm->is_not_entrant() ? 1 :
@@ -1593,7 +1592,7 @@ void CodeCache::print_nmethod_statistics_on(outputStream* st) {
     int total_osr    = stats[1][i][0][1] + stats[1][i][1][1] + stats[1][i][2][1];
     assert(total_osr == 0, "sanity");
     if (total_normal + total_osr > 0) {
-      st->print("  SC T%d:", i);
+      st->print("  AOT Code T%d:", i);
       print_helper1(st,      "", total_normal, stats[1][i][1][0], stats_used[1][i][0][0] + stats_used[1][i][1][0]);
       print_helper1(st, "; osr:", total_osr,    stats[1][i][1][1], stats_used[1][i][0][1] + stats_used[1][i][1][1]);
       st->cr();

--- a/src/hotspot/share/code/exceptionHandlerTable.hpp
+++ b/src/hotspot/share/code/exceptionHandlerTable.hpp
@@ -84,8 +84,8 @@ class HandlerTableEntry {
 
 class nmethod;
 class ExceptionHandlerTable {
-  friend class SCCache;
-  friend class SCCReader;
+  friend class AOTCodeCache;
+  friend class AOTCodeReader;
 
  private:
   HandlerTableEntry* _table;    // the table
@@ -147,8 +147,8 @@ class ExceptionHandlerTable {
 typedef  uint              implicit_null_entry;
 
 class ImplicitExceptionTable {
-  friend class SCCache;
-  friend class SCCReader;
+  friend class AOTCodeCache;
+  friend class AOTCodeReader;
  private:
   uint _size;
   uint _len;

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -45,8 +45,8 @@ class JvmtiThreadState;
 class MetadataClosure;
 class NativeCallWrapper;
 class OopIterateClosure;
-class SCCReader;
-class SCCEntry;
+class AOTCodeReader;
+class AOTCodeEntry;
 class ScopeDesc;
 class xmlStream;
 
@@ -263,7 +263,7 @@ class nmethod : public CodeBlob {
   CompLevel    _comp_level;            // compilation level (s1)
   CompilerType _compiler_type;         // which compiler made this nmethod (u1)
 
-  SCCEntry* _scc_entry;
+  AOTCodeEntry* _aot_code_entry;
 
   bool _used; // has this nmethod ever been invoked?
 
@@ -337,7 +337,7 @@ class nmethod : public CodeBlob {
           ImplicitExceptionTable* nul_chk_table,
           AbstractCompiler* compiler,
           CompLevel comp_level
-          , SCCEntry* scc_entry
+          , AOTCodeEntry* aot_code_entry
 #if INCLUDE_JVMCI
           , char* speculations = nullptr,
           int speculations_len = 0,
@@ -496,7 +496,7 @@ class nmethod : public CodeBlob {
                             AsmRemarks& asm_remarks,
                             DbgStrings& dbg_strings,
 #endif /* PRODUCT */
-                            SCCReader* scc_reader);
+                            AOTCodeReader* aot_code_reader);
 
 public:
   // create nmethod using archived nmethod from AOT code cache
@@ -515,7 +515,7 @@ public:
                               AsmRemarks& asm_remarks,
                               DbgStrings& dbg_strings,
 #endif /* PRODUCT */
-                              SCCReader* scc_reader);
+                              AOTCodeReader* aot_code_reader);
 
   // create nmethod with entry_bci
   static nmethod* new_nmethod(const methodHandle& method,
@@ -532,7 +532,7 @@ public:
                               ImplicitExceptionTable* nul_chk_table,
                               AbstractCompiler* compiler,
                               CompLevel comp_level
-                              , SCCEntry* scc_entry
+                              , AOTCodeEntry* aot_code_entry
 #if INCLUDE_JVMCI
                               , char* speculations = nullptr,
                               int speculations_len = 0,
@@ -960,9 +960,9 @@ public:
 
   int orig_pc_offset() { return _orig_pc_offset; }
 
-  SCCEntry* scc_entry() const { return _scc_entry; }
-  bool is_scc() const { return scc_entry() != nullptr; }
-  void set_scc_entry(SCCEntry* entry) { _scc_entry = entry; }
+  AOTCodeEntry* aot_code_entry() const { return _aot_code_entry; }
+  bool is_aot() const { return aot_code_entry() != nullptr; }
+  void set_aot_code_entry(AOTCodeEntry* entry) { _aot_code_entry = entry; }
 
   bool     used() const { return _used; }
   void set_used()       { _used = true; }

--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -23,11 +23,11 @@
  */
 
 #include "ci/ciUtilities.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/codeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "code/nmethod.hpp"
 #include "code/relocInfo.hpp"
-#include "code/SCCache.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "oops/compressedOops.inline.hpp"
@@ -476,7 +476,7 @@ void external_word_Relocation::pack_data_to(CodeSection* dest) {
   short* p = (short*) dest->locs_end();
   int index = ExternalsRecorder::find_index(_target);
   // Use 4 bytes to store index to be able patch it when
-  // updating relocations in SCCReader::read_relocations().
+  // updating relocations in AOTCodeReader::read_relocations().
   p = add_jint(p, index);
   dest->set_locs_end((relocInfo*) p);
 }
@@ -750,8 +750,8 @@ void external_word_Relocation::fix_relocation_after_move(const CodeBuffer* src, 
   // location, which means  there is nothing to fix here.  In either case, the
   // resulting target should be an "external" address.
 #ifdef ASSERT
-  if (SCCache::is_on()) {
-    // SCA needs relocation info for card table base which may point to CodeCache
+  if (AOTCodeCache::is_on()) {
+    // AOTCode needs relocation info for card table base which may point to CodeCache
     if (is_card_table_address(target())) {
       return;
     }

--- a/src/hotspot/share/code/relocInfo.hpp
+++ b/src/hotspot/share/code/relocInfo.hpp
@@ -672,7 +672,7 @@ class RelocIterator : public StackObj {
 
 class Relocation {
   friend class RelocIterator;
-  friend class SCCReader;
+  friend class AOTCodeReader;
 
  private:
   // When a relocation has been created by a RelocIterator,

--- a/src/hotspot/share/compiler/compilationPolicy.hpp
+++ b/src/hotspot/share/compiler/compilationPolicy.hpp
@@ -252,7 +252,7 @@ class CompilationPolicy : AllStatic {
   typedef CompilationPolicyUtils::Queue<InstanceKlass> TrainingReplayQueue;
 
   static int64_t _start_time;
-  static int _c1_count, _c2_count, _c3_count, _sc_count;
+  static int _c1_count, _c2_count, _c3_count, _ac_count;
   static double _increase_threshold_at_ratio;
   static TrainingReplayQueue _training_replay_queue;
 
@@ -320,7 +320,7 @@ class CompilationPolicy : AllStatic {
   static void set_c1_count(int x) { _c1_count = x;    }
   static void set_c2_count(int x) { _c2_count = x;    }
   static void set_c3_count(int x) { _c3_count = x;    }
-  static void set_sc_count(int x) { _sc_count = x;    }
+  static void set_ac_count(int x) { _ac_count = x;    }
 
   enum EventType { CALL, LOOP, COMPILE, FORCE_COMPILE, FORCE_RECOMPILE, REMOVE_FROM_QUEUE, UPDATE_IN_QUEUE, REPROFILE, MAKE_NOT_ENTRANT };
   static void print_event(EventType type, Method* m, Method* im, int bci, CompLevel level);
@@ -353,7 +353,7 @@ class CompilationPolicy : AllStatic {
   static int c1_count() { return _c1_count; }
   static int c2_count() { return _c2_count; }
   static int c3_count() { return _c3_count; }
-  static int sc_count() { return _sc_count; }
+  static int ac_count() { return _ac_count; }
   static int compiler_count(CompLevel comp_level);
   // If m must_be_compiled then request a compilation from the CompileBroker.
   // This supports the -Xcomp option.

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -199,13 +199,13 @@ class CompileBroker: AllStatic {
   static AbstractCompiler* _compilers[3];
 
   // The maximum numbers of compiler threads to be determined during startup.
-  static int _c1_count, _c2_count, _c3_count, _sc_count;
+  static int _c1_count, _c2_count, _c3_count, _ac_count;
 
   // An array of compiler thread Java objects
-  static jobject *_compiler1_objects, *_compiler2_objects, *_compiler3_objects, *_sc_objects;
+  static jobject *_compiler1_objects, *_compiler2_objects, *_compiler3_objects, *_ac_objects;
 
   // An array of compiler logs
-  static CompileLog **_compiler1_logs, **_compiler2_logs, **_compiler3_logs, **_sc_logs;
+  static CompileLog **_compiler1_logs, **_compiler2_logs, **_compiler3_logs, **_ac_logs;
 
   // These counters are used for assigning id's to each compilation
   static volatile jint _compilation_id;
@@ -215,8 +215,8 @@ class CompileBroker: AllStatic {
   static CompileQueue* _c3_compile_queue;
   static CompileQueue* _c2_compile_queue;
   static CompileQueue* _c1_compile_queue;
-  static CompileQueue* _sc1_compile_queue;
-  static CompileQueue* _sc2_compile_queue;
+  static CompileQueue* _ac1_compile_queue;
+  static CompileQueue* _ac2_compile_queue;
 
   // performance counters
   static PerfCounter* _perf_total_compilation;
@@ -265,8 +265,8 @@ class CompileBroker: AllStatic {
   static jlong _peak_compilation_time;
 
   static CompilerStatistics _stats_per_level[];
-  static CompilerStatistics _scc_stats;
-  static CompilerStatistics _scc_stats_per_level[];
+  static CompilerStatistics _aot_stats;
+  static CompilerStatistics _aot_stats_per_level[];
 
   static volatile int _print_compilation_warning;
 
@@ -290,7 +290,7 @@ class CompileBroker: AllStatic {
                                           int                 comp_level,
                                           const methodHandle& hot_method,
                                           int                 hot_count,
-                                          SCCEntry*           scc_entry,
+                                          AOTCodeEntry*       aot_code_entry,
                                           CompileTask::CompileReason compile_reason,
                                           bool                requires_online_compilation,
                                           bool                blocking);
@@ -322,13 +322,13 @@ private:
                                   bool blocking,
                                   Thread* thread);
 
-  static CompileQueue* compile_queue(int comp_level, bool is_scc);
+  static CompileQueue* compile_queue(int comp_level, bool is_aot);
   static bool init_compiler_runtime();
   static void shutdown_compiler_runtime(AbstractCompiler* comp, CompilerThread* thread);
 
-  static SCCEntry* find_scc_entry(const methodHandle& method, int osr_bci, int comp_level,
-                                  CompileTask::CompileReason compile_reason,
-                                  bool requires_online_compilation);
+  static AOTCodeEntry* find_aot_code_entry(const methodHandle& method, int osr_bci, int comp_level,
+                                           CompileTask::CompileReason compile_reason,
+                                           bool requires_online_compilation);
 
 public:
   enum {
@@ -347,8 +347,8 @@ public:
                                       CompileTask::CompileReason compile_reason);
   static bool compilation_is_in_queue(const methodHandle& method);
   static void print_compile_queues(outputStream* st);
-  static int queue_size(int comp_level, bool is_scc = false) {
-    CompileQueue *q = compile_queue(comp_level, is_scc);
+  static int queue_size(int comp_level, bool is_aot = false) {
+    CompileQueue *q = compile_queue(comp_level, is_aot);
     return q != nullptr ? q->size() : 0;
   }
   static void compilation_init(JavaThread* THREAD);
@@ -461,10 +461,10 @@ public:
     return _compiler3_objects[idx];
   }
 
-  static jobject sc_object(int idx) {
-    assert(_sc_objects != nullptr, "must be initialized");
-    assert(idx < _sc_count, "oob");
-    return _sc_objects[idx];
+  static jobject ac_object(int idx) {
+    assert(_ac_objects != nullptr, "must be initialized");
+    assert(idx < _ac_count, "oob");
+    return _ac_objects[idx];
   }
 
   static AbstractCompiler* compiler1() { return _compilers[0]; }

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -22,7 +22,6 @@
  *
  */
 
-#include "code/SCCache.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compileLog.hpp"
@@ -106,7 +105,7 @@ void CompileTask::initialize(int compile_id,
                              int comp_level,
                              const methodHandle& hot_method,
                              int hot_count,
-                             SCCEntry* scc_entry,
+                             AOTCodeEntry* aot_code_entry,
                              CompileTask::CompileReason compile_reason,
                              CompileQueue* compile_queue,
                              bool requires_online_compilation,
@@ -147,7 +146,7 @@ void CompileTask::initialize(int compile_id,
   _failure_reason = nullptr;
   _failure_reason_on_C_heap = false;
   _training_data = nullptr;
-  _scc_entry = scc_entry;
+  _aot_code_entry = aot_code_entry;
   _compile_queue = compile_queue;
 
   AbstractCompiler* comp = CompileBroker::compiler(comp_level);
@@ -263,7 +262,7 @@ void CompileTask::print_tty() {
 // ------------------------------------------------------------------
 // CompileTask::print_impl
 void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, int comp_level,
-                             bool is_osr_method, int osr_bci, bool is_blocking, bool is_scc, bool is_preload,
+                             bool is_osr_method, int osr_bci, bool is_blocking, bool is_aot, bool is_preload,
                              const char* compiler_name,
                              const char* msg, bool short_form, bool cr,
                              jlong time_created, jlong time_queued, jlong time_started, jlong time_finished,
@@ -325,11 +324,11 @@ void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, i
   const char exception_char = has_exception_handler           ? '!' : ' ';
   const char blocking_char  = is_blocking                     ? 'b' : ' ';
   const char native_char    = is_native                       ? 'n' : ' ';
-  const char scc_char       = is_scc                          ? 'A' : ' ';
+  const char aot_char       = is_aot                          ? 'A' : ' ';
   const char preload_char   = is_preload                      ? 'P' : ' ';
 
   // print method attributes
-  st->print("%c%c%c%c%c%c%c ", compile_type, sync_char, exception_char, blocking_char, native_char, scc_char, preload_char);
+  st->print("%c%c%c%c%c%c%c ", compile_type, sync_char, exception_char, blocking_char, native_char, aot_char, preload_char);
 
   if (TieredCompilation) {
     if (comp_level != -1)  st->print("%d ", comp_level);
@@ -362,7 +361,7 @@ void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, i
 // CompileTask::print_compilation
 void CompileTask::print(outputStream* st, const char* msg, bool short_form, bool cr) {
   bool is_osr_method = osr_bci() != InvocationEntryBci;
-  print_impl(st, is_unloaded() ? nullptr : method(), compile_id(), comp_level(), is_osr_method, osr_bci(), is_blocking(), is_scc(), preload(),
+  print_impl(st, is_unloaded() ? nullptr : method(), compile_id(), comp_level(), is_osr_method, osr_bci(), is_blocking(), is_aot(), preload(),
              compiler()->name(), msg, short_form, cr, _time_created, _time_queued, _time_started, _time_finished, _aot_load_start, _aot_load_finish);
 }
 
@@ -560,7 +559,7 @@ void CompileTask::print_ul(const nmethod* nm, const char* msg) {
     print_impl(&ls, nm->method(), nm->compile_id(),
                nm->comp_level(), nm->is_osr_method(),
                nm->is_osr_method() ? nm->osr_entry_bci() : -1,
-               /*is_blocking*/ false, nm->scc_entry() != nullptr,
+               /*is_blocking*/ false, nm->aot_code_entry() != nullptr,
                nm->preloaded(), nm->compiler_name(),
                msg, /* short form */ true, /* cr */ true);
   }

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -34,7 +34,7 @@
 class CompileQueue;
 class CompileTrainingData;
 class DirectiveSet;
-class SCCEntry;
+class AOTCodeEntry;
 
 JVMCI_ONLY(class JVMCICompileState;)
 
@@ -65,7 +65,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
       Reason_Whitebox,         // Whitebox API
       Reason_MustBeCompiled,   // Used for -Xcomp or AlwaysCompileLoopMethods (see CompilationPolicy::must_be_compiled())
       Reason_Bootstrap,        // JVMCI bootstrap
-      Reason_Preload,          // pre-load SC code
+      Reason_Preload,          // pre-load AOT code
       Reason_Precompile,
       Reason_PrecompileForPreload,
       Reason_Count
@@ -110,7 +110,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
   CodeSection::csize_t _nm_insts_size;
   DirectiveSet*  _directive;
   AbstractCompiler*    _compiler;
-  SCCEntry*            _scc_entry;
+  AOTCodeEntry*        _aot_code_entry;
 #if INCLUDE_JVMCI
   bool                 _has_waiter;
   // Compilation state for a blocking JVMCI compilation
@@ -147,7 +147,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
   }
 
   void initialize(int compile_id, const methodHandle& method, int osr_bci, int comp_level,
-                  const methodHandle& hot_method, int hot_count, SCCEntry* scc_entry,
+                  const methodHandle& hot_method, int hot_count, AOTCodeEntry* aot_code_entry,
                   CompileTask::CompileReason compile_reason,
                   CompileQueue* compile_queue,
                   bool requires_online_compilation, bool is_blocking);
@@ -163,9 +163,9 @@ class CompileTask : public CHeapObj<mtCompiler> {
   bool         is_complete() const                  { return _is_complete; }
   bool         is_blocking() const                  { return _is_blocking; }
   bool         is_success() const                   { return _is_success; }
-  bool         is_scc() const                       { return _scc_entry != nullptr; }
-  void         clear_scc()                          { _scc_entry = nullptr; }
-  SCCEntry*    scc_entry()                          { return _scc_entry; }
+  bool         is_aot() const                       { return _aot_code_entry != nullptr; }
+  void         clear_aot()                          { _aot_code_entry = nullptr; }
+  AOTCodeEntry* aot_code_entry()                    { return _aot_code_entry; }
   bool         requires_online_compilation() const  { return _requires_online_compilation; }
   DirectiveSet* directive() const                   { return _directive; }
   CompileReason compile_reason() const              { return _compile_reason; }
@@ -272,7 +272,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
 private:
   static void  print_impl(outputStream* st, Method* method, int compile_id, int comp_level,
                                       bool is_osr_method = false, int osr_bci = -1, bool is_blocking = false,
-                                      bool is_scc = false, bool is_preload = false,
+                                      bool is_aot = false, bool is_preload = false,
                                       const char* compiler_name = nullptr,
                                       const char* msg = nullptr, bool short_form = false, bool cr = true,
                                       jlong time_created = 0, jlong time_queued = 0, jlong time_started = 0, jlong time_finished = 0,
@@ -284,7 +284,7 @@ public:
   static void  print(outputStream* st, const nmethod* nm, const char* msg = nullptr, bool short_form = false, bool cr = true) {
     print_impl(st, nm->method(), nm->compile_id(), nm->comp_level(),
                            nm->is_osr_method(), nm->is_osr_method() ? nm->osr_entry_bci() : -1, /*is_blocking*/ false,
-                           nm->scc_entry() != nullptr, nm->preloaded(),
+                           nm->aot_code_entry() != nullptr, nm->preloaded(),
                            nm->compiler_name(), msg, short_form, cr);
   }
   static void  print_ul(const nmethod* nm, const char* msg = nullptr);

--- a/src/hotspot/share/compiler/oopMap.hpp
+++ b/src/hotspot/share/compiler/oopMap.hpp
@@ -154,7 +154,7 @@ class OopMap: public ResourceObj {
   friend class VMStructs;
   friend class OopMapSet;
   friend class OopMapSort;
-  friend class SCCReader;
+  friend class AOTCodeReader;
  private:
   int  _pc_offset; // offset in the code that this OopMap corresponds to
   int  _omv_count; // number of OopMapValues in the stream
@@ -218,7 +218,7 @@ class OopMap: public ResourceObj {
 
 class OopMapSet : public ResourceObj {
   friend class VMStructs;
-  friend class SCCReader;
+  friend class AOTCodeReader;
  private:
   GrowableArray<OopMap*> _list;
 

--- a/src/hotspot/share/compiler/precompiler.cpp
+++ b/src/hotspot/share/compiler/precompiler.cpp
@@ -26,7 +26,7 @@
 #include "cds/cdsAccess.hpp"
 #include "cds/cdsConfig.hpp"
 #include "cds/runTimeClassInfo.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compiler_globals.hpp"
 #include "compiler/precompiler.hpp"
@@ -163,7 +163,7 @@ public:
           Method* requested_m = builder->to_requested(builder->get_buffered_addr(m));
           log.print(" -> %p", requested_m);
         }
-        log.print("] [%d] (%s)", SCCache::store_entries_cnt(), (is_success ? "success" : "FAILED"));
+        log.print("] [%d] (%s)", AOTCodeCache::store_entries_cnt(), (is_success ? "success" : "FAILED"));
       }
     }
 

--- a/src/hotspot/share/compiler/recompilationPolicy.cpp
+++ b/src/hotspot/share/compiler/recompilationPolicy.cpp
@@ -80,7 +80,7 @@ bool RecompilationPolicy::recompilation_step(int step, TRAPS) {
         continue;
       }
 
-      if (!AOTForceRecompilation && !(nm->is_scc() && nm->comp_level() == CompLevel_full_optimization)) {
+      if (!AOTForceRecompilation && !(nm->is_aot() && nm->comp_level() == CompLevel_full_optimization)) {
         // If it's already online-compiled at level 4, mark it as done.
         if (nm->comp_level() == CompLevel_full_optimization) {
           RecompilationSchedule::set_status_at(i, true);

--- a/src/hotspot/share/gc/g1/c1/g1BarrierSetC1.cpp
+++ b/src/hotspot/share/gc/g1/c1/g1BarrierSetC1.cpp
@@ -25,7 +25,7 @@
 #include "c1/c1_LIRGenerator.hpp"
 #include "c1/c1_CodeStubs.hpp"
 #if INCLUDE_CDS
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #endif
 #include "gc/g1/c1/g1BarrierSetC1.hpp"
 #include "gc/g1/g1BarrierSet.hpp"
@@ -171,7 +171,7 @@ void G1BarrierSetC1::post_barrier(LIRAccess& access, LIR_Opr addr, LIR_Opr new_v
     __ move(addr, xor_res);
     __ logical_xor(xor_res, new_val, xor_res);
 #if INCLUDE_CDS
-    if (SCCache::is_on_for_write()) {
+    if (AOTCodeCache::is_on_for_write()) {
       __ move(grain_shift_addr, grain_shift_reg);
       __ move(xor_res, xor_shift_res);
       __ move(grain_shift_indirect, grain_shift);
@@ -191,7 +191,7 @@ void G1BarrierSetC1::post_barrier(LIRAccess& access, LIR_Opr addr, LIR_Opr new_v
   } else {
     __ logical_xor(addr, new_val, xor_res);
 #if INCLUDE_CDS
-    if (SCCache::is_on_for_write()) {
+    if (AOTCodeCache::is_on_for_write()) {
       __ move(grain_shift_addr, grain_shift_reg);
       __ move(grain_shift_indirect, grain_shift);
       __ unsigned_shift_right(xor_res,

--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -23,9 +23,6 @@
  */
 
 #include "classfile/javaClasses.hpp"
-#if INCLUDE_CDS
-#include "code/SCCache.hpp"
-#endif
 #include "code/vmreg.inline.hpp"
 #include "gc/g1/c2/g1BarrierSetC2.hpp"
 #include "gc/g1/g1BarrierSet.hpp"

--- a/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.hpp
+++ b/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.hpp
@@ -190,10 +190,10 @@ public:
 #endif // PRODUCT
 };
 
-class SCAddressTable;
+class AOTCodeAddressTable;
 
 class ShenandoahBarrierSetC1 : public BarrierSetC1 {
-  friend class SCAddressTable;
+  friend class AOTCodeAddressTable;
 private:
   CodeBlob* _pre_barrier_c1_runtime_code_blob;
   CodeBlob* _load_reference_barrier_strong_rt_code_blob;

--- a/src/hotspot/share/gc/z/c1/zBarrierSetC1.hpp
+++ b/src/hotspot/share/gc/z/c1/zBarrierSetC1.hpp
@@ -87,10 +87,10 @@ public:
 #endif // PRODUCT
 };
 
-class SCAddressTable;
+class AOTCodeAddressTable;
 
 class ZBarrierSetC1 : public BarrierSetC1 {
-  friend SCAddressTable;
+  friend AOTCodeAddressTable;
 private:
   address _load_barrier_on_oop_field_preloaded_runtime_stub;
   address _load_barrier_on_weak_oop_field_preloaded_runtime_stub;

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -2164,7 +2164,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
                                  debug_info, dependencies, code_buffer,
                                  frame_words, oop_map_set,
                                  handler_table, implicit_exception_table,
-                                 compiler, comp_level, nullptr /* SCCEntry */,
+                                 compiler, comp_level, nullptr /* AOTCodeEntry */,
                                  speculations, speculations_len, data);
 
 

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -181,7 +181,6 @@ class outputStream;
   LOG_TAG(safepoint) \
   LOG_TAG(sampling) \
   LOG_TAG(scavenge) \
-  LOG_TAG(scc) \
   LOG_TAG(sealed) \
   LOG_TAG(setting) \
   LOG_TAG(smr) \

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1326,7 +1326,7 @@ void Method::link_method(const methodHandle& h_method, TRAPS) {
   if (_preload_code != nullptr) {
     MutexLocker ml(NMethodState_lock, Mutex::_no_safepoint_check_flag);
     set_code(h_method, _preload_code);
-    assert(((nmethod*)_preload_code)->scc_entry() == _scc_entry, "sanity");
+    assert(((nmethod*)_preload_code)->aot_code_entry() == _aot_code_entry, "sanity");
   }
 }
 

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -64,7 +64,7 @@ class ConstMethod;
 class InlineTableSizes;
 class nmethod;
 class InterpreterOopMap;
-class SCCEntry;
+class AOTCodeEntry;
 
 class Method : public Metadata {
  friend class VMStructs;
@@ -103,8 +103,8 @@ class Method : public Metadata {
   nmethod* volatile _code;                   // Points to the corresponding piece of native code
   volatile address  _from_interpreted_entry; // Cache of _code ? _adapter->i2c_entry() : _i2i_entry
 
-  nmethod*  _preload_code;  // preloaded SCCache code
-  SCCEntry* _scc_entry;     // SCCache entry for pre-loading code
+  nmethod*  _preload_code;       // preloaded AOT code
+  AOTCodeEntry* _aot_code_entry; // AOT Code Cache entry for pre-loading code
 
   // Constructor
   Method(ConstMethod* xconst, AccessFlags access_flags, Symbol* name);
@@ -395,11 +395,11 @@ public:
   void set_preload_code(nmethod* code) {
     _preload_code = code;
   }
-  void set_scc_entry(SCCEntry* entry) {
-    _scc_entry = entry;
+  void set_aot_code_entry(AOTCodeEntry* entry) {
+    _aot_code_entry = entry;
   }
-  SCCEntry* scc_entry() const {
-    return _scc_entry;
+  AOTCodeEntry* aot_code_entry() const {
+    return _aot_code_entry;
   }
 
   address get_i2c_entry();

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -23,7 +23,7 @@
  */
 
 #include "classfile/vmClasses.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compilationMemoryStatistic.hpp"
 #include "compiler/compilerDefinitions.inline.hpp"
 #include "runtime/handles.inline.hpp"
@@ -102,7 +102,7 @@ bool C2Compiler::init_c2_runtime() {
   HandleMark handle_mark(thread);
   bool success = OptoRuntime::generate(thread->env());
   if (success) {
-    SCCache::init_opto_table();
+    AOTCodeCache::init_opto_table();
   }
   return success;
 }
@@ -127,21 +127,21 @@ void C2Compiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, boo
   assert(is_initialized(), "Compiler thread must be initialized");
   CompilationMemoryStatisticMark cmsm(directive);
   CompileTask* task = env->task();
-  if (install_code && task->is_scc()) {
-    bool success = SCCache::load_nmethod(env, target, entry_bci, this, CompLevel_full_optimization);
+  if (install_code && task->is_aot()) {
+    bool success = AOTCodeCache::load_nmethod(env, target, entry_bci, this, CompLevel_full_optimization);
     if (success) {
       assert(task->is_success(), "sanity");
       return;
     }
     if (!task->preload()) { // Do not mark entry if pre-loading failed - it can pass normal load
-      SCCache::invalidate(task->scc_entry()); // mark sca_entry as not entrant
+      AOTCodeCache::invalidate(task->aot_code_entry()); // mark aot_code_entry as not entrant
     }
-    if (SCCache::is_code_load_thread_on()) {
-      env->record_failure("Failed to load cached code");
-      // Bail out if failed to load cached code in SC thread
+    if (AOTCodeCache::is_code_load_thread_on()) {
+      env->record_failure("Failed to load AOT code");
+      // Bail out if failed to load AOT code in AOTCodeCache thread
       return;
     }
-    task->clear_scc();
+    task->clear_aot();
   }
 
   bool subsume_loads = SubsumeLoads;
@@ -152,7 +152,7 @@ void C2Compiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, boo
   bool do_locks_coarsening = EliminateLocks;
   bool do_superword = UseSuperWord;
   bool for_preload = (task->compile_reason() != CompileTask::Reason_Precompile) && // non-preload version is requested
-                     SCCache::gen_preload_code(target, entry_bci);
+                     AOTCodeCache::gen_preload_code(target, entry_bci);
   if (task->compile_reason() == CompileTask::Reason_PrecompileForPreload) {
     assert(for_preload, "required");
   }

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2142,7 +2142,7 @@ Node* GraphKit::uncommon_trap(int trap_request,
       (action != Deoptimization::Action_none)) {
     ResourceMark rm;
     ciMethod* cim = Compile::current()->method();
-    log_debug(scc,deoptimization)("Uncommon trap in preload code: reason=%s action=%s method=%s::%s bci=%d, %s",
+    log_debug(aot, codecache, deoptimization)("Uncommon trap in preload code: reason=%s action=%s method=%s::%s bci=%d, %s",
                   Deoptimization::trap_reason_name(reason), Deoptimization::trap_action_name(action),
                   cim->holder()->name()->as_klass_external_name(), cim->name()->as_klass_external_name(),
                   bci(), comment);

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -23,10 +23,10 @@
  */
 
 #include "asm/assembler.inline.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "code/debugInfo.hpp"
 #include "code/debugInfoRec.hpp"
-#include "code/SCCache.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compilerDirectives.hpp"
 #include "compiler/disassembler.hpp"
@@ -3674,7 +3674,7 @@ void PhaseOutput::print_statistics() {
 #endif
 
 int PhaseOutput::max_inst_size() {
-  if (SCCache::is_on_for_write()) {
+  if (AOTCodeCache::is_on_for_write()) {
     // See the comment in output.hpp.
     return 16384;
   } else {

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -182,11 +182,11 @@ public:
 
   BufferSizingData* buffer_sizing_data()        { return &_buf_sizes; }
 
-  // SCCache::write_nmethod bails when nmethod buffer is expanded.
+  // AOTCodeCache::write_nmethod bails when nmethod buffer is expanded.
   // Large methods would routinely expand the buffer, making themselves
-  // ineligible for SCCache stores. In order to minimize this effect,
-  // we default to larger default sizes. We do this only when SCC dumping
-  // is active, to avoid impact on default configuration.
+  // ineligible for AOTCodeCache stores. In order to minimize this effect,
+  // we default to larger default sizes. We do this only when AOTCodeCache
+  // dumping is active, to avoid impact on default configuration.
   //
   // Additionally, GC barrier stubs expand up to MAX_inst_size in mainline,
   // which also forced resizes often. Current code replaces it with
@@ -196,7 +196,7 @@ public:
   // The old enum is renamed, so direct misuse in new code from mainline would
   // be caught as build failure.
   //
-  // TODO: Revert this back to mainline once SCCache is fixed.
+  // TODO: Revert this back to mainline once AOTCodeCache is fixed.
   enum ScratchBufferBlob {
     mainline_MAX_inst_size = 2048,
     MAX_locs_size       = 128, // number of relocInfo elements

--- a/src/hotspot/share/opto/rootnode.cpp
+++ b/src/hotspot/share/opto/rootnode.cpp
@@ -30,7 +30,7 @@
 #include "opto/rootnode.hpp"
 #include "opto/subnode.hpp"
 #include "opto/type.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 
 //------------------------------Ideal------------------------------------------
 // Remove dead inputs
@@ -71,7 +71,7 @@ HaltNode::HaltNode(Node* ctrl, Node* frameptr, const char* halt_reason, bool rea
   init_req(TypeFunc::Memory,   top);
   init_req(TypeFunc::FramePtr, frameptr    );
   init_req(TypeFunc::ReturnAdr,top);
-  SCCache::add_C_string(halt_reason);
+  AOTCodeCache::add_C_string(halt_reason);
 }
 
 const Type *HaltNode::bottom_type() const { return Type::BOTTOM; }

--- a/src/hotspot/share/opto/runtime.hpp
+++ b/src/hotspot/share/opto/runtime.hpp
@@ -113,7 +113,7 @@ enum class OptoStubId :int {
 
 class OptoRuntime : public AllStatic {
   friend class Matcher;  // allow access to stub names
-  friend class SCAddressTable;
+  friend class AOTCodeAddressTable;
  private:
   // declare opto stub address/blob holder static fields
 #define C2_BLOB_FIELD_DECLARE(name, type) \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3762,7 +3762,7 @@ jint Arguments::apply_ergo() {
     warning("UseSecondarySupersTable is not supported");
     FLAG_SET_DEFAULT(UseSecondarySupersTable, false);
   }
-  UseSecondarySupersTable = false; // FIXME: Disabled for Leyden. Neet to fix SCAddressTable::id_for_address()
+  UseSecondarySupersTable = false; // FIXME: Disabled for Leyden. Neet to fix AOTCodeAddressTable::id_for_address()
   if (!UseSecondarySupersTable) {
     FLAG_SET_DEFAULT(StressSecondarySupers, false);
     FLAG_SET_DEFAULT(VerifySecondarySupers, false);

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -2863,7 +2863,7 @@ void Deoptimization::gather_statistics(nmethod* nm, DeoptReason reason, DeoptAct
 
   update(_deoptimization_hist[0][reason][1+action], bc);
 
-  uint lvl = nm->comp_level() + (nm->is_scc() ? 4 : 0) + (nm->preloaded() ? 1 : 0);
+  uint lvl = nm->comp_level() + (nm->is_aot() ? 4 : 0) + (nm->preloaded() ? 1 : 0);
   _deoptimization_hist[lvl][Reason_none][0][0] += 1;  // total
   _deoptimization_hist[lvl][reason][0][0]      += 1;  // per-reason total
   update(_deoptimization_hist[lvl][reason][1+action], bc);
@@ -2951,10 +2951,10 @@ void Deoptimization::print_statistics_on(outputStream* st) {
   print_statistics_on("Tier3", 3, st);
   print_statistics_on("Tier4", 4, st);
 
-  print_statistics_on("SC Tier1", 5, st);
-  print_statistics_on("SC Tier2", 6, st);
-  print_statistics_on("SC Tier4", 8, st);
-  print_statistics_on("SC Tier5 (preloaded)", 9, st);
+  print_statistics_on("AOT Code Tier1", 5, st);
+  print_statistics_on("AOT Code Tier2", 6, st);
+  print_statistics_on("AOT Code Tier4", 8, st);
+  print_statistics_on("AOT Code Tier5 (preloaded)", 9, st);
 }
 
 #define DO_COUNTERS(macro) \

--- a/src/hotspot/share/runtime/init.cpp
+++ b/src/hotspot/share/runtime/init.cpp
@@ -26,7 +26,7 @@
 #include "classfile/stringTable.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compiler_globals.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/gcHeapSummary.hpp"
@@ -159,7 +159,7 @@ jint init_globals() {
     LSAN_REGISTER_ROOT_REGION(summary.start(), summary.reserved_size());
   }
 #endif // LEAK_SANITIZER
-  SCCache::init2();        // depends on universe_init
+  AOTCodeCache::init2();        // depends on universe_init
   AsyncLogWriter::initialize();
   gc_barrier_stubs_init();   // depends on universe_init, must be before interpreter_init
   continuations_init();      // must precede continuation stub generation
@@ -172,8 +172,8 @@ jint init_globals() {
   InterfaceSupport_init();
   VMRegImpl::set_regName();  // need this before generate_stubs (for printing oop maps).
   SharedRuntime::generate_stubs();
-  SCCache::init_shared_blobs_table();  // need this after generate_stubs
-  SharedRuntime::init_adapter_library(); // do this after SCCache::init_shared_blobs_table
+  AOTCodeCache::init_shared_blobs_table();  // need this after generate_stubs
+  SharedRuntime::init_adapter_library(); // do this after AOTCodeCache::init_shared_blobs_table
   return JNI_OK;
 }
 
@@ -225,7 +225,7 @@ jint init_globals2() {
   }
   compiler_stubs_init(false /* in_compiler_thread */); // compiler's intrinsics stubs
   final_stubs_init();    // final StubRoutines stubs
-  SCCache::init_stubs_table();
+  AOTCodeCache::init_stubs_table();
   MethodHandles::generate_adapters();
 
   // All the flags that get adjusted by VM_Version_init and os::init_2

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -36,7 +36,7 @@
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "code/codeCache.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compilationMemoryStatistic.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
@@ -211,11 +211,11 @@ void log_vm_init_stats() {
       log.cr();
     }
 
-    if (SCCache::is_on_for_read()) {
+    if (AOTCodeCache::is_on_for_read()) {
       log.print_cr("Startup Code Cache: ");
-      SCCache::print_statistics_on(&log);
+      AOTCodeCache::print_statistics_on(&log);
       log.cr();
-      SCCache::print_timers_on(&log);
+      AOTCodeCache::print_timers_on(&log);
     }
 
     VMThread::print_counters_on(&log);
@@ -548,7 +548,7 @@ void before_exit(JavaThread* thread, bool halt) {
   }
 #endif
 
-  SCCache::close(); // Write final data and close archive
+  AOTCodeCache::close(); // Write final data and close archive
 
   // Hang forever on exit if we're reporting an error.
   if (ShowMessageBoxOnError && VMError::is_error_reported()) {

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -30,7 +30,7 @@
 #include "classfile/stringTable.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/codeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "code/nmethod.inline.hpp"
@@ -2845,7 +2845,7 @@ bool AdapterHandlerLibrary::lookup_aot_cache(AdapterHandlerEntry* handler, CodeB
   const char* name = AdapterHandlerLibrary::name(handler->fingerprint());
   const uint32_t id = AdapterHandlerLibrary::id(handler->fingerprint());
   uint32_t offsets[4];
-  if (SCCache::load_adapter(buffer, id, name, offsets)) {
+  if (AOTCodeCache::load_adapter(buffer, id, name, offsets)) {
     address i2c_entry = buffer->insts_begin();
     assert(offsets[0] == 0, "sanity check");
     handler->set_entry_points(i2c_entry, i2c_entry + offsets[1], i2c_entry + offsets[2], i2c_entry + offsets[3]);
@@ -2909,7 +2909,7 @@ bool AdapterHandlerLibrary::generate_adapter_code(AdapterBlob*& adapter_blob,
     offsets[1] = handler->get_c2i_entry() - handler->get_i2c_entry();
     offsets[2] = handler->get_c2i_unverified_entry() - handler->get_i2c_entry();
     offsets[3] = handler->get_c2i_no_clinit_check_entry() - handler->get_i2c_entry();
-    SCCache::store_adapter(&buffer, id, name, offsets);
+    AOTCodeCache::store_adapter(&buffer, id, name, offsets);
   }
 #ifdef ASSERT
   if (VerifyAdapterSharing) {

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -202,7 +202,7 @@ public:
   // Dependencies
   friend class StubGenerator;
   friend class VMStructs;
-  friend class SCAddressTable;
+  friend class AOTCodeAddressTable;
 #if INCLUDE_JVMCI
   friend class JVMCIVMStructs;
 #endif

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -38,7 +38,7 @@
 #include "classfile/systemDictionaryShared.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
-#include "code/SCCache.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compileTask.hpp"
@@ -862,7 +862,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   if (PrecompileCode) {
     Precompiler::compile_cached_code(CHECK_JNI_ERR);
     if (PrecompileOnlyAndExit) {
-      SCCache::close();
+      AOTCodeCache::close();
       log_vm_init_stats();
       vm_direct_exit(0, "Code precompiation is over");
     }
@@ -871,7 +871,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 
 #if defined(COMPILER2)
   // Pre-load cached compiled methods
-  SCCache::preload_code(CHECK_JNI_ERR);
+  AOTCodeCache::preload_code(CHECK_JNI_ERR);
 #endif
 
   if (NativeHeapTrimmer::enabled()) {

--- a/test/hotspot/jtreg/premain/javac/javac-test.sh
+++ b/test/hotspot/jtreg/premain/javac/javac-test.sh
@@ -71,7 +71,7 @@ while true; do
         shift
     elif [[ $1 = "-lsc" ]]; then
         # Log shared code
-        EXTRA_ARGS="$EXTRA_ARGS -Xlog:scc -Xlog:scc,nmethod"
+        EXTRA_ARGS="$EXTRA_ARGS -Xlog:aot+codecache -Xlog:aot+codecache+nmethod"
         shift
     elif [[ $1 = "-r" ]]; then
         # Limit the run to a single test case
@@ -428,7 +428,7 @@ for i in $TESTS; do
     fi
 
     #----------------------------------------------------------------------
-    CMD="$JVM_AND_ARGS $EXTRA_ARGS -Xlog:scc*=warning:file=javac.scc-store.log::filesize=0 \
+    CMD="$JVM_AND_ARGS $EXTRA_ARGS -Xlog:aot+codecache*=warning:file=javac.aot-store.log::filesize=0 \
         -XX:SharedArchiveFile=$JSA2 $X2 -XX:+StoreCachedCode -XX:CachedCodeFile=${JSA2}-sc -XX:CachedCodeMaxSize=100M \
         -cp JavacBench.jar JavacBench $LOOPS"
     test-info "${STEP4}Run with $JSA2 and generate AOT code" &&
@@ -439,7 +439,7 @@ for i in $TESTS; do
     fi
 
     #----------------------------------------------------------------------
-    CMD="$JVM_AND_ARGS $EXTRA_ARGS -Xlog:scc*=warning:file=javac.scc-load.log::filesize=0 \
+    CMD="$JVM_AND_ARGS $EXTRA_ARGS -Xlog:aot+codecache*=warning:file=javac.aot-load.log::filesize=0 \
         -XX:SharedArchiveFile=$JSA2 $X2 -XX:+LoadCachedCode -XX:CachedCodeFile=${JSA2}-sc \
         -cp JavacBench.jar JavacBench $LOOPS"
     test-info "${STEP5}Final production run: with $JSA2 and load AOT code" &&

--- a/test/hotspot/jtreg/premain/javac_new_workflow/run.sh
+++ b/test/hotspot/jtreg/premain/javac_new_workflow/run.sh
@@ -40,7 +40,7 @@
 # as shown above, or edit the following line
 #
 # The training run uses two JVM processes. We add "pid" to the log to distinguish their output.
-TRAINING_OPTS="${TRAINING_OPTS} -Xlog:scc -Xlog:cds=debug::uptime,tags,pid"
+TRAINING_OPTS="${TRAINING_OPTS} -Xlog:aot+codecache -Xlog:cds=debug::uptime,tags,pid"
 TRAINING_OPTS="${TRAINING_OPTS} -XX:+AOTClassLinking"
 #TRAINING_OPTS="${TRAINING_OPTS} -XX:+UnlockDiagnosticVMOptions -XX:+AOTRecordTraining"
 
@@ -67,7 +67,7 @@ eval $cmd
 #========================================
 # Production run
 #    TODO: add flags for AOT cache
-cmd="$launcher $PRODUCTION_OPTS -Xlog:cds -Xlog:scc -XX:CacheDataStore=javac.cds $@ com.sun.tools.javac.Main HelloWorld.java"
+cmd="$launcher $PRODUCTION_OPTS -Xlog:cds -Xlog:aot+codecache -XX:CacheDataStore=javac.cds $@ com.sun.tools.javac.Main HelloWorld.java"
 perfcmd="perf stat -r 20 $(echo $cmd | sed -e 's/ [-]Xlog:[^ ]*//g')"
 echo "Production run: "
 echo "   $cmd"

--- a/test/hotspot/jtreg/premain/jmh/run.sh
+++ b/test/hotspot/jtreg/premain/jmh/run.sh
@@ -91,10 +91,10 @@ do_test "(STEP 3 of 5) Run with $APP-static.jsa and dump profile in $APP-dynamic
 
 do_test "(STEP 4 of 5) Run with $APP-dynamic.jsa and generate AOT code" \
     $JAVA -XX:SharedArchiveFile=$APP-dynamic.jsa -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+StoreCachedCode \
-        -Xlog:scc*=warning:file=$APP-store-sc.log \
+        -Xlog:aot+codecache*=warning:file=$APP-store-sc.log \
         -XX:CachedCodeFile=$APP-dynamic.jsa-sc -XX:CachedCodeMaxSize=100M $CMDLINE
 
 do_test "(STEP 5 of 5) Final production run: with $APP-dynamic.jsa and load AOT code" \
     $JAVA -XX:SharedArchiveFile=$APP-dynamic.jsa -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+LoadCachedCode \
-        -Xlog:scc*=warning:file=$APP-load-sc.log \
+        -Xlog:aot+codecache*=warning:file=$APP-load-sc.log \
         -XX:CachedCodeFile=$APP-dynamic.jsa-sc $CMDLINE

--- a/test/hotspot/jtreg/premain/lib/bench-lib-new-workflow.sh
+++ b/test/hotspot/jtreg/premain/lib/bench-lib-new-workflow.sh
@@ -56,7 +56,7 @@
 #
 #     LEYDEN_CALLER_OPTS
 #       extra args to be added to Leyden JVM runs
-#       e.g. LEYDEN_CALLER_OPTS='-Xlog:scc=error'
+#       e.g. LEYDEN_CALLER_OPTS='-Xlog:aot+codecache=error'
 #     TASKSET
 #       allows pinning of perf runs to specific processors
 #       e.g. setting TASKSET='taskest 0xff0' will execute

--- a/test/hotspot/jtreg/premain/lib/bench-lib.sh
+++ b/test/hotspot/jtreg/premain/lib/bench-lib.sh
@@ -233,7 +233,7 @@ function dump_one_jvm () {
         echo "(Premain  4 of 5) Run with $APPID-dynamic.jsa and generate AOT code"
         rm -f $APPID-store-sc.log
         (set -x; $JAVA -XX:SharedArchiveFile=$APPID-dynamic.jsa -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+StoreCachedCode \
-                       -Xlog:scc*=warning:file=$APPID-store-sc.log::filesize=0 \
+                       -Xlog:aot+codecache*=warning:file=$APPID-store-sc.log::filesize=0 \
                        -XX:CachedCodeFile=$APPID-dynamic.jsa-sc -XX:CachedCodeMaxSize=100M $CMDLINE) || exit 1
 
     fi
@@ -266,7 +266,7 @@ function exec_one_jvm () {
         RUNLOG=$RUNLOG,$(get_elapsed logs/${1}_td.$2)
         (set -x;
          perf stat -r $REPEAT $JAVA -XX:SharedArchiveFile=$APPID-dynamic.jsa -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+LoadCachedCode \
-              -XX:CachedCodeFile=$APPID-dynamic.jsa-sc -Xlog:scc=error \
+              -XX:CachedCodeFile=$APPID-dynamic.jsa-sc -Xlog:aot+codecache=error \
               $CMDLINE 2> logs/${1}_aot.$2
         )
         RUNLOG=$RUNLOG,$(get_elapsed logs/${1}_aot.$2)

--- a/test/hotspot/jtreg/premain/lib/premain-run.sh
+++ b/test/hotspot/jtreg/premain/lib/premain-run.sh
@@ -92,10 +92,10 @@ do_test "(STEP 3 of 5) Run with $APP-static.jsa and dump profile in $APP-dynamic
 
 do_test "(STEP 4 of 5) Run with $APP-dynamic.jsa and generate AOT code" \
     $JAVA -XX:SharedArchiveFile=$APP-dynamic.jsa -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+StoreCachedCode \
-        -Xlog:scc*=warning:file=$APP-store-sc.log::filesize=0 \
+        -Xlog:aot+codecache*=warning:file=$APP-store-sc.log::filesize=0 \
         -XX:CachedCodeFile=$APP-dynamic.jsa-sc -XX:CachedCodeMaxSize=100M $CMDLINE
 
 do_test "(STEP 5 of 5) Final production run: with $APP-dynamic.jsa and load AOT code" \
     $JAVA -XX:SharedArchiveFile=$APP-dynamic.jsa -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+LoadCachedCode \
-        -Xlog:scc*=warning:file=$APP-load-sc.log::filesize=0 \
+        -Xlog:aot+codecache*=warning:file=$APP-load-sc.log::filesize=0 \
         -XX:CachedCodeFile=$APP-dynamic.jsa-sc $CMDLINE

--- a/test/hotspot/jtreg/premain/spring-petclinic/WarmupMakefile
+++ b/test/hotspot/jtreg/premain/spring-petclinic/WarmupMakefile
@@ -281,7 +281,7 @@ ${PC_ST_CACHED_CODE}: ${PC_DYNAMIC_ST_JSA}
 
 ${PC_LT_CACHED_CODE}: ${PC_DYNAMIC_LT_JSA}
 	${PREMAIN_JAVA} -XX:SharedArchiveFile=${PC_DYNAMIC_LT_JSA} -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+StoreCachedCode \
-	     -Xlog:scc,cds=debug,cds+class=debug,cds+heap=warning,cds+resolve=debug:file=$@.log \
+	     -Xlog:aot+codecache=debug,cds=debug,cds+class=debug,cds+heap=warning,cds+resolve=debug:file=$@.log \
 	     -XX:CachedCodeFile=${PC_LT_CACHED_CODE} -XX:CachedCodeMaxSize=512M ${UNPACKED_CMDLINE} &> $@.out &
 	$(wait-for-startup)
 	$(run-jmeter)
@@ -305,7 +305,7 @@ ${PC_CDS}: ${PC_CDS_PREIMAGE}
 	rm -f ${PC_CDS}
 	${PREMAIN_JAVA} -XX:+AOTClassLinking -XX:CachedCodeMaxSize=512M \
 	       -XX:+UnlockDiagnosticVMOptions -XX:CDSPreimage=${PC_CDS_PREIMAGE} -XX:CacheDataStore=${PC_CDS} \
-	       -Xlog:scc,cds=debug,cds+class=debug,cds+heap=warning,cds+resolve=debug:file=$@.log \
+	       -Xlog:aot+codecache=debug,cds=debug,cds+class=debug,cds+heap=warning,cds+resolve=debug:file=$@.log \
 	       -XX:-AssemblyStepInlining \
 	       ${UNPACKED_CMDLINE} &> $@.out
 	ls -l $@

--- a/test/hotspot/jtreg/premain/spring-petclinic/bench.sh
+++ b/test/hotspot/jtreg/premain/spring-petclinic/bench.sh
@@ -42,7 +42,7 @@ cd pet-clinic-bench
 mkdir -p data
 
 CMDLINE="-XX:SharedArchiveFile=spring-petclinic.dynamic.jsa -XX:+UnlockDiagnosticVMOptions -XX:+AOTReplayTraining -XX:+LoadCachedCode"
-CMDLINE="$CMDLINE -XX:CachedCodeFile=spring-petclinic.code.jsa -Xlog:init -Xlog:scc=error -Xmx2g"
+CMDLINE="$CMDLINE -XX:CachedCodeFile=spring-petclinic.code.jsa -Xlog:init -Xlog:aot+codecache=error -Xmx2g"
 CMDLINE="$CMDLINE -cp @petclinic-snapshot/target/unpacked/classpath -DautoQuit=true"
 CMDLINE="$CMDLINE -Dspring.aot.enabled=true org.springframework.samples.petclinic.PetClinicApplication"
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/AOTFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/AOTFlags.java
@@ -93,7 +93,7 @@ public class AOTFlags {
         pb = ProcessTools.createLimitedTestJavaProcessBuilder(
             "-XX:AOTCache=" + aotCacheFile,
             "-Xlog:cds",
-            "-Xlog:scc*",
+            "-Xlog:aot+codecache*",
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod");
         out.shouldContain("Using AOT-linked classes: true (static archive: has aot-linked classes)");
@@ -165,7 +165,7 @@ public class AOTFlags {
         pb = ProcessTools.createLimitedTestJavaProcessBuilder(
             "-XX:AOTCache=" + aotCacheFile,
             "-Xlog:cds",
-            "-Xlog:scc*",
+            "-Xlog:aot+codecache*",
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod");
         out.shouldContain("Using AOT-linked classes: false (static archive: no aot-linked classes)");

--- a/test/hotspot/jtreg/runtime/cds/appcds/applications/HelidonQuickStartSE.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/applications/HelidonQuickStartSE.java
@@ -130,7 +130,7 @@ public class HelidonQuickStartSE {
             };
 
             if (runMode.isProductionRun()) {
-                cmdLine = StringArrayUtils.concat("-Xlog:scc=error", cmdLine);
+                cmdLine = StringArrayUtils.concat("-Xlog:aot+codecache=error", cmdLine);
             }
             return cmdLine;
         }

--- a/test/hotspot/jtreg/runtime/cds/appcds/applications/MicronautFirstApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/applications/MicronautFirstApp.java
@@ -129,7 +129,7 @@ public class MicronautFirstApp {
             };
 
             if (runMode.isProductionRun()) {
-                cmdLine = StringArrayUtils.concat("-Xlog:scc=error", cmdLine);
+                cmdLine = StringArrayUtils.concat("-Xlog:aot+codecache=error", cmdLine);
             }
             return cmdLine;
         }

--- a/test/hotspot/jtreg/runtime/cds/appcds/applications/QuarkusGettingStarted.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/applications/QuarkusGettingStarted.java
@@ -129,7 +129,7 @@ public class QuarkusGettingStarted {
             };
 
             if (runMode.isProductionRun()) {
-                cmdLine = StringArrayUtils.concat("-Xlog:scc=error", cmdLine);
+                cmdLine = StringArrayUtils.concat("-Xlog:aot+codecache=error", cmdLine);
             }
             return cmdLine;
         }

--- a/test/hotspot/jtreg/runtime/cds/appcds/applications/SpringPetClinic.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/applications/SpringPetClinic.java
@@ -208,7 +208,7 @@ public class SpringPetClinic {
             }
 
             if (runMode.isProductionRun()) {
-                cmdLine = StringArrayUtils.concat("-Xlog:scc=error", cmdLine);
+                cmdLine = StringArrayUtils.concat("-Xlog:aot+codecache=error", cmdLine);
             }
  */
             return cmdLine;

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/JDKMethodHandlesTestRunner.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/JDKMethodHandlesTestRunner.java
@@ -91,7 +91,7 @@ public class JDKMethodHandlesTestRunner {
                 public void checkExecution(OutputAnalyzer out, RunMode runMode) throws Exception {
                     out.shouldHaveExitValue(0);
                     if (runMode.isProductionRun()) {
-                        out.shouldMatch(".class.load. test.java.lang.invoke." + testClassName +
+                        out.shouldMatch(".class.load.* test.java.lang.invoke." + testClassName +
                                         "[$][$]Lambda.*/0x.*source:.*shared.*objects.*file");
                     }
                 }


### PR DESCRIPTION
Rename AOT Code classes and logging tags to match changes for mainline: https://github.com/openjdk/jdk/pull/24740

I also searched and renamed `sc_` to `ac_` and `scc_` to `aot_code_` patterns, also `SC`, `SCA`.

I tried to build without CDS locally and found few places we missed `NOT_CDS_RETURN` macro or `#if INCLUDE_CDS` check.

This is first part of changes in premain branch. AOT code flags renaming and more code changes will be done in separate PRs.

Tested with premain-tier1