### PR TITLE
8347830: [premain] UseCompatibleCompressedOops is broken after merging with mainline

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -4088,6 +4088,16 @@ int AOTCodeAddressTable::id_for_address(address addr, RelocIterator reloc, CodeB
   if (addr == (address)-1) { // Static call stub has jump to itself
     return id;
   }
+  // Check card_table_base address first since it can point to any address
+  BarrierSet* bs = BarrierSet::barrier_set();
+  if (bs->is_a(BarrierSet::CardTableBarrierSet)) {
+    if (addr == ci_card_table_address_as<address>()) {
+      id = search_address(addr, _extrs_addr, _extrs_length);
+      assert(id > 0 && _extrs_addr[id - _extrs_base] == addr, "sanity");
+      return id;
+    }
+  }
+
   // Seach for C string
   id = id_for_C_string(addr);
   if (id >= 0) {


### PR DESCRIPTION
The issue was that we did not allocate space "noaccess prefix" before heap for read-only page when we setup type of encoding  with `UseCompatibleCompressedOops` flag. I update code which reserves heap for compressed oops to take into account this flag.

An other issue was that `UseCompatibleCompressedOops` flag was set during CDS arguments consistency checkup. But `UseCompressedOops` flag is set by GC ergonomics. I moved code to CDS ergonomics setting method.

During testing I hit assert that AOT code address table is missing some code blob address. But it was actually card table base address which pointed inside CodeCache. I added special case to check for it early.

Tested premain-tier1.