### PR TITLE
8340474: [premain] Revert ArchiveRelocationMode back to 1

### DIFF
--- a/src/hotspot/share/cds/cds_globals.hpp
+++ b/src/hotspot/share/cds/cds_globals.hpp
@@ -91,8 +91,7 @@
   product(ccstr, ExtraSharedClassListFile, nullptr,                         \
           "Extra classlist for building the CDS archive file")              \
                                                                             \
-  /*FIXME - AOT code has direct pointers to metadata that's not relocated*/ \
-  product(int, ArchiveRelocationMode, 0, DIAGNOSTIC,                        \
+  product(int, ArchiveRelocationMode, 1, DIAGNOSTIC,                        \
            "(0) first map at preferred address, and if "                    \
            "unsuccessful, map at alternative address; "                     \
            "(1) always map at alternative address (default); "              \

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -233,8 +233,3 @@ runtime/cds/appcds/leyden/CacheOnlyClassesIn.java#aot 8350619 generic-all
 runtime/cds/appcds/leyden/CacheOnlyClassesIn.java#dynamic 8350619 generic-all
 runtime/cds/appcds/leyden/CacheOnlyClassesIn.java#leyden 8350619 generic-all
 runtime/cds/appcds/leyden/CacheOnlyClassesIn.java#static 8350619 generic-all
-
-runtime/cds/appcds/ArchiveRelocationTest.java 8340474 generic-all
-runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java 8340474 generic-all
-
-


### PR DESCRIPTION
Current Leyden premain repo has this change:

```
- product(int, ArchiveRelocationMode, 1, DIAGNOSTIC, \
+ /*FIXME - AOT code has direct pointers to metadata that's not relocated*/ \
+ product(int, ArchiveRelocationMode, 0, DIAGNOSTIC, \
```

We need to revert this to make sure we can compare the performance against mainline. 

Needs https://github.com/openjdk/leyden/pull/68 to work.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds` after https://github.com/openjdk/leyden/pull/68

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8340474](https://bugs.openjdk.org/browse/JDK-8340474): [premain] Revert ArchiveRelocationMode back to 1 (**Bug** - P4)


### Reviewers
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.org/leyden.git pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/69.diff">https://git.openjdk.org/leyden/pull/69.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/69#issuecomment-2890388547)
</details>
