### PR TITLE
8358693: [leyden] Bootstrapping circularity leads to never starting preload threads

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -230,7 +230,12 @@ bool AOTCodeCache::is_C3_on() {
 }
 
 bool AOTCodeCache::is_code_load_thread_on() {
-  return UseCodeLoadThread && is_using_code();
+  // We cannot trust AOTCodeCache status here, due to bootstrapping circularity.
+  // Compilation policy init runs before AOT cache is fully initialized, so the
+  // normal AOT cache status check would always fail.
+  // See: https://bugs.openjdk.org/browse/JDK-8358690
+  // return UseCodeLoadThread && is_using_code();
+  return UseCodeLoadThread && AOTCodeCaching && CDSConfig::is_using_archive();
 }
 
 bool AOTCodeCache::allow_const_field(ciConstant& value) {

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -663,13 +663,7 @@ void CompilationPolicy::initialize() {
       set_c2_count(count);
       count *= 2; // satisfy the assert below
     }
-    // We cannot trust AOTCodeCache status here, due to bootstrapping circularity.
-    // Compilation policy init runs before AOT cache is fully initialized, so the
-    // normal AOT cache status check would always fail.
-    // See: https://bugs.openjdk.org/browse/JDK-8358690
-    //
-    // if (AOTCodeCache::is_code_load_thread_on()) {
-    if (AOTCodeCaching && UseCodeLoadThread && CDSConfig::is_using_archive()) {
+    if (AOTCodeCache::is_code_load_thread_on()) {
       set_ac_count((c1_only || c2_only) ? 1 : 2); // At minimum we need 2 threads to load C1 and C2 cached code in parallel
     }
     assert(count == c1_count() + c2_count(), "inconsistent compiler thread count");

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -663,7 +663,13 @@ void CompilationPolicy::initialize() {
       set_c2_count(count);
       count *= 2; // satisfy the assert below
     }
-    if (AOTCodeCache::is_code_load_thread_on()) {
+    // We cannot trust AOTCodeCache status here, due to bootstrapping circularity.
+    // Compilation policy init runs before AOT cache is fully initialized, so the
+    // normal AOT cache status check would always fail.
+    // See: https://bugs.openjdk.org/browse/JDK-8358690
+    //
+    // if (AOTCodeCache::is_code_load_thread_on()) {
+    if (AOTCodeCaching && UseCodeLoadThread && CDSConfig::is_using_archive()) {
       set_ac_count((c1_only || c2_only) ? 1 : 2); // At minimum we need 2 threads to load C1 and C2 cached code in parallel
     }
     assert(count == c1_count() + c2_count(), "inconsistent compiler thread count");


### PR DESCRIPTION
This relates to [JDK-8358690](https://bugs.openjdk.org/browse/JDK-8358690), but we want to make sure Leyden preload runs until we have a fuller fix.

Additional testing:
 - [x] Ad-hoc perf tests
 - [x] Linux x86_64 server fastdebug, `runtime/cds`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8358693](https://bugs.openjdk.org/browse/JDK-8358693): [leyden] Bootstrapping circularity leads to never starting preload threads (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/75/head:pull/75` \
`$ git checkout pull/75`

Update a local copy of the PR: \
`$ git checkout pull/75` \
`$ git pull https://git.openjdk.org/leyden.git pull/75/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 75`

View PR using the GUI difftool: \
`$ git pr show -t 75`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/75.diff">https://git.openjdk.org/leyden/pull/75.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/75#issuecomment-2944091007)
</details>
