### PR TITLE
8358707: [leyden] Flip AOTCompileEagerly back on

### DIFF
--- a/src/hotspot/share/cds/cds_globals.hpp
+++ b/src/hotspot/share/cds/cds_globals.hpp
@@ -144,11 +144,11 @@
   product(bool, AOTPrintTrainingInfo, false, DIAGNOSTIC,                    \
           "Print additional information about training")                    \
                                                                             \
-  product(bool, AOTCompileEagerly, true, DIAGNOSTIC,                        \
-          "Compile methods as soon as possible")                            \
-                                                                            \
   product(bool, AOTVerifyTrainingData, trueInDebug, DIAGNOSTIC,             \
           "Verify archived training data")                                  \
+                                                                            \
+  product(bool, AOTCompileEagerly, true, DIAGNOSTIC,                        \
+          "Compile methods as soon as possible")                            \
                                                                             \
   product(bool, AOTRecordOptCompilationOrder, false,                        \
           "Record c2/jvmci nmethod temperature to guide compilation order.")\

--- a/src/hotspot/share/cds/cds_globals.hpp
+++ b/src/hotspot/share/cds/cds_globals.hpp
@@ -144,7 +144,7 @@
   product(bool, AOTPrintTrainingInfo, false, DIAGNOSTIC,                    \
           "Print additional information about training")                    \
                                                                             \
-  product(bool, AOTCompileEagerly, false, DIAGNOSTIC,                       \
+  product(bool, AOTCompileEagerly, true, DIAGNOSTIC,                        \
           "Compile methods as soon as possible")                            \
                                                                             \
   product(bool, AOTVerifyTrainingData, trueInDebug, DIAGNOSTIC,             \


### PR DESCRIPTION
When upstreaming [JDK-8355003](https://bugs.openjdk.org/browse/JDK-8355003), we introduced `AOTCompileEagerly` flag and defaulted it to disabled, to gate the training data replay. Without AOT code, this causes extra compilations, this is why it is false by default in mainline. But for Leyden, it should remain enabled, since this is the path that loads AOT compiled C2 code. We got this flag as `false` during the mainline->Leyden merge/ports.

Additional testing:
 - [x] Ad-hoc benchmarks
 - [x] Linux x86_64 server fastdebug, `runtime/cds`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8358707](https://bugs.openjdk.org/browse/JDK-8358707): [leyden] Flip AOTCompileEagerly back on (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.org/leyden.git pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/76.diff">https://git.openjdk.org/leyden/pull/76.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/76#issuecomment-2944974419)
</details>
