### PR TITLE
Restore Method pointer for every AOTCodeEntry

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -730,13 +730,14 @@ void VM_Version::initialize_cpu_information(void) {
 void VM_Version::insert_features_names(uint64_t features, stringStream& ss) {
   int i = 0;
   ss.join([&]() {
-    while (i < MAX_CPU_FEATURES) {
+    const char* str = nullptr;
+    while ((i < MAX_CPU_FEATURES) && (str == nullptr)) {
       if (supports_feature((VM_Version::Feature_Flag)i)) {
-        return _features_names[i++];
+        str = _features_names[i];
       }
       i += 1;
     }
-    return (const char*)nullptr;
+    return str;
   }, ", ");
 }
 
@@ -749,14 +750,15 @@ void VM_Version::get_missing_features_name(void* features_buffer, stringStream& 
   uint64_t features_to_test = *(uint64_t*)features_buffer;
   int i = 0;
   ss.join([&]() {
-    while (i < MAX_CPU_FEATURES) {
+    const char* str = nullptr;
+    while ((i < MAX_CPU_FEATURES) && (str == nullptr)) {
       Feature_Flag flag = (Feature_Flag)i;
       if (supports_feature(features_to_test, flag) && !supports_feature(flag)) {
-        return _features_names[i];
+        str = _features_names[i];
       }
       i += 1;
     }
-    return (const char*)nullptr;
+    return str;
   }, ", ");
 }
 

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -3295,13 +3295,14 @@ bool VM_Version::is_intrinsic_supported(vmIntrinsicID id) {
 void VM_Version::insert_features_names(VM_Version::VM_Features features, stringStream& ss) {
   int i = 0;
   ss.join([&]() {
-    while (i < MAX_CPU_FEATURES) {
+    const char* str = nullptr;
+    while ((i < MAX_CPU_FEATURES) && (str == nullptr)) {
       if (features.supports_feature((VM_Version::Feature_Flag)i)) {
-        return _features_names[i++];
+        str = _features_names[i];
       }
       i += 1;
     }
-    return (const char*)nullptr;
+    return str;
   }, ", ");
 }
 
@@ -3314,14 +3315,15 @@ void VM_Version::get_missing_features_name(void* features_buffer, stringStream& 
   VM_Features* features_to_test = (VM_Features*)features_buffer;
   int i = 0;
   ss.join([&]() {
-    while (i < MAX_CPU_FEATURES) {
+    const char* str = nullptr;
+    while ((i < MAX_CPU_FEATURES) && (str == nullptr)) {
       Feature_Flag flag = (Feature_Flag)i;
       if (features_to_test->supports_feature(flag) && !_features.supports_feature(flag)) {
-        return _features_names[i];
+        str = _features_names[i];
       }
       i += 1;
     }
-    return (const char*)nullptr;
+    return str;
   }, ", ");
 }
 

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -352,6 +352,7 @@ protected:
     uint   _strings_count;   // number of recorded C strings
     uint   _strings_offset;  // offset to recorded C strings
     uint   _entries_count;   // number of recorded entries
+    uint   _search_table_offset; // offset of table for looking up an AOTCodeEntry
     uint   _entries_offset;  // offset of AOTCodeEntry array describing entries
     uint   _preload_entries_count; // entries for pre-loading code
     uint   _preload_entries_offset;
@@ -365,7 +366,7 @@ protected:
   public:
     void init(uint cache_size,
               uint strings_count,  uint strings_offset,
-              uint entries_count,  uint entries_offset,
+              uint entries_count,  uint search_table_offset, uint entries_offset,
               uint preload_entries_count, uint preload_entries_offset,
               uint adapters_count, uint shared_blobs_count,
               uint C1_blobs_count, uint C2_blobs_count, uint stubs_count) {
@@ -374,6 +375,7 @@ protected:
       _strings_count  = strings_count;
       _strings_offset = strings_offset;
       _entries_count  = entries_count;
+      _search_table_offset = search_table_offset;
       _entries_offset = entries_offset;
       _preload_entries_count  = preload_entries_count;
       _preload_entries_offset = preload_entries_offset;
@@ -390,6 +392,7 @@ protected:
     uint strings_count()  const { return _strings_count; }
     uint strings_offset() const { return _strings_offset; }
     uint entries_count()  const { return _entries_count; }
+    uint search_table_offset() const { return _search_table_offset; }
     uint entries_offset() const { return _entries_offset; }
     uint preload_entries_count()  const { return _preload_entries_count; }
     uint preload_entries_offset() const { return _preload_entries_offset; }

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -93,7 +93,6 @@ public:
 
 private:
   Method*       _method;
-  uint   _method_offset;
   Kind   _kind;
   uint   _id;          // Adapter's id, vmIntrinsic::ID for stub or name's hash for nmethod
   uint   _offset;      // Offset to entry
@@ -183,10 +182,9 @@ public:
   // Delete is a NOP
   void operator delete( void *ptr ) {}
 
-  Method*   method()  const { return _method; }
+  Method* method()  const { return _method; }
+  Method** method_addr() { return &_method; }
   void set_method(Method* method) { _method = method; }
-  void update_method_for_writing();
-  uint method_offset() const { return _method_offset; }
 
   Kind kind()         const { return _kind; }
   uint id()           const { return _id; }
@@ -524,6 +522,8 @@ public:
 
   AOTCodeEntry* find_entry(AOTCodeEntry::Kind kind, uint id, uint comp_level = 0);
   void invalidate_entry(AOTCodeEntry* entry);
+
+  void mark_method_pointer(AOTCodeEntry* entries, int count);
 
   bool finish_write();
 


### PR DESCRIPTION
There was a recent commit [0] that included code to invalidate preload entry when invalidating a normal `AOTCodeEntry`. This is done by reaching out to the preload entry through the normal `AOTCodeEntry::_method`:

https://github.com/openjdk/leyden/blob/7b7648a4c9f67be509c6fccbcbc0502648388fdc/src/hotspot/share/code/aotCodeCache.cpp#L1056-L1070

But unfortunately `AOTCodeEntry::_method` is restored only for the entries marked for preload:
https://github.com/openjdk/leyden/blob/7b7648a4c9f67be509c6fccbcbc0502648388fdc/src/hotspot/share/code/aotCodeCache.cpp#L1938-L1939

This PR fixes this bug by restoring `AOTCodeEntry::_method` for all AOTCodeEntry-s. This is achieved by using AOTCache's pointer bitmap to track `AOTCodeEntry::_method`. It removes the need to store method offset separately in the AOTCodeEntry.
It also fixes a couple of related bugs:
1. In `AOTCodeCache::finish_write()` it is possible that the AOTCodeEntry array is not properly aligned.
2. When invalidating a preload entry, it is possible that the entry has not been loaded. This triggers the assert that expects an entry to be invalidated is always loaded.

[0] https://github.com/openjdk/leyden/commit/392fbbb1859cd71521cb915b601a65cf59ba495b

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer) ⚠️ Review applies to [8d01aebf](https://git.openjdk.org/leyden/pull/90/files/8d01aebfd25bf847658a9f39be1c05f40a0afad3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.org/leyden.git pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/90.diff">https://git.openjdk.org/leyden/pull/90.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/90#issuecomment-3165282175)
</details>
