### PR TITLE
8357060: [premain] assert(left >= right) failed: avoid underflow

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5361,7 +5361,41 @@ bool MacroAssembler::set_klass_decode_mode(address base, int shift, const size_t
   return _klass_decode_mode != KlassDecodeNone;
 }
 
+static Register pick_different_tmp(Register dst, Register src) {
+  auto tmps = RegSet::of(r0, r1, r2) - RegSet::of(src, dst);
+  return *tmps.begin();
+}
+
+void MacroAssembler::encode_klass_not_null_for_aot(Register dst, Register src) {
+  // we have to load the klass base from the AOT constants area but
+  // not the shift because it is not allowed to change
+  int shift = CompressedKlassPointers::shift();
+  assert(shift >= 0 && shift < 4, "unexpected compressd klass shift!");
+  if (dst != src) {
+    // we can load the base into dst, subtract it formthe src and shift down
+    lea(dst, ExternalAddress(CompressedKlassPointers::base_addr()));
+    ldr(dst, dst);
+    sub(dst, src, dst);
+    lsr(dst, dst, shift);
+  } else {
+    // we need an extra register in order to load the coop base
+    Register tmp = pick_different_tmp(dst, src);
+    RegSet regs = RegSet::of(tmp);
+    push(regs, sp);
+    lea(tmp, ExternalAddress(CompressedKlassPointers::base_addr()));
+    ldr(tmp, tmp);
+    sub(dst, src, tmp);
+    lsr(dst, dst, shift);
+    pop(regs, sp);
+  }
+}
+
 void MacroAssembler::encode_klass_not_null(Register dst, Register src) {
+  if (AOTCodeCache::is_on_for_dump()) {
+    encode_klass_not_null_for_aot(dst, src);
+    return;
+  }
+
   switch (klass_decode_mode()) {
   case KlassDecodeZero:
     if (CompressedKlassPointers::shift() != 0) {
@@ -5398,8 +5432,35 @@ void MacroAssembler::encode_klass_not_null(Register r) {
   encode_klass_not_null(r, r);
 }
 
+void MacroAssembler::decode_klass_not_null_for_aot(Register dst, Register src) {
+  // we have to load the klass base from the AOT constants area but
+  // not the shift because it is not allowed to change
+  int shift = CompressedKlassPointers::shift();
+  assert(shift >= 0 && shift < 4, "unexpected compressd klass shift!");
+  if (dst != src) {
+    // we can load the base into dst then add the offset with a suitable shift
+    lea(dst, ExternalAddress(CompressedKlassPointers::base_addr()));
+    ldr(dst, dst);
+    add(dst, dst, src, LSL,  shift);
+  } else {
+    // we need an extra register in order to load the coop base
+    Register tmp = pick_different_tmp(dst, src);
+    RegSet regs = RegSet::of(tmp);
+    push(regs, sp);
+    lea(tmp, ExternalAddress(CompressedKlassPointers::base_addr()));
+    ldr(tmp, tmp);
+    add(dst, tmp,  src, LSL,  shift);
+    pop(regs, sp);
+  }
+}
+
 void  MacroAssembler::decode_klass_not_null(Register dst, Register src) {
   assert (UseCompressedClassPointers, "should only be used for compressed headers");
+
+  if (AOTCodeCache::is_on_for_dump()) {
+    decode_klass_not_null_for_aot(dst, src);
+    return;
+  }
 
   switch (klass_decode_mode()) {
   case KlassDecodeZero:
@@ -6698,7 +6759,7 @@ void MacroAssembler::get_thread(Register dst) {
   protect_return_address();
   push(saved_regs, sp);
 
-  mov(lr, CAST_FROM_FN_PTR(address, JavaThread::aarch64_get_thread_helper));
+  mov(lr, ExternalAddress(CAST_FROM_FN_PTR(address, JavaThread::aarch64_get_thread_helper)));
   blr(lr);
   if (dst != c_rarg0) {
     mov(dst, c_rarg0);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -935,6 +935,8 @@ public:
 
   void set_narrow_oop(Register dst, jobject obj);
 
+  void decode_klass_not_null_for_aot(Register dst, Register src);
+  void encode_klass_not_null_for_aot(Register dst, Register src);
   void encode_klass_not_null(Register r);
   void decode_klass_not_null(Register r);
   void encode_klass_not_null(Register dst, Register src);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5404,7 +5404,11 @@ void  MacroAssembler::decode_heap_oop_not_null(Register dst, Register src) {
 void MacroAssembler::encode_klass_not_null(Register r, Register tmp) {
   assert_different_registers(r, tmp);
   if (CompressedKlassPointers::base() != nullptr) {
-    mov64(tmp, (int64_t)CompressedKlassPointers::base());
+    if (AOTCodeCache::is_on_for_dump()) {
+      movptr(tmp, ExternalAddress(CompressedKlassPointers::base_addr()));
+    } else {
+      mov64(tmp, (int64_t)CompressedKlassPointers::base());
+    }
     subq(r, tmp);
   }
   if (CompressedKlassPointers::shift() != 0) {
@@ -5415,7 +5419,12 @@ void MacroAssembler::encode_klass_not_null(Register r, Register tmp) {
 void MacroAssembler::encode_and_move_klass_not_null(Register dst, Register src) {
   assert_different_registers(src, dst);
   if (CompressedKlassPointers::base() != nullptr) {
-    mov64(dst, -(int64_t)CompressedKlassPointers::base());
+    if (AOTCodeCache::is_on_for_dump()) {
+      movptr(dst, ExternalAddress(CompressedKlassPointers::base_addr()));
+      negl(dst);
+    } else {
+      mov64(dst, -(int64_t)CompressedKlassPointers::base());
+    }
     addq(dst, src);
   } else {
     movptr(dst, src);
@@ -5436,7 +5445,11 @@ void  MacroAssembler::decode_klass_not_null(Register r, Register tmp) {
     shlq(r, CompressedKlassPointers::shift());
   }
   if (CompressedKlassPointers::base() != nullptr) {
-    mov64(tmp, (int64_t)CompressedKlassPointers::base());
+    if (AOTCodeCache::is_on_for_dump()) {
+      movptr(tmp, ExternalAddress(CompressedKlassPointers::base_addr()));
+    } else {
+      mov64(tmp, (int64_t)CompressedKlassPointers::base());
+    }
     addq(r, tmp);
   }
 }
@@ -5457,7 +5470,11 @@ void  MacroAssembler::decode_and_move_klass_not_null(Register dst, Register src)
   } else {
     if (CompressedKlassPointers::shift() <= Address::times_8) {
       if (CompressedKlassPointers::base() != nullptr) {
-        mov64(dst, (int64_t)CompressedKlassPointers::base());
+        if (AOTCodeCache::is_on_for_dump()) {
+          movptr(dst, ExternalAddress(CompressedKlassPointers::base_addr()));
+        } else {
+          mov64(dst, (int64_t)CompressedKlassPointers::base());
+        }
       } else {
         xorq(dst, dst);
       }

--- a/src/hotspot/share/cds/aotCacheAccess.cpp
+++ b/src/hotspot/share/cds/aotCacheAccess.cpp
@@ -67,13 +67,6 @@ uint AOTCacheAccess::delta_from_base_address(address addr) {
   return (uint)pointer_delta(requested_addr, (address)MetaspaceShared::requested_base_address(), 1);
 }
 
-Method* AOTCacheAccess::method_in_aot_code(Method* m) {
-  assert(CDSConfig::is_dumping_final_static_archive(), "must be");
-  assert(ArchiveBuilder::is_active(), "must be");
-  ArchiveBuilder* builder = ArchiveBuilder::current();
-  return builder->to_requested(builder->get_buffered_addr(m));
-}
-
 #if INCLUDE_CDS_JAVA_HEAP
 int AOTCacheAccess::get_archived_object_permanent_index(oop obj) {
   return HeapShared::get_archived_object_permanent_index(obj);

--- a/src/hotspot/share/cds/aotCacheAccess.hpp
+++ b/src/hotspot/share/cds/aotCacheAccess.hpp
@@ -48,14 +48,31 @@ public:
   }
   static bool can_generate_aot_code(InstanceKlass* ik) NOT_CDS_RETURN_(false);
 
+  /*
+   * Used during an assembly run to compute the offset of the metadata object in the AOT Cache.
+   * The input argument is the "source" address of a metadata object (Method/Klass) loaded by the assembly JVM.
+   * Computation of the offset requires mapping the supplied metadata object to its "requested" address
+   * and subtracting that address from the requested base address.
+   * See ArchiveBuilder.hpp for definition of "source" and "requested" address.
+   */
   static uint delta_from_base_address(address addr);
 
+  /*
+   * Used during a production run to materialize a pointer to a Klass located in a loaded AOT Cache.
+   * The offset argument identifies a delta from the AOT Cache's currently mapped base address to the start of the Klass object.
+   * The offset is normally obtained by reading a value embedded in some other AOT-ed entry, like an AOT compiled code.
+   */
   static Klass* convert_offset_to_klass(uint offset_from_base_addr) {
     Metadata* metadata = (Metadata*)((address)SharedBaseAddress + offset_from_base_addr);
     assert(metadata->is_klass(), "sanity check");
     return (Klass*)metadata;
   }
 
+  /*
+   * Used during a production run to materialize a pointer to a Method located in a loaded AOT Cache.
+   * The offset argument identifies a delta from the AOT Cache's currently mapped base address to the start of the Method object.
+   * The offset is normally obtained by reading a value embedded in some other AOT-ed entry, like an AOT compiled code.
+   */
   static Method* convert_offset_to_method(uint offset_from_base_addr) {
     Metadata* metadata = (Metadata*)((address)SharedBaseAddress + offset_from_base_addr);
     assert(metadata->is_method(), "sanity check");

--- a/src/hotspot/share/cds/aotCacheAccess.hpp
+++ b/src/hotspot/share/cds/aotCacheAccess.hpp
@@ -49,7 +49,18 @@ public:
   static bool can_generate_aot_code(InstanceKlass* ik) NOT_CDS_RETURN_(false);
 
   static uint delta_from_base_address(address addr);
-  static Method* method_in_aot_code(Method* m) NOT_CDS_RETURN_(nullptr);
+
+  static Klass* convert_offset_to_klass(uint offset_from_base_addr) {
+    Metadata* metadata = (Metadata*)((address)SharedBaseAddress + offset_from_base_addr);
+    assert(metadata->is_klass(), "sanity check");
+    return (Klass*)metadata;
+  }
+
+  static Method* convert_offset_to_method(uint offset_from_base_addr) {
+    Metadata* metadata = (Metadata*)((address)SharedBaseAddress + offset_from_base_addr);
+    assert(metadata->is_method(), "sanity check");
+    return (Method*)metadata;
+  }
 
   static int get_archived_object_permanent_index(oop obj) NOT_CDS_JAVA_HEAP_RETURN_(-1);
   static oop get_archived_object(int permanent_index) NOT_CDS_JAVA_HEAP_RETURN_(nullptr);

--- a/src/hotspot/share/cds/aotCacheAccess.hpp
+++ b/src/hotspot/share/cds/aotCacheAccess.hpp
@@ -48,7 +48,7 @@ public:
   }
   static bool can_generate_aot_code(InstanceKlass* ik) NOT_CDS_RETURN_(false);
 
-  static uint delta_from_shared_address_base(address addr);
+  static uint delta_from_base_address(address addr);
   static Method* method_in_aot_code(Method* m) NOT_CDS_RETURN_(nullptr);
 
   static int get_archived_object_permanent_index(oop obj) NOT_CDS_JAVA_HEAP_RETURN_(-1);

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -1050,7 +1050,8 @@ void AOTCodeCache::invalidate_entry(AOTCodeEntry* entry) {
 
 void AOTCodeEntry::update_method_for_writing() {
   if (_method != nullptr) {
-    _method = AOTCacheAccess::method_in_aot_code(_method);
+    _method_offset = AOTCacheAccess::delta_from_base_address((address)_method);
+    _method = nullptr;
   }
 }
 
@@ -1900,16 +1901,6 @@ bool AOTCodeReader::compile_nmethod(ciEnv* env, ciMethod* target, AbstractCompil
 
   const char* name = addr(entry_position + aot_code_entry->name_offset());
 
-  log_info(aot, codecache, nmethod)("%d (L%d): Read nmethod '%s' from AOT Code Cache", compile_id(), comp_level(), name);
-#ifdef ASSERT
-  LogStreamHandle(Debug, aot, codecache, nmethod) log;
-  if (log.is_enabled()) {
-    FlagSetting fs(PrintRelocations, true);
-    archived_nm->print_on(&log);
-    archived_nm->decode2(&log);
-  }
-#endif
-
   if (VerifyCachedCode) {
     return false;
   }
@@ -1932,7 +1923,18 @@ bool AOTCodeReader::compile_nmethod(ciEnv* env, ciMethod* target, AbstractCompil
   bool success = task->is_success();
   if (success) {
     aot_code_entry->set_loaded();
+    log_info(aot, codecache, nmethod)("%d (L%d): Read nmethod '%s' from AOT Code Cache", compile_id(), comp_level(), name);
+#ifdef ASSERT
+    LogStreamHandle(Debug, aot, codecache, nmethod) log;
+    if (log.is_enabled()) {
+      nmethod* nm = target->get_Method()->code();
+      FlagSetting fs(PrintRelocations, true);
+      nm->print_on(&log);
+      nm->decode2(&log);
+    }
+#endif
   }
+
   return success;
 }
 
@@ -1993,6 +1995,8 @@ void AOTCodeCache::preload_startup_code(TRAPS) {
       if (entry->not_entrant()) {
         continue;
       }
+      Method* m = (Method*)((address)SharedBaseAddress + entry->method_offset());
+      entry->set_method(m);
       methodHandle mh(THREAD, entry->method());
       assert((mh.not_null() && MetaspaceShared::is_in_shared_metaspace((address)mh())), "sanity");
       if (skip_preload(mh)) {
@@ -2642,7 +2646,7 @@ bool AOTCodeCache::write_method(Method* method) {
     if (n != sizeof(int)) {
       return false;
     }
-    uint method_offset = AOTCacheAccess::delta_from_shared_address_base((address)method);
+    uint method_offset = AOTCacheAccess::delta_from_base_address((address)method);
     n = write_bytes(&method_offset, sizeof(uint));
     if (n != sizeof(uint)) {
       return false;
@@ -2882,7 +2886,7 @@ bool AOTCodeCache::write_klass(Klass* klass) {
     if (n != sizeof(int)) {
       return false;
     }
-    uint klass_offset = AOTCacheAccess::delta_from_shared_address_base((address)klass);
+    uint klass_offset = AOTCacheAccess::delta_from_base_address((address)klass);
     n = write_bytes(&klass_offset, sizeof(uint));
     if (n != sizeof(uint)) {
       return false;
@@ -3450,7 +3454,9 @@ void AOTCodeAddressTable::init_extrs() {
   SET_ADDRESS(_extrs, SharedRuntime::handle_wrong_method);
   SET_ADDRESS(_extrs, SharedRuntime::handle_wrong_method_abstract);
   SET_ADDRESS(_extrs, SharedRuntime::handle_wrong_method_ic_miss);
-
+#if defined(AARCH64)
+  SET_ADDRESS(_extrs, JavaThread::aarch64_get_thread_helper);
+#endif
 #ifdef COMPILER2
   SET_ADDRESS(_extrs, OptoRuntime::handle_exception_C);
 #endif
@@ -3460,6 +3466,7 @@ void AOTCodeAddressTable::init_extrs() {
 #endif
 
   SET_ADDRESS(_extrs, CompressedOops::base_addr());
+  SET_ADDRESS(_extrs, CompressedKlassPointers::base_addr());
 
 #if INCLUDE_G1GC
   SET_ADDRESS(_extrs, G1BarrierSetRuntime::write_ref_field_post_entry);

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -1995,7 +1995,7 @@ void AOTCodeCache::preload_startup_code(TRAPS) {
       if (entry->not_entrant()) {
         continue;
       }
-      Method* m = (Method*)((address)SharedBaseAddress + entry->method_offset());
+      Method* m = AOTCacheAccess::convert_offset_to_method(entry->method_offset());
       entry->set_method(m);
       methodHandle mh(THREAD, entry->method());
       assert((mh.not_null() && MetaspaceShared::is_in_shared_metaspace((address)mh())), "sanity");
@@ -2738,7 +2738,7 @@ Method* AOTCodeReader::read_method(const methodHandle& comp_method, bool shared)
     uint method_offset = *(uint*)addr(code_offset);
     code_offset += sizeof(uint);
     set_read_position(code_offset);
-    Method* m = (Method*)((address)SharedBaseAddress + method_offset);
+    Method* m = AOTCacheAccess::convert_offset_to_method(method_offset);
     if (!MetaspaceShared::is_in_shared_metaspace((address)m)) {
       // Something changed in CDS
       set_lookup_failed();
@@ -2969,7 +2969,7 @@ Klass* AOTCodeReader::read_klass(const methodHandle& comp_method, bool shared) {
     uint klass_offset = *(uint*)addr(code_offset);
     code_offset += sizeof(uint);
     set_read_position(code_offset);
-    Klass* k = (Klass*)((address)SharedBaseAddress + klass_offset);
+    Klass* k = AOTCacheAccess::convert_offset_to_klass(klass_offset);
     if (!MetaspaceShared::is_in_shared_metaspace((address)k)) {
       // Something changed in CDS
       set_lookup_failed();

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -3454,7 +3454,7 @@ void AOTCodeAddressTable::init_extrs() {
   SET_ADDRESS(_extrs, SharedRuntime::handle_wrong_method);
   SET_ADDRESS(_extrs, SharedRuntime::handle_wrong_method_abstract);
   SET_ADDRESS(_extrs, SharedRuntime::handle_wrong_method_ic_miss);
-#if defined(AARCH64)
+#if defined(AARCH64) && !defined(ZERO)
   SET_ADDRESS(_extrs, JavaThread::aarch64_get_thread_helper);
 #endif
 #ifdef COMPILER2

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -91,6 +91,7 @@ public:
 private:
   AOTCodeEntry* _next;
   Method*       _method;
+  uint   _method_offset;
   Kind   _kind;
   uint   _id;          // Adapter's id, vmIntrinsic::ID for stub or name's hash for nmethod
 
@@ -204,6 +205,7 @@ public:
   Method*   method()  const { return _method; }
   void set_method(Method* method) { _method = method; }
   void update_method_for_writing();
+  uint method_offset() const { return _method_offset; }
 
   Kind kind()         const { return _kind; }
   uint id()           const { return _id; }

--- a/src/hotspot/share/oops/compressedKlass.hpp
+++ b/src/hotspot/share/oops/compressedKlass.hpp
@@ -213,6 +213,7 @@ public:
 
   // Can only be used after initialization
   static address  base()             { check_init(_base); return  _base; }
+  static address  base_addr()        { return (address)&_base; }
   static int      shift()            { check_init(_shift); return  _shift; }
 
   static address  klass_range_start()  { return  _klass_range_start; }


### PR DESCRIPTION
This PR fixes a few things in the premain:
1. When storing metadata in aot code cache, `AOTCacheAccess::delta_from_shared_address_base` was incorrectly using `SharedBaseAddress` for computing the offset. It should be using `MetaspaceShared::requested_base_address` because we convert the input address to the requested address.
2. Fixing the above issue results in crash in C1 and C2 compiled code during production run because CompressedKlassPointer::base() value was hardcoded in the generated code. In mainline we emit relocation for `CompressedKlassPointer::base()`. This patch adds the same changes to premain. In addition to that, it also modifies `MacroAssembler::decode_and_move_klass_not_null` and `MacroAssembler::encode_and_move_klass_not_null` which are used by C2 compiled code.
3. Fixing 2 reveals another problem when preload the code. `AOTCodeEntry::_method` can be invalid if the AOT Cache gets mapped to different address than the "requested" address, and can result in crash when accessing `AOTCodeEntry::_method` during preload. Fix is to store the offset of the `AOTCodeEntry::_method` and use the offset on load to get the correct Method pointer.
4. While working on this issue, I realized archived `AOTCodeCache::compile_nmethod` is using archived nmethod to print the assembly. This results in crash as archived nmethod has some state cleaned up. Updated `AOTCodeCache::compile_nmethod` to fix this issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8357060](https://bugs.openjdk.org/browse/JDK-8357060): [premain] assert(left &gt;= right) failed: avoid underflow (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer) ⚠️ Review applies to [82567bab](https://git.openjdk.org/leyden/pull/68/files/82567bab6da5a006fbc7de44fca0264e4b433ae2)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - Committer) ⚠️ Review applies to [82567bab](https://git.openjdk.org/leyden/pull/68/files/82567bab6da5a006fbc7de44fca0264e4b433ae2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/leyden.git pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/68.diff">https://git.openjdk.org/leyden/pull/68.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/68#issuecomment-2887030494)
</details>
