### PR TITLE
8350550: Preload classes from AOT cache during VM bootstrap

### DIFF
--- a/src/hotspot/share/cds/aotClassLinker.cpp
+++ b/src/hotspot/share/cds/aotClassLinker.cpp
@@ -196,7 +196,7 @@ void AOTClassLinker::write_to_archive() {
 
   if (CDSConfig::is_dumping_aot_linked_classes()) {
     AOTLinkedClassTable* table = AOTLinkedClassTable::get(CDSConfig::is_dumping_static_archive());
-    table->set_boot(write_classes(nullptr, true));
+    table->set_boot1(write_classes(nullptr, true));
     table->set_boot2(write_classes(nullptr, false));
     table->set_platform(write_classes(SystemDictionary::java_platform_loader(), false));
     table->set_app(write_classes(SystemDictionary::java_system_loader(), false));

--- a/src/hotspot/share/cds/aotLinkedClassBulkLoader.cpp
+++ b/src/hotspot/share/cds/aotLinkedClassBulkLoader.cpp
@@ -119,6 +119,8 @@ void AOTLinkedClassBulkLoader::preload_classes(TRAPS) {
 
   preload_classes_in_table(AOTLinkedClassTable::for_static_archive()->boot1(), "boot1", Handle(), THREAD);
   preload_classes_in_table(AOTLinkedClassTable::for_static_archive()->boot2(), "boot2", Handle(), THREAD);
+  preload_classes_in_table(AOTLinkedClassTable::for_static_archive()->platform(), "plat", h_platform_loader, THREAD);
+  preload_classes_in_table(AOTLinkedClassTable::for_static_archive()->app(), "app", h_system_loader, THREAD);
 
   log_info(aot, load)("Finished preloading classes");
 }
@@ -175,8 +177,14 @@ void AOTLinkedClassBulkLoader::restore_module_of_preloaded_classes() {
     restore_module(tak, "boot1", javabase_module_oop);
   }
 
+  JavaThread* current = JavaThread::current();
+  Handle h_platform_loader(current, SystemDictionary::java_platform_loader());
+  Handle h_system_loader(current, SystemDictionary::java_system_loader());
+
   restore_module_of_preloaded_classes_in_table(AOTLinkedClassTable::for_static_archive()->boot1(), "boot1", Handle());
   restore_module_of_preloaded_classes_in_table(AOTLinkedClassTable::for_static_archive()->boot2(), "boot2", Handle());
+  restore_module_of_preloaded_classes_in_table(AOTLinkedClassTable::for_static_archive()->platform(), "plat", h_platform_loader);
+  restore_module_of_preloaded_classes_in_table(AOTLinkedClassTable::for_static_archive()->app(), "app", h_system_loader);
 }
 
 void AOTLinkedClassBulkLoader::restore_module_of_preloaded_classes_in_table(Array<InstanceKlass*>* classes,

--- a/src/hotspot/share/cds/aotLinkedClassBulkLoader.hpp
+++ b/src/hotspot/share/cds/aotLinkedClassBulkLoader.hpp
@@ -49,17 +49,20 @@ class AOTLinkedClassBulkLoader :  AllStatic {
   static bool _all_completed;
   static bool _preloading_non_javavase_classes;
 
+  static void preload_classes_in_table(Array<InstanceKlass*>* classes,
+                                       const char* category_name, Handle loader, TRAPS);
   static void load_classes_in_loader(JavaThread* current, AOTLinkedClassCategory class_category, oop class_loader_oop);
   static void load_classes_in_loader_impl(AOTLinkedClassCategory class_category, oop class_loader_oop, TRAPS);
   static void load_table(AOTLinkedClassTable* table, AOTLinkedClassCategory class_category, Handle loader, TRAPS);
   static void initiate_loading(JavaThread* current, const char* category, Handle initiating_loader, Array<InstanceKlass*>* classes);
-  static void load_classes_impl(AOTLinkedClassCategory class_category, Array<InstanceKlass*>* classes,
+  static void load_classes_impl(Array<InstanceKlass*>* classes,
                                 const char* category_name, Handle loader, TRAPS);
   static void load_hidden_class(ClassLoaderData* loader_data, InstanceKlass* ik, TRAPS);
   static void init_required_classes_for_loader(Handle class_loader, Array<InstanceKlass*>* classes, TRAPS);
   static void replay_training_at_init(Array<InstanceKlass*>* classes, TRAPS) NOT_CDS_RETURN;
 public:
   static void serialize(SerializeClosure* soc, bool is_static_archive) NOT_CDS_RETURN;
+  static void preload_classes(TRAPS);
   static void load_javabase_classes(JavaThread* current) NOT_CDS_RETURN;
   static void load_non_javabase_classes(JavaThread* current) NOT_CDS_RETURN;
   static void finish_loading_javabase_classes(TRAPS) NOT_CDS_RETURN;

--- a/src/hotspot/share/cds/aotLinkedClassBulkLoader.hpp
+++ b/src/hotspot/share/cds/aotLinkedClassBulkLoader.hpp
@@ -51,6 +51,10 @@ class AOTLinkedClassBulkLoader :  AllStatic {
 
   static void preload_classes_in_table(Array<InstanceKlass*>* classes,
                                        const char* category_name, Handle loader, TRAPS);
+  static void restore_module_of_preloaded_classes();
+  static void restore_module_of_preloaded_classes_in_table(Array<InstanceKlass*>* classes,
+                                                           const char* category_name, Handle loader);
+  static void restore_module(Klass* k, const char* category_name, oop module_oop);
   static void load_classes_in_loader(JavaThread* current, AOTLinkedClassCategory class_category, oop class_loader_oop);
   static void load_classes_in_loader_impl(AOTLinkedClassCategory class_category, oop class_loader_oop, TRAPS);
   static void load_table(AOTLinkedClassTable* table, AOTLinkedClassCategory class_category, Handle loader, TRAPS);
@@ -61,6 +65,7 @@ class AOTLinkedClassBulkLoader :  AllStatic {
   static void init_required_classes_for_loader(Handle class_loader, Array<InstanceKlass*>* classes, TRAPS);
   static void replay_training_at_init(Array<InstanceKlass*>* classes, TRAPS) NOT_CDS_RETURN;
 public:
+  static void init_archived_loader_indices() NOT_CDS_RETURN;
   static void serialize(SerializeClosure* soc, bool is_static_archive) NOT_CDS_RETURN;
   static void preload_classes(TRAPS);
   static void load_javabase_classes(JavaThread* current) NOT_CDS_RETURN;
@@ -68,7 +73,7 @@ public:
   static void finish_loading_javabase_classes(TRAPS) NOT_CDS_RETURN;
   static void exit_on_exception(JavaThread* current);
   static void replay_training_at_init_for_preloaded_classes(TRAPS) NOT_CDS_RETURN;
-  static bool class_preloading_finished() NOT_CDS_RETURN_(true);
+  static bool has_finished_loading_classes() NOT_CDS_RETURN_(true);
   static void print_counters_on(outputStream* st) NOT_CDS_RETURN;
   static bool is_pending_aot_linked_class(Klass* k) NOT_CDS_RETURN_(false);
 };

--- a/src/hotspot/share/cds/aotLinkedClassTable.cpp
+++ b/src/hotspot/share/cds/aotLinkedClassTable.cpp
@@ -31,7 +31,7 @@ AOTLinkedClassTable AOTLinkedClassTable::_for_static_archive;
 AOTLinkedClassTable AOTLinkedClassTable::_for_dynamic_archive;
 
 void AOTLinkedClassTable::serialize(SerializeClosure* soc) {
-  soc->do_ptr((void**)&_boot);
+  soc->do_ptr((void**)&_boot1);
   soc->do_ptr((void**)&_boot2);
   soc->do_ptr((void**)&_platform);
   soc->do_ptr((void**)&_app);

--- a/src/hotspot/share/cds/aotLinkedClassTable.hpp
+++ b/src/hotspot/share/cds/aotLinkedClassTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/cds/aotLinkedClassTable.hpp
+++ b/src/hotspot/share/cds/aotLinkedClassTable.hpp
@@ -44,14 +44,14 @@ class AOTLinkedClassTable {
   static AOTLinkedClassTable _for_static_archive;
   static AOTLinkedClassTable _for_dynamic_archive;
 
-  Array<InstanceKlass*>* _boot;  // only java.base classes
+  Array<InstanceKlass*>* _boot1; // only java.base classes
   Array<InstanceKlass*>* _boot2; // boot classes in other modules
   Array<InstanceKlass*>* _platform;
   Array<InstanceKlass*>* _app;
 
 public:
   AOTLinkedClassTable() :
-    _boot(nullptr), _boot2(nullptr),
+    _boot1(nullptr), _boot2(nullptr),
     _platform(nullptr), _app(nullptr) {}
 
   static AOTLinkedClassTable* for_static_archive()  { return &_for_static_archive; }
@@ -61,12 +61,12 @@ public:
     return is_static_archive ? for_static_archive() : for_dynamic_archive();
   }
 
-  Array<InstanceKlass*>* boot()     const { return _boot;     }
+  Array<InstanceKlass*>* boot1()    const { return _boot1;    }
   Array<InstanceKlass*>* boot2()    const { return _boot2;    }
   Array<InstanceKlass*>* platform() const { return _platform; }
   Array<InstanceKlass*>* app()      const { return _app;      }
 
-  void set_boot    (Array<InstanceKlass*>* value) { _boot     = value; }
+  void set_boot1   (Array<InstanceKlass*>* value) { _boot1    = value; }
   void set_boot2   (Array<InstanceKlass*>* value) { _boot2    = value; }
   void set_platform(Array<InstanceKlass*>* value) { _platform = value; }
   void set_app     (Array<InstanceKlass*>* value) { _app      = value; }

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -54,6 +54,7 @@ bool CDSConfig::_is_using_optimized_module_handling = true;
 bool CDSConfig::_is_dumping_full_module_graph = true;
 bool CDSConfig::_is_using_full_module_graph = true;
 bool CDSConfig::_has_aot_linked_classes = false;
+bool CDSConfig::_has_preloaded_classes = false;
 bool CDSConfig::_is_single_command_training = false;
 bool CDSConfig::_has_temp_aot_config_file = false;
 bool CDSConfig::_is_loading_packages = false;
@@ -1207,6 +1208,14 @@ bool CDSConfig::is_dumping_dynamic_proxies() {
 
 void CDSConfig::set_has_aot_linked_classes(bool has_aot_linked_classes) {
   _has_aot_linked_classes |= has_aot_linked_classes;
+}
+
+bool CDSConfig::is_using_preloaded_classes() {
+  return is_using_full_module_graph() && _has_preloaded_classes;
+}
+
+void CDSConfig::set_has_preloaded_classes(bool has_preloaded_classes) {
+  _has_preloaded_classes |= has_preloaded_classes;
 }
 
 bool CDSConfig::is_initing_classes_at_dump_time() {

--- a/src/hotspot/share/cds/cdsConfig.hpp
+++ b/src/hotspot/share/cds/cdsConfig.hpp
@@ -42,6 +42,7 @@ class CDSConfig : public AllStatic {
   static bool _is_dumping_full_module_graph;
   static bool _is_using_full_module_graph;
   static bool _has_aot_linked_classes;
+  static bool _has_preloaded_classes;
   static bool _is_single_command_training;
   static bool _is_one_step_training;
   static bool _has_temp_aot_config_file;
@@ -176,6 +177,9 @@ public:
   static bool is_dumping_aot_linked_classes()                NOT_CDS_JAVA_HEAP_RETURN_(false);
   static bool is_using_aot_linked_classes()                  NOT_CDS_JAVA_HEAP_RETURN_(false);
   static void set_has_aot_linked_classes(bool has_aot_linked_classes) NOT_CDS_JAVA_HEAP_RETURN;
+
+  static bool is_using_preloaded_classes()                   NOT_CDS_JAVA_HEAP_RETURN_(false);
+  static void set_has_preloaded_classes(bool has_preloaded_classes) NOT_CDS_JAVA_HEAP_RETURN;
 
   // archive_path
 

--- a/src/hotspot/share/cds/dynamicArchive.hpp
+++ b/src/hotspot/share/cds/dynamicArchive.hpp
@@ -70,6 +70,7 @@ public:
   static bool validate(FileMapInfo* dynamic_info);
   static void dump_array_klasses();
   static void setup_array_klasses();
+  static void setup_and_restore_array_klasses(TRAPS);
   static void append_array_klass(ObjArrayKlass* oak);
   static void serialize_array_klasses(SerializeClosure* soc);
   static void make_array_klasses_shareable();

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1919,6 +1919,11 @@ bool FileMapInfo::validate_aot_class_linking() {
   if (header()->has_aot_linked_classes()) {
     const char* archive_type = CDSConfig::type_of_archive_being_loaded();
     CDSConfig::set_has_aot_linked_classes(true);
+    if (is_static()) {
+      // The aot-linked classes in the dynamic archive don't have archived mirror/package/protection domain, so they
+      // cannot be preloaded.
+      CDSConfig::set_has_preloaded_classes(true);
+    }
     if (JvmtiExport::should_post_class_file_load_hook()) {
       aot_log_error(aot)("%s has aot-linked classes. It cannot be used when JVMTI ClassFileLoadHook is in use.",
                      archive_type);

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1405,6 +1405,7 @@ bool MetaspaceShared::try_link_class(JavaThread* current, InstanceKlass* ik) {
 
 void VM_PopulateDumpSharedSpace::dump_java_heap_objects() {
   if (CDSConfig::is_dumping_heap()) {
+    AOTLinkedClassBulkLoader::init_archived_loader_indices();
     HeapShared::write_heap(&_heap_info);
   } else if (!CDSConfig::is_dumping_preimage_static_archive()) {
     CDSConfig::log_reasons_for_not_dumping_heap();
@@ -2160,7 +2161,9 @@ void MetaspaceShared::initialize_shared_spaces() {
     intptr_t* buffer = (intptr_t*)dynamic_mapinfo->serialized_data();
     ReadClosure rc(&buffer, (intptr_t)SharedBaseAddress);
     ArchiveBuilder::serialize_dynamic_archivable_items(&rc);
-    DynamicArchive::setup_array_klasses();
+    if (!CDSConfig::is_using_preloaded_classes()) {
+      DynamicArchive::setup_array_klasses();
+    }
     dynamic_mapinfo->close();
     dynamic_mapinfo->unmap_region(MetaspaceShared::bm);
   }

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1171,7 +1171,7 @@ bool ciMethod::can_be_compiled() {
 
 #if INCLUDE_JVMCI
   if (EnableJVMCI && UseJVMCICompiler &&
-      env->comp_level() == CompLevel_full_optimization && !AOTLinkedClassBulkLoader::class_preloading_finished()) {
+      env->comp_level() == CompLevel_full_optimization && !AOTLinkedClassBulkLoader::has_finished_loading_classes()) {
     return false;
   }
 #endif

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1036,6 +1036,8 @@ void java_lang_Class::set_mirror_module_field(JavaThread* current, Klass* k, Han
       Handle javabase_handle(current, javabase_entry->module());
       set_module(mirror(), javabase_handle());
     }
+  } else if (CDSConfig::is_using_preloaded_classes() && !Universe::is_module_initialized()) {
+    // Do nothing. The module will be set later by AOTLinkedClassBulkLoader::restore_module_of_preloaded_classes().
   } else {
     assert(Universe::is_module_initialized() ||
            (ModuleEntryTable::javabase_defined() &&

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -337,6 +337,7 @@ protected:
                                           const ClassFileStream *cfs,
                                           PackageEntry* pkg_entry,
                                           TRAPS);
+  static void preload_class(ClassLoaderData* loader_data, InstanceKlass* ik, TRAPS); // FIXME -- rename
   static Handle get_loader_lock_or_null(Handle class_loader);
   static InstanceKlass* find_or_define_instance_class(Symbol* class_name,
                                                       Handle class_loader,

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -326,7 +326,7 @@ private:
   static void restore_archived_method_handle_intrinsics_impl(TRAPS) NOT_CDS_RETURN;
 
 protected:
-  // Used by SystemDictionaryShared and LambdaProxyClassDictionary
+  // Used by AOTLinkedClassBulkLoader, LambdaProxyClassDictionary, and SystemDictionaryShared
 
   static bool add_loader_constraint(Symbol* name, Klass* klass_being_linked,  Handle loader1,
                                     Handle loader2);
@@ -337,7 +337,7 @@ protected:
                                           const ClassFileStream *cfs,
                                           PackageEntry* pkg_entry,
                                           TRAPS);
-  static void preload_class(ClassLoaderData* loader_data, InstanceKlass* ik, TRAPS); // FIXME -- rename
+  static void preload_class(ClassLoaderData* loader_data, InstanceKlass* ik, TRAPS);
   static Handle get_loader_lock_or_null(Handle class_loader);
   static InstanceKlass* find_or_define_instance_class(Symbol* class_name,
                                                       Handle class_loader,

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -900,7 +900,7 @@ nmethod* CompilationPolicy::event(const methodHandle& method, const methodHandle
 
 #if INCLUDE_JVMCI
   if (EnableJVMCI && UseJVMCICompiler &&
-      comp_level == CompLevel_full_optimization CDS_ONLY(&& !AOTLinkedClassBulkLoader::class_preloading_finished())) {
+      comp_level == CompLevel_full_optimization CDS_ONLY(&& !AOTLinkedClassBulkLoader::has_finished_loading_classes())) {
     return nullptr;
   }
 #endif
@@ -1510,7 +1510,7 @@ CompLevel CompilationPolicy::call_event(const methodHandle& method, CompLevel cu
   }
 #if INCLUDE_JVMCI
   if (EnableJVMCI && UseJVMCICompiler &&
-      next_level == CompLevel_full_optimization CDS_ONLY(&& !AOTLinkedClassBulkLoader::class_preloading_finished())) {
+      next_level == CompLevel_full_optimization CDS_ONLY(&& !AOTLinkedClassBulkLoader::has_finished_loading_classes())) {
     next_level = cur_level;
   }
 #endif

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1594,7 +1594,7 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
 
 #if INCLUDE_JVMCI
   if (EnableJVMCI && UseJVMCICompiler &&
-      comp_level == CompLevel_full_optimization && !AOTLinkedClassBulkLoader::class_preloading_finished()) {
+      comp_level == CompLevel_full_optimization && !AOTLinkedClassBulkLoader::has_finished_loading_classes()) {
     return nullptr;
   }
 #endif

--- a/src/hotspot/share/memory/iterator.inline.hpp
+++ b/src/hotspot/share/memory/iterator.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,12 +51,7 @@ inline void ClaimMetadataVisitingOopIterateClosure::do_cld(ClassLoaderData* cld)
 }
 
 inline void ClaimMetadataVisitingOopIterateClosure::do_klass(Klass* k) {
-  ClassLoaderData* cld = k->class_loader_data();
-  if (cld != nullptr) {
-    ClaimMetadataVisitingOopIterateClosure::do_cld(cld);
-  } else {
-    assert(AOTLinkedClassBulkLoader::is_pending_aot_linked_class(k), "sanity");
-  }
+  ClaimMetadataVisitingOopIterateClosure::do_cld(k->class_loader_data());
 }
 
 inline void ClaimMetadataVisitingOopIterateClosure::do_nmethod(nmethod* nm) {

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -578,6 +578,10 @@ void Universe::initialize_basic_type_mirrors(TRAPS) {
 }
 
 void Universe::fixup_mirrors(TRAPS) {
+  if (CDSConfig::is_using_preloaded_classes()) {
+    return;
+  }
+
   // Bootstrap problem: all classes gets a mirror (java.lang.Class instance) assigned eagerly,
   // but we cannot do that for classes created before java.lang.Class is loaded. Here we simply
   // walk over permanent objects created so far (mostly classes) and fixup their mirrors. Note

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -336,30 +336,6 @@ static void call_initPhase2(TRAPS) {
   }
 
   universe_post_module_init();
-
-#if 0
-  if (CDSConfig::is_using_aot_linked_classes()) {
-    AOTLinkedClassBulkLoader::load_non_javabase_boot_classes(THREAD); 
-    if (CDSConfig::is_using_full_module_graph()) {
-      assert(SystemDictionary::java_platform_loader() != nullptr, "must be");
-      assert(SystemDictionary::java_system_loader() != nullptr,   "must be");
-      AOTLinkedClassBulkLoader::load_platform_classes(THREAD);
-      AOTLinkedClassBulkLoader::load_app_classes(THREAD);
-    } else {
-      // Special case -- we assume that the final archive has the same module graph
-      // as the training run.
-      // AOTLinkedClassBulkLoader will be called for the platform/system loaders
-      // inside SystemDictionary::compute_java_loaders().
-      assert(CDSConfig::is_dumping_final_static_archive(), "must be");
-      assert(SystemDictionary::java_platform_loader() == nullptr, "must be");
-      assert(SystemDictionary::java_system_loader() == nullptr,   "must be");
-    }
-  }
-
-#ifndef PRODUCT
-  HeapShared::initialize_test_class_from_archive(THREAD);
-#endif
-#endif
 }
 
 // Phase 3. final setup - set security manager, system class loader and TCCL

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -820,7 +820,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   // loaded until phase 2 completes
   call_initPhase2(CHECK_JNI_ERR);
 
-  if (CDSConfig::is_using_aot_linked_classes() && !CDSConfig::is_dumping_final_static_archive()) {
+  if (CDSConfig::is_using_aot_linked_classes()) {
     AOTLinkedClassBulkLoader::load_non_javabase_classes(THREAD);
   }
 #ifndef PRODUCT

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/DynamicArchiveOverAOTCache.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/DynamicArchiveOverAOTCache.java
@@ -24,14 +24,14 @@
 
 /*
  * @test
- * @summary interation between static archive and dynamic archive related to
- *          regenerated lambda form invoker classes.
+ * @summary interaction between AOT cache (with +AOTClassLinking) and dynamic archive related to
+ *          (a) regenerated lambda form invoker classes, (b) java.lang.Module for array classes
  * @requires vm.cds
  * @requires vm.cds.supports.aot.class.linking
  * @library /test/lib
- * @build RegeneratedClassesInDynamicArchive
+ * @build DynamicArchiveOverAOTCache
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar TestApp CachedInDynamic MyInterface
- * @run driver RegeneratedClassesInDynamicArchive
+ * @run driver DynamicArchiveOverAOTCache
  */
 
 import java.util.List;
@@ -42,7 +42,7 @@ import jdk.test.lib.helpers.ClassFileInstaller;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
-public class RegeneratedClassesInDynamicArchive {
+public class DynamicArchiveOverAOTCache {
     static String appJar = ClassFileInstaller.getJarPath("app.jar");
     static String aotConfigFile = "app.aotconfig";
     static String aotCacheFile = "app.aot";


### PR DESCRIPTION
This is still work-in-progress

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8350550](https://bugs.openjdk.org/browse/JDK-8350550): Preload classes from AOT cache during VM bootstrap (**Enhancement** - P3)


### Reviewers
 * [John R Rose](https://openjdk.org/census#jrose) (@rose00 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/81/head:pull/81` \
`$ git checkout pull/81`

Update a local copy of the PR: \
`$ git checkout pull/81` \
`$ git pull https://git.openjdk.org/leyden.git pull/81/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 81`

View PR using the GUI difftool: \
`$ git pr show -t 81`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/81.diff">https://git.openjdk.org/leyden/pull/81.diff</a>

</details>
