### PR TITLE
8362534: [Leyden] assert(comp != nullptr) failed: Ensure we have a compiler

### DIFF
--- a/src/hotspot/share/compiler/precompiler.cpp
+++ b/src/hotspot/share/compiler/precompiler.cpp
@@ -26,6 +26,7 @@
 #include "cds/cdsConfig.hpp"
 #include "cds/runTimeClassInfo.hpp"
 #include "code/aotCodeCache.hpp"
+#include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compiler_globals.hpp"
 #include "compiler/precompiler.hpp"
@@ -224,14 +225,14 @@ void Precompiler::compile_cached_code(ArchiveBuilder* builder, TRAPS) {
   assert(AOTCodeCache::is_dumping_code(), "sanity");
   if (TrainingData::have_data()) {
     ResourceMark rm;
-
-    {
+    CompLevel highest_level = CompilationPolicy::highest_compile_level();
+    if (highest_level >= CompLevel_full_optimization) {
       PrecompileIterator pi(CompLevel_full_optimization, true /*for_preload*/, CompLevel_full_optimization, THREAD);
       TrainingData::iterate(pi);
       pi.precompile(builder, THREAD);
     }
 
-    for (int level = CompLevel_simple; level <= CompLevel_full_optimization; level++) {
+    for (int level = CompLevel_simple; level <= highest_level; level++) {
       CompLevel comp_level = (CompLevel)level;
       if (comp_level == CompLevel_full_profile) {
         comp_level = CompLevel_limited_profile;


### PR DESCRIPTION
Precompiler tries to compile methods at all levels without taking into account TieredStopAtLevel value.
This patch updates Precompiler to restrict compilation to only levels allowed by TieredStopAtLevel.