### PR TITLE
[leyden] Do not enable -XX:AOTMode=on by default

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -852,11 +852,6 @@ void CDSConfig::setup_compiler_args() {
     FLAG_SET_ERGO(AOTRecordTraining, false);
     FLAG_SET_ERGO_IF_DEFAULT(AOTReplayTraining, true);
     AOTCodeCache::enable_caching();
-
-    if (UseSharedSpaces && FLAG_IS_DEFAULT(AOTMode)) {
-      log_info(aot)("Enabled -XX:AOTMode=on by default for troubleshooting Leyden prototype");
-      RequireSharedSpaces = true;
-    }
   } else {
     FLAG_SET_ERGO(AOTReplayTraining, false);
     FLAG_SET_ERGO(AOTRecordTraining, false);


### PR DESCRIPTION
During early Leyden development, we decided to make `-XX:AOTMode=on` the default to make it easier to diagnose mismatches between training and production runs. However, this make it impossible to run the `make test JTREG=AOT_JDK...` tests:

```
$ make test JTREG=AOT_JDK=onestep TEST=open/test/hotspot/jtreg/runtime/invokedynamic
[...]
Running test 'jtreg:open/test/hotspot/jtreg/runtime/invokedynamic'
[0.010s][error][aot] An error has occurred while processing the AOT cache. Run with -Xlog:aot for details.
[0.010s][error][aot] Mismatched values for property jdk.module.addexports: java.base/jdk.internal.foreign=ALL-UNNAMED,java.base/jdk.internal.misc=ALL-UNNAMED specified during runtime but not during dump time
[0.010s][error][aot] Disabling optimized module handling
[0.010s][error][aot] AOT cache has aot-linked classes. It cannot be used when archived full module graph is not used.
[0.011s][error][aot] Unable to map shared spaces
failed to get JDK properties:
```

Now people should be familiar with using the AOT cache, so this nanny mode isn't necessary more.