### PR TITLE
Fix recent merge errors

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.hpp
+++ b/src/hotspot/share/compiler/compilationPolicy.hpp
@@ -85,6 +85,7 @@ public:
   T* pop(Monitor* lock, TRAPS) {
     MonitorLocker locker(THREAD, lock);
     while(is_empty_unlocked() && !CompileBroker::is_compilation_disabled_forever()) {
+      locker.notify_all(); // notify that queue is empty
       locker.wait();
     }
     T* value = pop_unlocked();


### PR DESCRIPTION
I skipped through current premain-vs-mainline webrev, and noticed a few merge errors.

`metaspaceShared.cpp` hunks are obvious duplications. I removed the lines that are actually different from mainline.

~`compilationPolicy.hpp` hunk is a leftover from AOT Profiling. I remember pointing this out to @veresov during mainline review, and we went into mainline without that extra `notify_all`. We should ditch it in premain too.~ Actually, I see test timeouts when that `notify_all` is removed. Filed [JDK-8358343](https://bugs.openjdk.org/browse/JDK-8358343) to figure it out. Yanked the hunk from this PR.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/72/head:pull/72` \
`$ git checkout pull/72`

Update a local copy of the PR: \
`$ git checkout pull/72` \
`$ git pull https://git.openjdk.org/leyden.git pull/72/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 72`

View PR using the GUI difftool: \
`$ git pr show -t 72`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/72.diff">https://git.openjdk.org/leyden/pull/72.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/72#issuecomment-2932340313)
</details>
