### PR TITLE
8355915: [leyden] Crash in MDO clearing the unloaded array type

### DIFF
--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -731,6 +731,7 @@ public:
   virtual MetaspaceObj::Type type() const { return ClassType; }
 
   inline bool is_loader_alive() const;
+  inline bool is_loader_present_and_alive() const;
 
   void clean_subklass();
 

--- a/src/hotspot/share/oops/klass.inline.hpp
+++ b/src/hotspot/share/oops/klass.inline.hpp
@@ -59,6 +59,11 @@ inline bool Klass::is_loader_alive() const {
   return class_loader_data()->is_alive();
 }
 
+inline bool Klass::is_loader_present_and_alive() const {
+  ClassLoaderData* cld = class_loader_data();
+  return (cld != nullptr) ? cld->is_alive() : false;
+}
+
 inline markWord Klass::prototype_header() const {
   assert(UseCompactObjectHeaders, "only use with compact object headers");
 #ifdef _LP64

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -341,26 +341,15 @@ static bool is_excluded(Klass* k) {
   return false;
 }
 
-static bool is_not_yet_initialized(Klass* k) {
-  if (k->is_instance_klass()) {
-    return InstanceKlass::cast(k)->is_not_initialized();
-  }
-  if (k->is_objArray_klass()) {
-    return is_not_yet_initialized(ObjArrayKlass::cast(k)->bottom_klass());
-  }
-  // All other klass types should be always initialized.
-  return false;
-}
-
 void TypeStackSlotEntries::clean_weak_klass_links(bool always_clean) {
   for (int i = 0; i < _number_of_entries; i++) {
     intptr_t p = type(i);
     Klass* k = (Klass*)klass_part(p);
     if (k != nullptr) {
-      if (!always_clean && is_not_yet_initialized(k)) {
+      if (!always_clean && k->is_instance_klass() && InstanceKlass::cast(k)->is_not_initialized()) {
         continue; // skip not-yet-initialized classes // TODO: maybe clear the slot instead?
       }
-      if (always_clean || !k->is_loader_alive() || is_excluded(k)) {
+      if (always_clean || k->class_loader_data() == nullptr || !k->is_loader_alive() || is_excluded(k)) {
         set_type(i, with_status((Klass*)nullptr, p));
       }
     }
@@ -378,10 +367,10 @@ void ReturnTypeEntry::clean_weak_klass_links(bool always_clean) {
   intptr_t p = type();
   Klass* k = (Klass*)klass_part(p);
   if (k != nullptr) {
-    if (!always_clean && is_not_yet_initialized(k)) {
+    if (!always_clean && k->is_instance_klass() && InstanceKlass::cast(k)->is_not_initialized()) {
       return; // skip not-yet-initialized classes // TODO: maybe clear the slot instead?
     }
-    if (always_clean || !k->is_loader_alive() || is_excluded(k)) {
+    if (always_clean || k->class_loader_data() == nullptr || !k->is_loader_alive() || is_excluded(k)) {
       set_type(with_status((Klass*)nullptr, p));
     }
   }
@@ -468,10 +457,11 @@ void ReceiverTypeData::clean_weak_klass_links(bool always_clean) {
     for (uint row = 0; row < row_limit(); row++) {
     Klass* p = receiver(row);
     if (p != nullptr) {
-      if (!always_clean && is_not_yet_initialized(p)) {
+      if (!always_clean && p->is_instance_klass() && InstanceKlass::cast(p)->is_not_initialized()) {
         continue; // skip not-yet-initialized classes // TODO: maybe clear the slot instead?
       }
-      if (always_clean || !p->is_loader_alive() || is_excluded(p)) {
+      assert(p->class_loader_data() != nullptr, "Sanity");
+      if (always_clean || p->class_loader_data() == nullptr || !p->is_loader_alive() || is_excluded(p)) {
         clear_row(row);
       }
     }
@@ -1853,7 +1843,7 @@ class CleanExtraDataKlassClosure : public CleanExtraDataClosure {
 public:
   CleanExtraDataKlassClosure(bool always_clean) : _always_clean(always_clean) {}
   bool is_live(Method* m) {
-    if (!_always_clean && is_not_yet_initialized(m->method_holder())) {
+    if (!_always_clean && m->method_holder()->is_instance_klass() && InstanceKlass::cast(m->method_holder())->is_not_initialized()) {
       return true; // TODO: treat as unloaded instead?
     }
     return !(_always_clean) && m->method_holder()->is_loader_alive();

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -349,7 +349,7 @@ void TypeStackSlotEntries::clean_weak_klass_links(bool always_clean) {
       if (!always_clean && k->is_instance_klass() && InstanceKlass::cast(k)->is_not_initialized()) {
         continue; // skip not-yet-initialized classes // TODO: maybe clear the slot instead?
       }
-      if (always_clean || k->class_loader_data() == nullptr || !k->is_loader_alive() || is_excluded(k)) {
+      if (always_clean || !k->is_loader_present_and_alive() || is_excluded(k)) {
         set_type(i, with_status((Klass*)nullptr, p));
       }
     }
@@ -370,7 +370,7 @@ void ReturnTypeEntry::clean_weak_klass_links(bool always_clean) {
     if (!always_clean && k->is_instance_klass() && InstanceKlass::cast(k)->is_not_initialized()) {
       return; // skip not-yet-initialized classes // TODO: maybe clear the slot instead?
     }
-    if (always_clean || k->class_loader_data() == nullptr || !k->is_loader_alive() || is_excluded(k)) {
+    if (always_clean || !k->is_loader_present_and_alive() || is_excluded(k)) {
       set_type(with_status((Klass*)nullptr, p));
     }
   }
@@ -460,8 +460,7 @@ void ReceiverTypeData::clean_weak_klass_links(bool always_clean) {
       if (!always_clean && p->is_instance_klass() && InstanceKlass::cast(p)->is_not_initialized()) {
         continue; // skip not-yet-initialized classes // TODO: maybe clear the slot instead?
       }
-      assert(p->class_loader_data() != nullptr, "Sanity");
-      if (always_clean || p->class_loader_data() == nullptr || !p->is_loader_alive() || is_excluded(p)) {
+      if (always_clean || !p->is_loader_present_and_alive() || is_excluded(p)) {
         clear_row(row);
       }
     }

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -349,7 +349,7 @@ void TypeStackSlotEntries::clean_weak_klass_links(bool always_clean) {
       if (!always_clean && k->is_instance_klass() && InstanceKlass::cast(k)->is_not_initialized()) {
         continue; // skip not-yet-initialized classes // TODO: maybe clear the slot instead?
       }
-      if (always_clean || !k->is_loader_alive() || is_excluded(k)) {
+      if (always_clean || k->class_loader_data() == nullptr || !k->is_loader_alive() || is_excluded(k)) {
         set_type(i, with_status((Klass*)nullptr, p));
       }
     }
@@ -370,7 +370,7 @@ void ReturnTypeEntry::clean_weak_klass_links(bool always_clean) {
     if (!always_clean && k->is_instance_klass() && InstanceKlass::cast(k)->is_not_initialized()) {
       return; // skip not-yet-initialized classes // TODO: maybe clear the slot instead?
     }
-    if (always_clean || !k->is_loader_alive() || is_excluded(k)) {
+    if (always_clean || k->class_loader_data() == nullptr || !k->is_loader_alive() || is_excluded(k)) {
       set_type(with_status((Klass*)nullptr, p));
     }
   }
@@ -460,7 +460,7 @@ void ReceiverTypeData::clean_weak_klass_links(bool always_clean) {
       if (!always_clean && p->is_instance_klass() && InstanceKlass::cast(p)->is_not_initialized()) {
         continue; // skip not-yet-initialized classes // TODO: maybe clear the slot instead?
       }
-      if (always_clean || !p->is_loader_alive() || is_excluded(p)) {
+      if (always_clean || p->class_loader_data() == nullptr || !p->is_loader_alive() || is_excluded(p)) {
         clear_row(row);
       }
     }


### PR DESCRIPTION
Caught this when doing benchmarks with Spring Boot. See the bug for reproducer.

The lifecycle of array types of `T` is bound to the lifecycle of `T` themselves. So the fix does similar thing to `is_excluded` and other code: when we encounter the `T[]`, we ask if its bottom component classes is not yet initialized. This fits nicely with our current uses, which skip such classes, and ever touch their (potentially nullptr) CLDs.

Additional testing:
 - [x] Ad-hoc testing with most recent spring-boot-petclinic
 - [x] Linux x86_64 server fastdebug, `runtime/cds`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8355915](https://bugs.openjdk.org/browse/JDK-8355915): [leyden] Crash in MDO clearing the unloaded array type (**Bug** - P4)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - Committer) ⚠️ Review applies to [ab91db2d](https://git.openjdk.org/leyden/pull/64/files/ab91db2dd72291dbb10bb0eb36f3b9e7c4b06839)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.org/leyden.git pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/64.diff">https://git.openjdk.org/leyden/pull/64.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/64#issuecomment-2839262311)
</details>
