### PR TITLE
8358343: [leyden] Drop notify_all in CompilationPolicyUtils::Queue::pop

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -185,7 +185,10 @@ void CompilationPolicy::replay_training_at_init_impl(InstanceKlass* klass, TRAPS
 void CompilationPolicy::flush_replay_training_at_init(TRAPS) {
    MonitorLocker locker(THREAD, TrainingReplayQueue_lock);
    while (!_training_replay_queue.is_empty_unlocked()) {
-     locker.wait(); // let the replay training thread drain the queue
+     // Let the replay training thread drain the queue.
+     // We need to re-check the queue periodically, since draining
+     // threads do not notify us about queue going empty.
+     locker.wait(100);
    }
 }
 

--- a/src/hotspot/share/compiler/compilationPolicy.hpp
+++ b/src/hotspot/share/compiler/compilationPolicy.hpp
@@ -85,7 +85,6 @@ public:
   T* pop(Monitor* lock, TRAPS) {
     MonitorLocker locker(THREAD, lock);
     while(is_empty_unlocked() && !CompileBroker::is_compilation_disabled_forever()) {
-      locker.notify_all(); // notify that queue is empty
       locker.wait();
     }
     T* value = pop_unlocked();


### PR DESCRIPTION
Found this when reading premain-vs-mainline webrev. Mainline does not have `notify_all` in this method:
https://github.com/openjdk/jdk/blob/c382da579884c28f2765b2c6ba68c0ad4fdcb2ce/src/hotspot/share/compiler/compilationPolicy.hpp#L85-L92

But if you remove `notify_all()` in `premain`, then tests start to deadlock, see bug for a sample. The culprit is `CompilationPolicy::flush_replay_training_at_init`, which is only present in premain. I fixed it by using timed waits, which obviates the need for extra notifications. We only enter this method with `-XX:+AOTVerifyTrainingData`, so we don't care much about its performance. This is IMO better than doing a questionable `notify_all` followed by `wait` in load-bearing code.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds` (5x, no timeouts yet; still running more iterations)