### PR TITLE
8358344: [leyden] Enable UseSecondarySupersTable support

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -3606,12 +3606,12 @@ void AOTCodeReader::read_dbg_strings(DbgStrings& dbg_strings) {
 //      ...
 //      [_c_str_base, _c_str_base + _c_str_max -1],
 #define _extrs_max 140
-#define _stubs_max 140
+#define _stubs_max 210
 #define _all_blobs_max 100
 #define _shared_blobs_max 25
 #define _C2_blobs_max 25
 #define _C1_blobs_max (_all_blobs_max - _shared_blobs_max - _C2_blobs_max)
-#define _all_max 380
+#define _all_max 450
 
 #define _extrs_base 0
 #define _stubs_base (_extrs_base + _extrs_max)
@@ -4032,6 +4032,11 @@ void AOTCodeAddressTable::init_stubs() {
 
   SET_ADDRESS(_stubs, StubRoutines::f2hf_adr());
   SET_ADDRESS(_stubs, StubRoutines::hf2f_adr());
+
+  for (int slot = 0; slot < Klass::SECONDARY_SUPERS_TABLE_SIZE; slot++) {
+    SET_ADDRESS(_stubs, StubRoutines::lookup_secondary_supers_table_stub(slot));
+  }
+  SET_ADDRESS(_stubs, StubRoutines::lookup_secondary_supers_table_slow_path_stub());
 
 #if defined(AMD64) && !defined(ZERO)
   SET_ADDRESS(_stubs, StubRoutines::x86::d2i_fixup());

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3822,7 +3822,6 @@ jint Arguments::apply_ergo() {
     warning("UseSecondarySupersTable is not supported");
     FLAG_SET_DEFAULT(UseSecondarySupersTable, false);
   }
-  UseSecondarySupersTable = false; // FIXME: Disabled for Leyden. Neet to fix AOTCodeAddressTable::id_for_address()
   if (!UseSecondarySupersTable) {
     FLAG_SET_DEFAULT(StressSecondarySupers, false);
     FLAG_SET_DEFAULT(VerifySecondarySupers, false);


### PR DESCRIPTION
`UseSecondarySupersTable` was disabled during the merge last month. It is time to enable it back. We need to record the table and slowpaths for `id_for_address` to work. `SECONDARY_SUPERS_TABLE_SIZE` is realistically at most `64` (matches machine bitness), so I added `+70` to all relevant sizing constants.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds` works (used to fail with just `UseSecondarySupersTable = false` removed)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8358344](https://bugs.openjdk.org/browse/JDK-8358344): [leyden] Enable UseSecondarySupersTable support (**Enhancement** - P4)


### Reviewers
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/73/head:pull/73` \
`$ git checkout pull/73`

Update a local copy of the PR: \
`$ git checkout pull/73` \
`$ git pull https://git.openjdk.org/leyden.git pull/73/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 73`

View PR using the GUI difftool: \
`$ git pr show -t 73`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/73.diff">https://git.openjdk.org/leyden/pull/73.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/73#issuecomment-2934146075)
</details>
