### PR TITLE
8362657: Make tables used in AOT assembly phase GC-safe

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -65,6 +65,7 @@
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/javaThread.hpp"
+#include "runtime/safepointVerifiers.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "utilities/align.hpp"
 #include "utilities/bitMap.inline.hpp"
@@ -1329,6 +1330,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
         // Don't print the requested addr again as we have just printed it at the beginning of the line.
         // Example:
         // 0x00000007ffd27938: @@ Object (0xfffa4f27) java.util.HashMap
+        assert(HeapShared::has_been_archived(source_oop), "did you call HeapShared::rehash_archived_object_cache()?");
         print_oop_info_cr(&st, source_oop, /*print_requested_addr=*/false);
         byte_size = source_oop->size() * BytesPerWord;
       } else if ((byte_size = ArchiveHeapWriter::get_filler_size_at(start)) > 0) {
@@ -1378,7 +1380,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
         }
         break;
       default:
-        if (ArchiveHeapWriter::is_marked_as_native_pointer(_heap_info, _source_obj, fd->offset())) {
+        if (ArchiveHeapWriter::is_marked_as_native_pointer(_heap_info, _buffered_addr, fd->offset())) {
           print_as_native_pointer(fd);
         } else {
           fd->print_on_for(_st, cast_to_oop(_buffered_addr)); // name, offset, value
@@ -1401,7 +1403,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
       address requested_native_ptr = builder->to_requested(builder->get_buffered_addr(source_native_ptr));
 
       // The address of _source_obj at runtime
-      oop requested_obj = ArchiveHeapWriter::source_obj_to_requested_obj(_source_obj);
+      oop requested_obj = cast_to_oop(ArchiveHeapWriter::buffered_addr_to_requested_addr(_buffered_addr));
       // The address of this field in the requested space
       assert(requested_obj != nullptr, "Attempting to load field from null oop");
       address requested_field_addr = cast_from_oop<address>(requested_obj) + fd->offset();
@@ -1501,6 +1503,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
       st->print_cr("null");
     } else {
       ResourceMark rm;
+      assert(HeapShared::has_been_archived(source_oop), "did you call HeapShared::rehash_archived_object_cache()?");
       oop requested_obj = ArchiveHeapWriter::source_obj_to_requested_obj(source_oop);
       if (print_requested_addr) {
         st->print(PTR_FORMAT " ", p2i(requested_obj));
@@ -1569,6 +1572,11 @@ public:
   static void log(ArchiveBuilder* builder, FileMapInfo* mapinfo,
                   ArchiveHeapInfo* heap_info,
                   char* bitmap, size_t bitmap_size_in_bytes) {
+    // HeapShared::archived_object_cache() uses raw address of oop to compute the hash. At this point,
+    // a GC might have happened and moved some of the oops, so the table needs to be rehashed.    
+    NoSafepointVerifier nsv;
+    HeapShared::rehash_archived_object_cache();
+
     log_info(aot, map)("%s CDS archive map for %s", CDSConfig::is_dumping_static_archive() ? "Static" : "Dynamic", mapinfo->full_path());
 
     address header = address(mapinfo->header());

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -1573,7 +1573,7 @@ public:
                   ArchiveHeapInfo* heap_info,
                   char* bitmap, size_t bitmap_size_in_bytes) {
     // HeapShared::archived_object_cache() uses raw address of oop to compute the hash. At this point,
-    // a GC might have happened and moved some of the oops, so the table needs to be rehashed.    
+    // a GC might have happened and moved some of the oops, so the table needs to be rehashed.
     NoSafepointVerifier nsv;
     HeapShared::rehash_archived_object_cache();
 

--- a/src/hotspot/share/cds/archiveHeapWriter.cpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.cpp
@@ -100,6 +100,11 @@ void ArchiveHeapWriter::init() {
   }
 }
 
+void ArchiveHeapWriter::delete_tables_with_raw_oops() {
+  delete _source_objs;
+  _source_objs = nullptr;
+}
+
 void ArchiveHeapWriter::add_source_obj(oop src_obj) {
   _source_objs->append(src_obj);
 }
@@ -150,7 +155,7 @@ oop ArchiveHeapWriter::requested_obj_from_buffer_offset(size_t offset) {
 
 oop ArchiveHeapWriter::source_obj_to_requested_obj(oop src_obj) {
   assert(CDSConfig::is_dumping_heap(), "dump-time only");
-  HeapShared::CachedOopInfo* p = HeapShared::archived_object_cache()->get(src_obj);
+  HeapShared::CachedOopInfo* p = HeapShared::get_cached_oop_info(src_obj);
   if (p != nullptr) {
     return requested_obj_from_buffer_offset(p->buffer_offset());
   } else {
@@ -159,9 +164,9 @@ oop ArchiveHeapWriter::source_obj_to_requested_obj(oop src_obj) {
 }
 
 oop ArchiveHeapWriter::buffered_addr_to_source_obj(address buffered_addr) {
-  oop* p = _buffer_offset_to_source_obj_table->get(buffered_address_to_offset(buffered_addr));
-  if (p != nullptr) {
-    return *p;
+  OopHandle* oh = _buffer_offset_to_source_obj_table->get(buffered_address_to_offset(buffered_addr));
+  if (oh != nullptr) {
+    return oh->resolve();
   } else {
     return nullptr;
   }
@@ -323,14 +328,15 @@ void ArchiveHeapWriter::copy_source_objs_to_buffer(GrowableArrayCHeap<oop, mtCla
   for (int i = 0; i < _source_objs_order->length(); i++) {
     int src_obj_index = _source_objs_order->at(i)._index;
     oop src_obj = _source_objs->at(src_obj_index);
-    HeapShared::CachedOopInfo* info = HeapShared::archived_object_cache()->get(src_obj);
+    HeapShared::CachedOopInfo* info = HeapShared::get_cached_oop_info(src_obj);
     assert(info != nullptr, "must be");
     size_t buffer_offset = copy_one_source_obj_to_buffer(src_obj);
     info->set_buffer_offset(buffer_offset);
     assert(buffer_offset <= 0x7fffffff, "sanity");
     HeapShared::add_to_permanent_oop_table(src_obj, (int)buffer_offset);
 
-    _buffer_offset_to_source_obj_table->put_when_absent(buffer_offset, src_obj);
+    OopHandle handle(Universe::vm_global(), src_obj);
+    _buffer_offset_to_source_obj_table->put_when_absent(buffer_offset, handle);
     _buffer_offset_to_source_obj_table->maybe_grow();
 
     if (java_lang_Module::is_instance(src_obj)) {
@@ -682,7 +688,7 @@ void ArchiveHeapWriter::relocate_embedded_oops(GrowableArrayCHeap<oop, mtClassSh
   for (int i = 0; i < _source_objs_order->length(); i++) {
     int src_obj_index = _source_objs_order->at(i)._index;
     oop src_obj = _source_objs->at(src_obj_index);
-    HeapShared::CachedOopInfo* info = HeapShared::archived_object_cache()->get(src_obj);
+    HeapShared::CachedOopInfo* info = HeapShared::get_cached_oop_info(src_obj);
     assert(info != nullptr, "must be");
     oop requested_obj = requested_obj_from_buffer_offset(info->buffer_offset());
     update_header_for_requested_obj(requested_obj, src_obj, src_obj->klass());
@@ -734,16 +740,9 @@ void ArchiveHeapWriter::mark_native_pointer(oop src_obj, int field_offset) {
 }
 
 // Do we have a jlong/jint field that's actually a pointer to a MetaspaceObj?
-bool ArchiveHeapWriter::is_marked_as_native_pointer(ArchiveHeapInfo* heap_info, oop src_obj, int field_offset) {
-  HeapShared::CachedOopInfo* p = HeapShared::archived_object_cache()->get(src_obj);
-  assert(p != nullptr, "must be");
-
-  // requested_field_addr = the address of this field in the requested space
-  oop requested_obj = requested_obj_from_buffer_offset(p->buffer_offset());
-  Metadata** requested_field_addr = (Metadata**)(cast_from_oop<address>(requested_obj) + field_offset);
-  assert((Metadata**)_requested_bottom <= requested_field_addr && requested_field_addr < (Metadata**) _requested_top, "range check");
-
-  BitMap::idx_t idx = requested_field_addr - (Metadata**) _requested_bottom;
+bool ArchiveHeapWriter::is_marked_as_native_pointer(ArchiveHeapInfo* heap_info, address buffered_obj, int field_offset) {
+  size_t offset = buffered_address_to_offset(buffered_obj) + checked_cast<size_t>(field_offset); // in bytes
+  BitMap::idx_t idx = checked_cast<BitMap::idx_t>(offset) / HeapWordSize;
   // Leading zeros have been removed so some addresses may not be in the ptrmap
   size_t start_pos = FileMapInfo::current_info()->heap_ptrmap_start_pos();
   if (idx < start_pos) {
@@ -765,7 +764,7 @@ void ArchiveHeapWriter::compute_ptrmap(ArchiveHeapInfo* heap_info) {
     NativePointerInfo info = _native_pointers->at(i);
     oop src_obj = info._src_obj;
     int field_offset = info._field_offset;
-    HeapShared::CachedOopInfo* p = HeapShared::archived_object_cache()->get(src_obj);
+    HeapShared::CachedOopInfo* p = HeapShared::get_cached_oop_info(src_obj);
     // requested_field_addr = the address of this field in the requested space
     oop requested_obj = requested_obj_from_buffer_offset(p->buffer_offset());
     Metadata** requested_field_addr = (Metadata**)(cast_from_oop<address>(requested_obj) + field_offset);

--- a/src/hotspot/share/cds/archiveHeapWriter.hpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.hpp
@@ -153,7 +153,7 @@ private:
   };
   static GrowableArrayCHeap<HeapObjOrder, mtClassShared>* _source_objs_order;
 
-  typedef ResizeableResourceHashtable<size_t, oop,
+  typedef ResizeableResourceHashtable<size_t, OopHandle,
       AnyObj::C_HEAP,
       mtClassShared> BufferOffsetToSourceObjectTable;
   static BufferOffsetToSourceObjectTable* _buffer_offset_to_source_obj_table;
@@ -229,6 +229,7 @@ private:
 
 public:
   static void init() NOT_CDS_JAVA_HEAP_RETURN;
+  static void delete_tables_with_raw_oops();
   static void add_source_obj(oop src_obj);
   static bool is_too_large_to_archive(size_t size);
   static bool is_too_large_to_archive(oop obj);
@@ -238,7 +239,7 @@ public:
   static size_t get_filler_size_at(address buffered_addr);
 
   static void mark_native_pointer(oop src_obj, int offset);
-  static bool is_marked_as_native_pointer(ArchiveHeapInfo* heap_info, oop src_obj, int field_offset);
+  static bool is_marked_as_native_pointer(ArchiveHeapInfo* heap_info, address buffered_obj, int field_offset);
   static oop source_obj_to_requested_obj(oop src_obj);
   static oop buffered_addr_to_source_obj(address buffered_addr);
   static address buffered_addr_to_requested_addr(address buffered_addr);

--- a/src/hotspot/share/cds/cdsHeapVerifier.cpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.cpp
@@ -36,6 +36,7 @@
 #include "oops/fieldStreams.inline.hpp"
 #include "oops/klass.inline.hpp"
 #include "oops/oop.inline.hpp"
+#include "oops/oopHandle.inline.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
 
 #if INCLUDE_CDS_JAVA_HEAP
@@ -285,7 +286,8 @@ void CDSHeapVerifier::add_static_obj_field(InstanceKlass* ik, oop field, Symbol*
 
 // This function is called once for every archived heap object. Warn if this object is referenced by
 // a static field of a class that's not aot-initialized.
-inline bool CDSHeapVerifier::do_entry(oop& orig_obj, HeapShared::CachedOopInfo& value) {
+inline bool CDSHeapVerifier::do_entry(OopHandle& orig_obj_handle, HeapShared::CachedOopInfo& value) {
+  oop orig_obj = orig_obj_handle.resolve();
   _archived_objs++;
 
   if (java_lang_String::is_instance(orig_obj) && HeapShared::is_dumped_interned_string(orig_obj)) {
@@ -335,7 +337,7 @@ public:
 
 // Call this function (from gdb, etc) if you want to know why an object is archived.
 void CDSHeapVerifier::trace_to_root(outputStream* st, oop orig_obj) {
-  HeapShared::CachedOopInfo* info = HeapShared::archived_object_cache()->get(orig_obj);
+  HeapShared::CachedOopInfo* info = HeapShared::get_cached_oop_info(orig_obj);
   if (info != nullptr) {
     trace_to_root(st, orig_obj, nullptr, info);
   } else {
@@ -369,7 +371,7 @@ const char* static_field_name(oop mirror, oop field) {
 int CDSHeapVerifier::trace_to_root(outputStream* st, oop orig_obj, oop orig_field, HeapShared::CachedOopInfo* info) {
   int level = 0;
   if (info->orig_referrer() != nullptr) {
-    HeapShared::CachedOopInfo* ref = HeapShared::archived_object_cache()->get(info->orig_referrer());
+    HeapShared::CachedOopInfo* ref = HeapShared::get_cached_oop_info(info->orig_referrer());
     assert(ref != nullptr, "sanity");
     level = trace_to_root(st, info->orig_referrer(), orig_obj, ref) + 1;
   } else if (java_lang_String::is_instance(orig_obj)) {

--- a/src/hotspot/share/cds/cdsHeapVerifier.hpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
 
 #include "cds/heapShared.hpp"
 #include "memory/iterator.hpp"
+#include "oops/oopHandle.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/resourceHash.hpp"
 
@@ -80,7 +81,7 @@ public:
   virtual void do_klass(Klass* k);
 
   // For ResourceHashtable::iterate()
-  inline bool do_entry(oop& orig_obj, HeapShared::CachedOopInfo& value);
+  inline bool do_entry(OopHandle& orig_obj, HeapShared::CachedOopInfo& value);
 
   static void verify();
 

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -179,6 +179,9 @@ oop HeapShared::CachedOopInfo::orig_referrer() const {
 }
 
 void HeapShared::rehash_archived_object_cache() {
+  if (!CDSConfig::is_dumping_heap()) {
+    return;
+  }
   assert(SafepointSynchronize::is_at_safepoint() ||
          JavaThread::current()->is_in_no_safepoint_scope(), "sanity");
 

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -427,7 +427,7 @@ private:
   static int append_root(oop obj);
   static GrowableArrayCHeap<OopHandle, mtClassShared>* pending_roots() { return _pending_roots; }
 
-  static void delete_tables_with_raw_oops() NOT_CDS_JAVA_HEAP_RETURN; 
+  static void delete_tables_with_raw_oops() NOT_CDS_JAVA_HEAP_RETURN;
 
   // Dump-time and runtime
   static objArrayOop root_segment(int segment_idx);

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -384,7 +384,6 @@ private:
   static ArchivedObjectCache* archived_object_cache() {
     return _archived_object_cache;
   }
-  static void rehash_archived_object_cache();
 
   static CachedOopInfo* get_cached_oop_info(oop orig_obj) {
     OopHandle oh(&orig_obj);
@@ -427,8 +426,6 @@ private:
   static int append_root(oop obj);
   static GrowableArrayCHeap<OopHandle, mtClassShared>* pending_roots() { return _pending_roots; }
 
-  static void delete_tables_with_raw_oops() NOT_CDS_JAVA_HEAP_RETURN;
-
   // Dump-time and runtime
   static objArrayOop root_segment(int segment_idx);
   static oop get_root(int index, bool clear=false);
@@ -452,6 +449,8 @@ private:
     CDS_JAVA_HEAP_ONLY(return (idx == MetaspaceShared::hp);)
     NOT_CDS_JAVA_HEAP_RETURN_(false);
   }
+  static void rehash_archived_object_cache() NOT_CDS_JAVA_HEAP_RETURN;
+  static void delete_tables_with_raw_oops() NOT_CDS_JAVA_HEAP_RETURN;
 
   static void resolve_classes(JavaThread* current) NOT_CDS_JAVA_HEAP_RETURN;
   static void initialize_from_archived_subgraph(JavaThread* current, Klass* k) NOT_CDS_JAVA_HEAP_RETURN;

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -168,6 +168,9 @@ private:
 public:
   static void debug_trace();
   static unsigned oop_hash(oop const& p);
+  static unsigned oop_handle_hash(OopHandle const& oh);
+  static unsigned oop_handle_hash_raw(OopHandle const& oh);
+  static bool oop_handle_equals(const OopHandle& a, const OopHandle& b);
   static unsigned string_oop_hash(oop const& string) {
     return java_lang_String::hash_code(string);
   }
@@ -176,7 +179,7 @@ public:
 
   class CachedOopInfo {
     // Used by CDSHeapVerifier.
-    oop _orig_referrer;
+    OopHandle _orig_referrer;
 
     // The location of this object inside ArchiveHeapWriter::_buffer
     size_t _buffer_offset;
@@ -187,12 +190,12 @@ public:
     // One or more fields in this object are pointing to MetaspaceObj
     bool _has_native_pointers;
   public:
-    CachedOopInfo(oop orig_referrer, bool has_oop_pointers)
+    CachedOopInfo(OopHandle orig_referrer, bool has_oop_pointers)
       : _orig_referrer(orig_referrer),
         _buffer_offset(0),
         _has_oop_pointers(has_oop_pointers),
         _has_native_pointers(false) {}
-    oop orig_referrer()             const { return _orig_referrer;   }
+    oop orig_referrer() const;
     void set_buffer_offset(size_t offset) { _buffer_offset = offset; }
     size_t buffer_offset()          const { return _buffer_offset;   }
     bool has_oop_pointers()         const { return _has_oop_pointers; }
@@ -203,10 +206,11 @@ public:
 private:
   static const int INITIAL_TABLE_SIZE = 15889; // prime number
   static const int MAX_TABLE_SIZE     = 1000000;
-  typedef ResizeableResourceHashtable<oop, CachedOopInfo,
+  typedef ResizeableResourceHashtable<OopHandle, CachedOopInfo,
       AnyObj::C_HEAP,
       mtClassShared,
-      HeapShared::oop_hash> ArchivedObjectCache;
+      HeapShared::oop_handle_hash_raw,
+      HeapShared::oop_handle_equals> ArchivedObjectCache;
   static ArchivedObjectCache* _archived_object_cache;
 
   class DumpTimeKlassSubGraphInfoTable
@@ -338,7 +342,6 @@ private:
                                           int num_loaded_regions);
   static void fill_failed_loaded_region();
   static void mark_native_pointers(oop orig_obj);
-  static bool has_been_archived(oop orig_obj);
   static void prepare_resolved_references();
   static void archive_strings();
   static void archive_subgraphs();
@@ -381,6 +384,12 @@ private:
   static ArchivedObjectCache* archived_object_cache() {
     return _archived_object_cache;
   }
+  static void rehash_archived_object_cache();
+
+  static CachedOopInfo* get_cached_oop_info(oop orig_obj) {
+    OopHandle oh(&orig_obj);
+    return _archived_object_cache->get(oh);
+  }
 
   static int archive_exception_instance(oop exception);
 
@@ -418,6 +427,8 @@ private:
   static int append_root(oop obj);
   static GrowableArrayCHeap<OopHandle, mtClassShared>* pending_roots() { return _pending_roots; }
 
+  static void delete_tables_with_raw_oops() NOT_CDS_JAVA_HEAP_RETURN; 
+
   // Dump-time and runtime
   static objArrayOop root_segment(int segment_idx);
   static oop get_root(int index, bool clear=false);
@@ -429,6 +440,7 @@ private:
 #endif // INCLUDE_CDS_JAVA_HEAP
 
  public:
+  static bool has_been_archived(oop orig_obj);
   static oop orig_to_scratch_object(oop orig_obj);
   static void write_heap(ArchiveHeapInfo* heap_info) NOT_CDS_JAVA_HEAP_RETURN;
   static objArrayOop scratch_resolved_references(ConstantPool* src);

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -723,6 +723,8 @@ void VM_PopulateDumpSharedSpace::doit() {
   _map_info->set_serialized_data(serialized_data);
   _map_info->set_cloned_vtables(CppVtables::vtables_serialized_base());
   _map_info->header()->set_class_location_config(cl_config);
+
+  HeapShared::delete_tables_with_raw_oops();
 }
 
 class CollectClassesForLinking : public KlassClosure {


### PR DESCRIPTION
This fixes crashes when using `-Xlog:aot+map=trace,aot+map+oops=trace:file=aot.oops.txt:none:filesize=0` during the assembly phase.

I basically changed a few raw `oop` pointers to `OopHandle`. I also simplified `ArchiveHeapWriter::is_marked_as_native_pointer()`.

Note that for `HeapShared::archived_object_cache()`, I calculate the hashcode using the raw oop. This way, we can avoid calling `oopDesc::identity_hash()` for every archived oops. As a result, when we use this table after exiting the CDS safepoint, we must rehash it. See changes in `ArchiveBuilder::CDSMapLogger::log()`.

- It might be alright to pre-calculate the identity hash of the archived oops in the assembly phase, but I think we should do that only if we find a reason to do so. We shouldn't do it just because it's convenient for implementing an internal table,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8362657](https://bugs.openjdk.org/browse/JDK-8362657): Make tables used in AOT assembly phase GC-safe (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer) ⚠️ Review applies to [123b766c](https://git.openjdk.org/leyden/pull/86/files/123b766c21e2a19b29633886cdf486d037f9230f)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - Committer) ⚠️ Review applies to [123b766c](https://git.openjdk.org/leyden/pull/86/files/123b766c21e2a19b29633886cdf486d037f9230f)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.org/leyden.git pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/86.diff">https://git.openjdk.org/leyden/pull/86.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/86#issuecomment-3090777803)
</details>
