### PR TITLE
8359107: [leyden] Pick up JDK-8357481, JDK-8357473 and rework precompilation waits

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -255,7 +255,7 @@ CompileTaskWrapper::~CompileTaskWrapper() {
 #if INCLUDE_JVMCI
       if (comp->is_jvmci()) {
         if (!task->has_waiter()) {
-          // The waiting thread timed out and thus did not free the task.
+          // The waiting thread timed out and thus did not delete the task.
           free_task = true;
         }
         task->set_blocking_jvmci_compile_state(nullptr);
@@ -268,15 +268,15 @@ CompileTaskWrapper::~CompileTaskWrapper() {
       }
     }
     if (free_task) {
-      // The task can only be freed once the task lock is released.
-      CompileTask::free(task);
+      // The task can only be deleted once the task lock is released.
+      delete task;
     }
   } else {
     task->mark_complete();
 
-    // By convention, the compiling thread is responsible for
-    // recycling a non-blocking CompileTask.
-    CompileTask::free(task);
+    // By convention, the compiling thread is responsible for deleting
+    // a non-blocking CompileTask.
+    delete task;
   }
 }
 
@@ -429,12 +429,12 @@ void CompileQueue::transfer_pending() {
 }
 
 /**
- * Empties compilation queue by putting all compilation tasks onto
- * a freelist. Furthermore, the method wakes up all threads that are
- * waiting on a compilation task to finish. This can happen if background
+ * Empties compilation queue by deleting all compilation tasks.
+ * Furthermore, the method wakes up all threads that are waiting
+ * on a compilation task to finish. This can happen if background
  * compilation is disabled.
  */
-void CompileQueue::free_all() {
+void CompileQueue::delete_all() {
   MutexLocker mu(_lock);
   transfer_pending();
 
@@ -456,11 +456,10 @@ void CompileQueue::free_all() {
       }
     }
     if (!found_waiter) {
-      // If no one was waiting for this task, we need to free it ourselves. In this case, the task
-      // is also certainly unlocked, because, again, there is no waiter.
-      // Otherwise, by convention, it's the waiters responsibility to free the task.
-      // Put the task back on the freelist.
-      CompileTask::free(current);
+      // If no one was waiting for this task, we need to delete it ourselves.
+      // In this case, the task is also certainly unlocked, because, again, there is no waiter.
+      // Otherwise, by convention, it's the waiters responsibility to delete the task.
+      delete current;
     }
   }
   _first = nullptr;
