### PR TITLE
8358546: [premain] AOT code generation should support UseCompactObjectHeaders

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5132,7 +5132,8 @@ void MacroAssembler::cmp_klass(Register obj, Register klass, Register tmp) {
     if (CompressedKlassPointers::base() == nullptr) {
       cmp(klass, tmp, LSL, CompressedKlassPointers::shift());
       return;
-    } else if (((uint64_t)CompressedKlassPointers::base() & 0xffffffff) == 0
+    } else if (!AOTCodeCache::is_on_for_dump() &&
+               ((uint64_t)CompressedKlassPointers::base() & 0xffffffff) == 0
                && CompressedKlassPointers::shift() == 0) {
       // Only the bottom 32 bits matter
       cmpw(klass, tmp);
@@ -5391,7 +5392,7 @@ void MacroAssembler::encode_klass_not_null_for_aot(Register dst, Register src) {
 }
 
 void MacroAssembler::encode_klass_not_null(Register dst, Register src) {
-  if (AOTCodeCache::is_on_for_dump()) {
+  if (CompressedKlassPointers::base() != nullptr && AOTCodeCache::is_on_for_dump()) {
     encode_klass_not_null_for_aot(dst, src);
     return;
   }
@@ -5457,7 +5458,7 @@ void MacroAssembler::decode_klass_not_null_for_aot(Register dst, Register src) {
 void  MacroAssembler::decode_klass_not_null(Register dst, Register src) {
   assert (UseCompressedClassPointers, "should only be used for compressed headers");
 
-  if (AOTCodeCache::is_on_for_dump()) {
+  if (CompressedKlassPointers::base() != nullptr && AOTCodeCache::is_on_for_dump()) {
     decode_klass_not_null_for_aot(dst, src);
     return;
   }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5503,9 +5503,14 @@ void  MacroAssembler::decode_and_move_klass_not_null(Register dst, Register src)
       }
     } else {
       if (CompressedKlassPointers::base() != nullptr) {
-        const intptr_t base_right_shifted =
-            (intptr_t)CompressedKlassPointers::base() >> CompressedKlassPointers::shift();
-        movptr(dst, base_right_shifted);
+        if (AOTCodeCache::is_on_for_dump()) {
+          movptr(dst, ExternalAddress(CompressedKlassPointers::base_addr()));
+          shrq(dst, CompressedKlassPointers::shift());
+        } else {
+          const intptr_t base_right_shifted =
+               (intptr_t)CompressedKlassPointers::base() >> CompressedKlassPointers::shift();
+          movptr(dst, base_right_shifted);
+        }
       } else {
         xorq(dst, dst);
       }

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -770,13 +770,13 @@ bool AOTCodeCache::Config::verify() const {
 
   if ((_compressedKlassBase == nullptr || CompressedKlassPointers::base() == nullptr) && (_compressedKlassBase != CompressedKlassPointers::base())) {
     log_debug(aot, codecache, init)("AOT Code Cache disabled: incompatible CompressedKlassPointers::base(): %p vs current %p", _compressedKlassBase, CompressedKlassPointers::base());
-    AOTStubCaching = false;
+    return false;
   }
 
   // This should be the last check as it only disables AOTStubCaching
   if ((_compressedOopBase == nullptr || CompressedOops::base() == nullptr) && (_compressedOopBase != CompressedOops::base())) {
     log_debug(aot, codecache, init)("AOTStubCaching is disabled: incompatible CompressedOops::base(): %p vs current %p", _compressedOopBase, CompressedOops::base());
-    AOTStubCaching = false;
+    return false;
   }
 
   return true;

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -700,6 +700,7 @@ void AOTCodeCache::Config::record(bool use_meta_ptrs) {
   _compressedOopShift    = CompressedOops::shift();
   _compressedOopBase     = CompressedOops::base();
   _compressedKlassShift  = CompressedKlassPointers::shift();
+  _compressedKlassBase   = CompressedKlassPointers::base();
   _contendedPaddingWidth = ContendedPaddingWidth;
   _objectAlignment       = ObjectAlignmentInBytes;
   _gc                    = (uint)Universe::heap()->kind();
@@ -765,6 +766,11 @@ bool AOTCodeCache::Config::verify() const {
   if (_objectAlignment != (uint)ObjectAlignmentInBytes) {
     log_debug(aot, codecache, init)("AOT Code Cache disabled: it was created with ObjectAlignmentInBytes = %d vs current %d", _objectAlignment, ObjectAlignmentInBytes);
     return false;
+  }
+
+  if ((_compressedKlassBase == nullptr || CompressedKlassPointers::base() == nullptr) && (_compressedKlassBase != CompressedKlassPointers::base())) {
+    log_debug(aot, codecache, init)("AOT Code Cache disabled: incompatible CompressedKlassPointers::base(): %p vs current %p", _compressedKlassBase, CompressedKlassPointers::base());
+    AOTStubCaching = false;
   }
 
   // This should be the last check as it only disables AOTStubCaching

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -338,6 +338,7 @@ class AOTCodeCache : public CHeapObj<mtCode> {
 protected:
   class Config {
     address _compressedOopBase;
+    address _compressedKlassBase;
     uint _compressedOopShift;
     uint _compressedKlassShift;
     uint _contendedPaddingWidth;


### PR DESCRIPTION
COH testing was added to tier3 which we use in premain branch testing. And we noticed that `runtime/cds/appcds/aotCode/` tests crashes during "production" run when UseCompactObjectHeaders is on.

There were five issues when AOT code is generated with COH:
 - missing CompressedKlassPointers::base() relocation on x86 in `MacroAssembler::decode_and_move_klass_not_null()`
 - missing CKP:base() relocation on aarch64 in `MacroAssembler::cmp_klass()` because `decode_klass_not_null_for_aot()` was not called
 - On aarch64 full AOT encoding/decoding code for compressed klass pointers was generated even when base is NULL. Do special AOT code only when base is not NULL, similar to code on x64.
 - Record CKP::basse in AOT code cache configuration and check it on load similar to what we do for compressed oops base.
 - Prototype header value for new allocated object is embedded into C2 generated code as constant. But with COH the prototype also contains encoded class. This class encoding (and prototype header) could be change when CDS store this information in archive. We need to load it in code.

Tested tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8358546](https://bugs.openjdk.org/browse/JDK-8358546): [premain] AOT code generation should support UseCompactObjectHeaders (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.org/leyden.git pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/78.diff">https://git.openjdk.org/leyden/pull/78.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/78#issuecomment-2948104540)
</details>
