### PR TITLE
8362559: [leyden] assert(!InstanceKlass::cast(receiver_klass)->is_not_initialized()) failed: receiver_klass must be initialized

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -835,7 +835,7 @@ ciMethod* ciEnv::get_method_by_index_impl(const constantPoolHandle& cpool,
     ResolvedIndyEntry* indy_info = cpool->resolved_indy_entry_at(index);
     Method* adapter = indy_info->method();
 #if INCLUDE_CDS
-    if (is_precompiled() && !AOTConstantPoolResolver::is_resolution_deterministic(cpool(), indy_info->constant_pool_index())) {
+    if (is_precompile() && !AOTConstantPoolResolver::is_resolution_deterministic(cpool(), indy_info->constant_pool_index())) {
       // This is an indy callsite that was resolved as a side effect of VM bootstrap, but
       // it cannot be cached in the resolved state, so AOT code should not reference it.
       adapter = nullptr;
@@ -1857,13 +1857,12 @@ void ciEnv::dump_replay_data_version(outputStream* out) {
   out->print_cr("version %d", REPLAY_VERSION);
 }
 
-bool ciEnv::is_precompiled() {
-  return (task() != nullptr) && (task()->compile_reason() == CompileTask::Reason_Precompile          ||
-                                 task()->compile_reason() == CompileTask::Reason_PrecompileForPreload);
+bool ciEnv::is_precompile() {
+  return (task() != nullptr) && task()->is_precompile();
 }
 
 bool ciEnv::is_fully_initialized(InstanceKlass* ik) {
-  assert(is_precompiled(), "");
+  assert(is_precompile(), "");
   if (task()->method()->method_holder() == ik) {
     return true; // FIXME: may be too strong; being_initialized, at least
   }
@@ -1904,7 +1903,7 @@ bool ciEnv::is_fully_initialized(InstanceKlass* ik) {
 
 InstanceKlass::ClassState ciEnv::compute_init_state_for_precompiled(InstanceKlass* ik) {
   ASSERT_IN_VM;
-  assert(is_precompiled(), "");
+  assert(is_precompile(), "");
   ResourceMark rm;
   if (is_fully_initialized(ik)) {
     log_trace(precompile)("%d: fully_initialized: %s", task()->compile_id(), ik->external_name());

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -546,7 +546,7 @@ public:
   void process_invokehandle(const constantPoolHandle &cp, int index, JavaThread* thread);
   void find_dynamic_call_sites();
 
-  bool is_precompiled();
+  bool is_precompile();
   bool is_fully_initialized(InstanceKlass* ik);
   InstanceKlass::ClassState compute_init_state_for_precompiled(InstanceKlass* ik);
 };

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -154,7 +154,7 @@ void ciInstanceKlass::compute_shared_init_state() {
 InstanceKlass::ClassState ciInstanceKlass::compute_init_state(InstanceKlass* ik) {
   ASSERT_IN_VM;
   ciEnv* env = CURRENT_ENV;
-  if (env != nullptr && env->is_precompiled()) {
+  if (env != nullptr && env->is_precompile()) {
     return env->compute_init_state_for_precompiled(ik);
   } else {
     return ik->init_state();

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1065,7 +1065,7 @@ bool ciMethod::ensure_method_data(bool training_data_only) {
 // ciMethod::method_data
 //
 ciMethodData* ciMethod::method_data() {
-  if (CURRENT_ENV->task()->is_precompiled() && CURRENT_ENV->task()->comp_level() == CompLevel_full_optimization) {
+  if (CURRENT_ENV->task()->is_precompile() && CURRENT_ENV->task()->comp_level() == CompLevel_full_optimization) {
     if (_method_data_recorded == nullptr) {
       VM_ENTRY_MARK;
       methodHandle h_m(thread, get_Method());

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -247,7 +247,10 @@ bool AOTCodeCache::is_code_load_thread_on() {
 }
 
 bool AOTCodeCache::allow_const_field(ciConstant& value) {
-  return !is_on() || !is_dumping_code() // Restrict only when we generate cache
+  ciEnv* env = CURRENT_ENV;
+  precond(env != nullptr);
+  assert(!env->is_precompile() || is_dumping_code(), "AOT compilation should be enabled");
+  return !env->is_precompile() // Restrict only when we generate AOT code
         // Can not trust primitive too   || !is_reference_type(value.basic_type())
         // May disable this too for now  || is_reference_type(value.basic_type()) && value.as_object()->should_be_constant()
         ;

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1633,7 +1633,7 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
          compile_reason == CompileTask::Reason_PrecompileForPreload, "method holder must be initialized");
   // return quickly if possible
 
-  if (PrecompileOnlyAndExit && !CompileTask::reason_is_precompiled(compile_reason)) {
+  if (PrecompileOnlyAndExit && !CompileTask::reason_is_precompile(compile_reason)) {
     return nullptr;
   }
 
@@ -1666,7 +1666,7 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
   assert(!HAS_PENDING_EXCEPTION, "No exception should be present");
   // some prerequisites that are compiler specific
   if (compile_reason != CompileTask::Reason_Preload &&
-      !CompileTask::reason_is_precompiled(compile_reason) &&
+      !CompileTask::reason_is_precompile(compile_reason) &&
      (comp->is_c2() || comp->is_jvmci())) {
     InternalOOMEMark iom(THREAD);
     method->constants()->resolve_string_constants(CHECK_AND_CLEAR_NONASYNC_NULL);
@@ -2612,7 +2612,7 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
     }
 
 
-    if (!ci_env.failing() && !task->is_success() && !task->is_precompiled()) {
+    if (!ci_env.failing() && !task->is_success() && !task->is_precompile()) {
       assert(ci_env.failure_reason() != nullptr, "expect failure reason");
       assert(false, "compiler should always document failure: %s", ci_env.failure_reason());
       // The compiler elected, without comment, not to register a result.

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -89,7 +89,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
     return reason_names[compile_reason];
   }
 
-  static bool reason_is_precompiled(CompileTask::CompileReason compile_reason) {
+  static bool reason_is_precompile(CompileTask::CompileReason compile_reason) {
     return (compile_reason == CompileTask::Reason_Precompile) ||
            (compile_reason == CompileTask::Reason_PrecompileForPreload);
   }
@@ -196,8 +196,8 @@ class CompileTask : public CHeapObj<mtCompiler> {
   }
 #endif
 
-  bool is_precompiled() {
-    return reason_is_precompiled(compile_reason());
+  bool is_precompile() {
+    return reason_is_precompile(compile_reason());
   }
 
   CompileQueue* compile_queue() const            { return _compile_queue; }


### PR DESCRIPTION
Fix is proposed by @iklam: add check that we precompiling AOT code in C1 where we check for initialized klass.

I renamed `is_compiled()` to `is_compile()` because we are in pricing of compiling.

Tested tier1-4,tier8-comp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8362559](https://bugs.openjdk.org/browse/JDK-8362559): [leyden] assert(!InstanceKlass::cast(receiver_klass)-&gt;is_not_initialized()) failed: receiver_klass must be initialized (**Bug** - P3)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - Committer)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/88/head:pull/88` \
`$ git checkout pull/88`

Update a local copy of the PR: \
`$ git checkout pull/88` \
`$ git pull https://git.openjdk.org/leyden.git pull/88/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 88`

View PR using the GUI difftool: \
`$ git pr show -t 88`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/88.diff">https://git.openjdk.org/leyden/pull/88.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/88#issuecomment-3109963691)
</details>