@@ -1892,8 +1891,7 @@ CompileTask* CompileBroker::create_compile_task(CompileQueue*       queue,
                                                 CompileTask::CompileReason compile_reason,
                                                 bool                requires_online_compilation,
                                                 bool                blocking) {
-  CompileTask* new_task = CompileTask::allocate();
-  new_task->initialize(compile_id, method, osr_bci, comp_level,
+  CompileTask* new_task = new CompileTask(compile_id, method, osr_bci, comp_level,
                        hot_count, aot_code_entry, compile_reason, queue,
                        requires_online_compilation, blocking);
   return new_task;
@@ -1915,7 +1913,7 @@ static const int JVMCI_COMPILATION_PROGRESS_WAIT_ATTEMPTS = 10;
  * JVMCI_COMPILATION_PROGRESS_WAIT_TIMESLICE *
  * JVMCI_COMPILATION_PROGRESS_WAIT_ATTEMPTS.
  *
- * @return true if this thread needs to free/recycle the task
+ * @return true if this thread needs to delete the task
  */
 bool CompileBroker::wait_for_jvmci_completion(JVMCICompiler* jvmci, CompileTask* task, JavaThread* thread) {
   assert(UseJVMCICompiler, "sanity");
@@ -1998,19 +1996,19 @@ void CompileBroker::wait_for_completion(CompileTask* task) {
 
   if (free_task) {
     if (is_compilation_disabled_forever()) {
-      CompileTask::free(task);
+      delete task;
       return;
     }
 
     // It is harmless to check this status without the lock, because
-    // completion is a stable property (until the task object is recycled).
+    // completion is a stable property (until the task object is deleted).
     assert(task->is_complete(), "Compilation should have completed");
 
-    // By convention, the waiter is responsible for recycling a
+    // By convention, the waiter is responsible for deleting a
     // blocking CompileTask. Since there is only one waiter ever
     // waiting on a CompileTask, we know that no one else will
-    // be using this CompileTask; we can free it.
-    CompileTask::free(task);
+    // be using this CompileTask; we can delete it.
+    delete task;
   }
 }
 
@@ -2092,15 +2090,15 @@ void CompileBroker::shutdown_compiler_runtime(AbstractCompiler* comp, CompilerTh
 
     // Delete all queued compilation tasks to make compiler threads exit faster.
     if (_c1_compile_queue != nullptr) {
-      _c1_compile_queue->free_all();
+      _c1_compile_queue->delete_all();
     }
 
     if (_c2_compile_queue != nullptr) {
-      _c2_compile_queue->free_all();
+      _c2_compile_queue->delete_all();
     }
 
     if (_c3_compile_queue != nullptr) {
-      _c3_compile_queue->free_all();
+      _c3_compile_queue->delete_all();
     }
 
     // Set flags so that we continue execution with using interpreter only.

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -250,7 +250,7 @@ CompileTaskWrapper::~CompileTaskWrapper() {
   if (task->is_blocking()) {
     bool free_task = false;
     {
-      MutexLocker notifier(thread, task->lock());
+      MutexLocker notifier(thread, CompileTaskWait_lock);
       task->mark_complete();
 #if INCLUDE_JVMCI
       if (comp->is_jvmci()) {
@@ -264,7 +264,7 @@ CompileTaskWrapper::~CompileTaskWrapper() {
       if (!free_task) {
         // Notify the waiting thread that the compilation has completed
         // so that it can free the task.
-        task->lock()->notify_all();
+        CompileTaskWait_lock->notify_all();
       }
     }
     if (free_task) {
@@ -446,12 +446,12 @@ void CompileQueue::free_all() {
     next = current->next();
     bool found_waiter = false;
     {
-      MutexLocker ct_lock(current->lock());
+      MutexLocker ct_lock(CompileTaskWait_lock);
       assert(current->waiting_for_completion_count() <= 1, "more than one thread are waiting for task");
       if (current->waiting_for_completion_count() > 0) {
         // If another thread waits for this task, we must wake them up
         // so they will stop waiting and free the task.
-        current->lock()->notify();
+        CompileTaskWait_lock->notify_all();
         found_waiter = true;
       }
     }
@@ -1919,7 +1919,7 @@ static const int JVMCI_COMPILATION_PROGRESS_WAIT_ATTEMPTS = 10;
  */
 bool CompileBroker::wait_for_jvmci_completion(JVMCICompiler* jvmci, CompileTask* task, JavaThread* thread) {
   assert(UseJVMCICompiler, "sanity");
-  MonitorLocker ml(thread, task->lock());
+  MonitorLocker ml(thread, CompileTaskWait_lock);
   int progress_wait_attempts = 0;
   jint thread_jvmci_compilation_ticks = 0;
   jint global_jvmci_compilation_ticks = jvmci->global_compilation_ticks();
@@ -1987,7 +1987,7 @@ void CompileBroker::wait_for_completion(CompileTask* task) {
   } else
 #endif
   {
-    MonitorLocker ml(thread, task->lock());
+    MonitorLocker ml(thread, CompileTaskWait_lock);
     free_task = true;
     task->inc_waiting_for_completion();
     while (!task->is_complete() && !is_compilation_disabled_forever()) {

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -152,7 +152,7 @@ class CompileQueue : public CHeapObj<mtCompiler> {
 
   // Redefine Classes support
   void mark_on_stack();
-  void free_all();
+  void delete_all();
   void print_tty();
   void print(outputStream* st = tty);
 

--- a/src/hotspot/share/compiler/compileLog.cpp
+++ b/src/hotspot/share/compiler/compileLog.cpp
@@ -49,7 +49,7 @@ CompileLog::CompileLog(const char* file_name, FILE* fp, intx thread_id)
    strcpy((char*)_file, file_name);
 
   // link into the global list
-  { MonitorLocker locker(CompileTaskAlloc_lock);
+  { MutexLocker locker(CompileTaskAlloc_lock);
     _next = _first;
     _first = this;
   }

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -36,83 +36,18 @@
 #include "runtime/jniHandles.hpp"
 #include "runtime/mutexLocker.hpp"
 
-CompileTask*  CompileTask::_task_free_list = nullptr;
 int CompileTask::_active_tasks = 0;
 
-/**
- * Allocate a CompileTask, from the free list if possible.
- */
-CompileTask* CompileTask::allocate() {
-  CompileTask* task = nullptr;
-
-  {
-    MutexLocker locker(CompileTaskAlloc_lock);
-    if (_task_free_list != nullptr) {
-      task = _task_free_list;
-      _task_free_list = task->next();
-      task->set_next(nullptr);
-    } else {
-      task = new CompileTask();
-      task->set_next(nullptr);
-      task->set_is_free(true);
-    }
-    assert(task->is_free(), "Task must be free.");
-    task->set_is_free(false);
-  }
-
-  // Once JDK-8357473 is here, move this to CompileTask::CompileTask
-  Atomic::add(&_active_tasks, 1);
-  return task;
-}
-
-/**
-* Add a task to the free list.
-*/
-void CompileTask::free(CompileTask* task) {
-  {
-    MutexLocker locker(CompileTaskAlloc_lock);
-    if (!task->is_free()) {
-      if ((task->_method_holder != nullptr && JNIHandles::is_weak_global_handle(task->_method_holder))) {
-        JNIHandles::destroy_weak_global(task->_method_holder);
-      } else {
-        JNIHandles::destroy_global(task->_method_holder);
-      }
-      if (task->_failure_reason_on_C_heap && task->_failure_reason != nullptr) {
-        os::free((void*) task->_failure_reason);
-      }
-      task->_failure_reason = nullptr;
-      task->_failure_reason_on_C_heap = false;
-
-      task->set_is_free(true);
-      task->set_next(_task_free_list);
-      _task_free_list = task;
-    }
-  }
-
-  // Once JDK-8357473 is here, move this to CompileTask::~CompileTask
-  if (Atomic::sub(&_active_tasks, 1) == 0) {
-    MonitorLocker wait_ml(CompileTaskWait_lock);
-    wait_ml.notify_all();
-  }
-}
-
-void CompileTask::wait_for_no_active_tasks() {
-  MonitorLocker locker(CompileTaskWait_lock);
-  while (Atomic::load(&_active_tasks) > 0) {
-    locker.wait();
-  }
-}
-
-void CompileTask::initialize(int compile_id,
-                             const methodHandle& method,
-                             int osr_bci,
-                             int comp_level,
-                             int hot_count,
-                             AOTCodeEntry* aot_code_entry,
-                             CompileTask::CompileReason compile_reason,
-                             CompileQueue* compile_queue,
-                             bool requires_online_compilation,
-                             bool is_blocking) {
+CompileTask::CompileTask(int compile_id,
+                         const methodHandle& method,
+                         int osr_bci,
+                         int comp_level,
+                         int hot_count,
+                         AOTCodeEntry* aot_code_entry,
+                         CompileTask::CompileReason compile_reason,
+                         CompileQueue* compile_queue,
+                         bool requires_online_compilation,
+                         bool is_blocking) {
   Thread* thread = Thread::current();
   _compile_id = compile_id;
   _method = method();
@@ -165,6 +100,33 @@ void CompileTask::initialize(int compile_id,
   _arena_bytes = 0;
 
   _next = nullptr;
+
+  Atomic::add(&_active_tasks, 1);
+}
+
+CompileTask::~CompileTask() {
+  if ((_method_holder != nullptr && JNIHandles::is_weak_global_handle(_method_holder))) {
+    JNIHandles::destroy_weak_global(_method_holder);
+  } else {
+    JNIHandles::destroy_global(_method_holder);
+  }
+  if (_failure_reason_on_C_heap && _failure_reason != nullptr) {
+    os::free((void*) _failure_reason);
+    _failure_reason = nullptr;
+    _failure_reason_on_C_heap = false;
+  }
+
+  if (Atomic::sub(&_active_tasks, 1) == 0) {
+    MonitorLocker wait_ml(CompileTaskWait_lock);
+    wait_ml.notify_all();
+  }
+}
+
+void CompileTask::wait_for_no_active_tasks() {
+  MonitorLocker locker(CompileTaskWait_lock);
+  while (Atomic::load(&_active_tasks) > 0) {
+    locker.wait();
+  }
 }
 
 /**

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -29,6 +29,7 @@
 #include "code/nmethod.hpp"
 #include "compiler/compileLog.hpp"
 #include "memory/allocation.hpp"
+#include "runtime/mutexLocker.hpp"
 #include "utilities/xmlstream.hpp"
 
 class CompileQueue;
@@ -96,7 +97,6 @@ class CompileTask : public CHeapObj<mtCompiler> {
  private:
   static CompileTask*  _task_free_list;
   static int           _active_tasks;
-  Monitor*             _lock;
   int                  _compile_id;
   Method*              _method;
   jobject              _method_holder;
@@ -139,11 +139,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
   size_t               _arena_bytes;  // peak size of temporary memory during compilation (e.g. node arenas)
 
  public:
-  CompileTask() : _failure_reason(nullptr), _failure_reason_on_C_heap(false) {
-    // May hold MethodCompileQueue_lock
-    _lock = new Monitor(Mutex::safepoint-1, "CompileTask_lock");
-  }
-
+  CompileTask() : _failure_reason(nullptr), _failure_reason_on_C_heap(false) {}
   void initialize(int compile_id, const methodHandle& method, int osr_bci, int comp_level,
                   int hot_count, AOTCodeEntry* aot_code_entry,
                   CompileTask::CompileReason compile_reason,
@@ -208,22 +204,21 @@ class CompileTask : public CHeapObj<mtCompiler> {
     return reason_is_precompiled(compile_reason());
   }
 
-  Monitor*     lock() const                      { return _lock; }
   CompileQueue* compile_queue() const            { return _compile_queue; }
 
   // See how many threads are waiting for this task. Must have lock to read this.
   int waiting_for_completion_count() {
-    assert(_lock->owned_by_self(), "must have lock to use waiting_for_completion_count()");
+    assert(CompileTaskWait_lock->owned_by_self(), "must have lock to use waiting_for_completion_count()");
     return _waiting_count;
   }
   // Indicates that a thread is waiting for this task to complete. Must have lock to use this.
   void inc_waiting_for_completion() {
-    assert(_lock->owned_by_self(), "must have lock to use inc_waiting_for_completion()");
+    assert(CompileTaskWait_lock->owned_by_self(), "must have lock to use inc_waiting_for_completion()");
     _waiting_count++;
   }
   // Indicates that a thread stopped waiting for this task to complete. Must have lock to use this.
   void dec_waiting_for_completion() {
-    assert(_lock->owned_by_self(), "must have lock to use dec_waiting_for_completion()");
+    assert(CompileTaskWait_lock->owned_by_self(), "must have lock to use dec_waiting_for_completion()");
     assert(_waiting_count > 0, "waiting count is not positive");
     _waiting_count--;
   }

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -95,7 +95,6 @@ class CompileTask : public CHeapObj<mtCompiler> {
   }
 
  private:
-  static CompileTask*  _task_free_list;
   static int           _active_tasks;
   int                  _compile_id;
   Method*              _method;
@@ -121,7 +120,6 @@ class CompileTask : public CHeapObj<mtCompiler> {
   int                  _num_inlined_bytecodes;
   CompileTask*         _next;
   CompileTask*         _prev;
-  bool                 _is_free;
   // Fields used for logging why the compilation was initiated:
   jlong                _time_created; // time when task was created
   jlong                _time_queued;  // time when task was enqueued
@@ -139,15 +137,13 @@ class CompileTask : public CHeapObj<mtCompiler> {
   size_t               _arena_bytes;  // peak size of temporary memory during compilation (e.g. node arenas)
 
  public:
-  CompileTask() : _failure_reason(nullptr), _failure_reason_on_C_heap(false) {}
-  void initialize(int compile_id, const methodHandle& method, int osr_bci, int comp_level,
+  CompileTask(int compile_id, const methodHandle& method, int osr_bci, int comp_level,
                   int hot_count, AOTCodeEntry* aot_code_entry,
                   CompileTask::CompileReason compile_reason,
                   CompileQueue* compile_queue,
                   bool requires_online_compilation, bool is_blocking);
+  ~CompileTask();
 
-  static CompileTask* allocate();
-  static void         free(CompileTask* task);
   static void         wait_for_no_active_tasks();
 
   int          compile_id() const                   { return _compile_id; }
@@ -247,8 +243,6 @@ class CompileTask : public CHeapObj<mtCompiler> {
   void         set_next(CompileTask* next)       { _next = next; }
   CompileTask* prev() const                      { return _prev; }
   void         set_prev(CompileTask* prev)       { _prev = prev; }
-  bool         is_free() const                   { return _is_free; }
-  void         set_is_free(bool val)             { _is_free = val; }
   bool         is_unloaded() const;
 
   CompileTrainingData* training_data() const      { return _training_data; }

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -82,6 +82,7 @@ Mutex*   MarkStackChunkList_lock      = nullptr;
 Mutex*   MonitoringSupport_lock       = nullptr;
 Monitor* ConcurrentGCBreakpoints_lock = nullptr;
 Mutex*   Compile_lock                 = nullptr;
+Monitor* CompileTaskWait_lock         = nullptr;
 Monitor* MethodCompileQueue_lock      = nullptr;
 Monitor* MethodCompileQueueC1_lock    = nullptr;
 Monitor* MethodCompileQueueC2_lock    = nullptr;
@@ -90,7 +91,7 @@ Monitor* MethodCompileQueueSC1_lock   = nullptr;
 Monitor* MethodCompileQueueSC2_lock   = nullptr;
 Monitor* CompileThread_lock           = nullptr;
 Monitor* Compilation_lock             = nullptr;
-Monitor* CompileTaskAlloc_lock        = nullptr;
+Mutex*   CompileTaskAlloc_lock        = nullptr;
 Mutex*   CompileStatistics_lock       = nullptr;
 Mutex*   DirectivesStack_lock         = nullptr;
 Monitor* Terminator_lock              = nullptr;
@@ -363,7 +364,9 @@ void mutex_init() {
     MUTEX_DEFL(G1RareEvent_lock             , PaddedMutex  , Threads_lock, true);
   }
 
-  MUTEX_DEFL(CompileTaskAlloc_lock          , PaddedMonitor,  MethodCompileQueue_lock);
+  MUTEX_DEFL(CompileTaskAlloc_lock          , PaddedMutex,   MethodCompileQueue_lock);
+  MUTEX_DEFL(CompileTaskWait_lock           , PaddedMonitor, MethodCompileQueue_lock);
+
 #if INCLUDE_PARALLELGC
   if (UseParallelGC) {
     MUTEX_DEFL(PSOldGenExpand_lock          , PaddedMutex  , Heap_lock, true);

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -92,7 +92,8 @@ extern Monitor* CompileThread_lock;              // a lock held by compile threa
 extern Monitor* Compilation_lock;                // a lock used to pause compilation
 extern Mutex*   TrainingData_lock;               // a lock used when accessing training records
 extern Monitor* TrainingReplayQueue_lock;        // a lock held when class are added/removed to the training replay queue
-extern Monitor* CompileTaskAlloc_lock;           // a lock held when CompileTasks are allocated
+extern Mutex*   CompileTaskAlloc_lock;           // a lock held when CompileTasks are allocated
+extern Monitor* CompileTaskWait_lock;            // a lock held when CompileTasks are waited/notified
 extern Mutex*   CompileStatistics_lock;          // a lock held when updating compilation statistics
 extern Mutex*   DirectivesStack_lock;            // a lock held when mutating the dirstack and ref counting directives
 extern Monitor* Terminator_lock;                 // a lock used to guard termination of the vm


### PR DESCRIPTION
[JDK-8357481](https://bugs.openjdk.org/browse/JDK-8357481) will come in from mainline and bring conflicting changes to `CompileTask`. Additionally, our precompilation ([JDK-8352042](https://bugs.openjdk.org/browse/JDK-8352042)) depends on the code that would go away with [JDK-8357473](https://bugs.openjdk.org/browse/JDK-8357473). We should cherry-pick [JDK-8357481](https://bugs.openjdk.org/browse/JDK-8357481), [JDK-8357473](https://bugs.openjdk.org/browse/JDK-8357473) and rework parallel recompilation to use the newly created `CompileTaskWait_lock` for notifications.

Additional testing:
 - [x] Ad-hoc performance tests
 - [x] Linux x86_64 server fastdebug, `runtime/cds`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8359107](https://bugs.openjdk.org/browse/JDK-8359107): [leyden] Pick up JDK-8357481, JDK-8357473 and rework precompilation waits (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/leyden.git pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/79.diff">https://git.openjdk.org/leyden/pull/79.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/79#issuecomment-2958531627)
</details>
