### PR TITLE
Use method offset as the hash for storing nmethods

### DIFF
--- a/src/hotspot/share/cds/aotCacheAccess.cpp
+++ b/src/hotspot/share/cds/aotCacheAccess.cpp
@@ -68,6 +68,7 @@ uint AOTCacheAccess::delta_from_base_address(address addr) {
 }
 
 uint AOTCacheAccess::convert_method_to_offset(Method* method) {
+  assert(CDSConfig::is_using_archive() && !CDSConfig::is_dumping_final_static_archive(), "must be");
   assert(MetaspaceShared::is_in_shared_metaspace(method), "method %p is not in AOTCache", method);
   uint offset = (uint)pointer_delta((address)method, (address)SharedBaseAddress, 1);
   return offset;

--- a/src/hotspot/share/cds/aotCacheAccess.cpp
+++ b/src/hotspot/share/cds/aotCacheAccess.cpp
@@ -67,6 +67,12 @@ uint AOTCacheAccess::delta_from_base_address(address addr) {
   return (uint)pointer_delta(requested_addr, (address)MetaspaceShared::requested_base_address(), 1);
 }
 
+uint AOTCacheAccess::convert_method_to_offset(Method* method) {
+  assert(MetaspaceShared::is_in_shared_metaspace(method), "method %p is not in AOTCache", method);
+  uint offset = (uint)pointer_delta((address)method, (address)SharedBaseAddress, 1);
+  return offset;
+}
+
 #if INCLUDE_CDS_JAVA_HEAP
 int AOTCacheAccess::get_archived_object_permanent_index(oop obj) {
   return HeapShared::get_archived_object_permanent_index(obj);

--- a/src/hotspot/share/cds/aotCacheAccess.hpp
+++ b/src/hotspot/share/cds/aotCacheAccess.hpp
@@ -80,6 +80,13 @@ public:
     return (Method*)metadata;
   }
 
+  // Used during production run to convert a Method in AOTCache to offset from SharedBaseAddress
+  static uint convert_method_to_offset(Method* method) {
+    assert(method->is_shared(), "method %p is not in AOTCache", method);
+    uint offset = (uint)pointer_delta((address)method, (address)SharedBaseAddress, 1);
+    return offset;
+  }
+
   static int get_archived_object_permanent_index(oop obj) NOT_CDS_JAVA_HEAP_RETURN_(-1);
   static oop get_archived_object(int permanent_index) NOT_CDS_JAVA_HEAP_RETURN_(nullptr);
 

--- a/src/hotspot/share/cds/aotCacheAccess.hpp
+++ b/src/hotspot/share/cds/aotCacheAccess.hpp
@@ -81,11 +81,7 @@ public:
   }
 
   // Used during production run to convert a Method in AOTCache to offset from SharedBaseAddress
-  static uint convert_method_to_offset(Method* method) {
-    assert(method->is_shared(), "method %p is not in AOTCache", method);
-    uint offset = (uint)pointer_delta((address)method, (address)SharedBaseAddress, 1);
-    return offset;
-  }
+  static uint convert_method_to_offset(Method* method);
 
   static int get_archived_object_permanent_index(oop obj) NOT_CDS_JAVA_HEAP_RETURN_(-1);
   static oop get_archived_object(int permanent_index) NOT_CDS_JAVA_HEAP_RETURN_(nullptr);

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -926,7 +926,6 @@ AOTCodeEntry* AOTCodeCache::find_code_entry(const methodHandle& method, uint com
   if (is_on() && _cache->cache_buffer() != nullptr) {
     ResourceMark rm;
     const char* target_name = method->name_and_sig_as_C_string();
-    //uint hash = java_lang_String::hash_code((const jbyte*)target_name, (int)strlen(target_name));
     uint hash = (uint)pointer_delta((address)method(), (address)SharedBaseAddress, 1);
     AOTCodeEntry* entry = _cache->find_entry(AOTCodeEntry::Code, hash, comp_level);
     if (entry == nullptr) {
@@ -1680,7 +1679,6 @@ AOTCodeEntry* AOTCodeCache::write_nmethod(nmethod* nm, bool for_preload) {
     if (n != name_size) {
       return nullptr;
     }
-    //hash = java_lang_String::hash_code((const jbyte*)name, (int)strlen(name));
   }
   hash = AOTCacheAccess::delta_from_base_address((address)nm->method());
 
@@ -1804,7 +1802,7 @@ bool AOTCodeCache::load_nmethod(ciEnv* env, ciMethod* target, int entry_bci, Abs
     ResourceMark rm;
     methodHandle method(THREAD, target->get_Method());
     const char* target_name = method->name_and_sig_as_C_string();
-    uint hash = java_lang_String::hash_code((const jbyte*)target_name, (int)strlen(target_name));
+    uint hash = (uint)pointer_delta((address)method(), (address)SharedBaseAddress, 1);
     bool clinit_brs = entry->has_clinit_barriers();
     log_info(aot, codecache, nmethod)("%d (L%d): %s nmethod '%s' (hash: " UINT32_FORMAT_X_0 "%s)",
                                       task->compile_id(), task->comp_level(), (preload ? "Preloading" : "Reading"),

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -93,15 +93,13 @@ public:
   };
 
 private:
-  Method*       _method;
   Kind   _kind;
-  uint   _id;          // Adapter's id, vmIntrinsic::ID for stub or name's hash for nmethod
+  uint   _id;          // Adapter's id, vmIntrinsic::ID for stub or Method's offset in AOTCache for nmethod
   uint   _offset;      // Offset to entry
   uint   _size;        // Entry size
   uint   _name_offset; // Method's or intrinsic name
   uint   _name_size;
   uint   _num_inlined_bytecodes;
-
   uint   _code_offset; // Start of code in cache
   uint   _code_size;   // Total size of all code sections
 
@@ -121,7 +119,6 @@ public:
                uint code_offset, uint code_size,
                Kind kind, uint id) {
     assert(kind == AOTCodeEntry::Stub, "sanity check");
-    _method       = nullptr;
     _kind         = kind;
     _id           = id;
     _offset       = offset;
@@ -152,7 +149,6 @@ public:
                uint comp_id = 0,
                bool has_clinit_barriers = false,
                bool for_preload = false) {
-    _method       = nullptr;
     _kind         = kind;
     _id           = id;
     _offset       = offset;
@@ -183,9 +179,7 @@ public:
   // Delete is a NOP
   void operator delete( void *ptr ) {}
 
-  Method* method()  const { return _method; }
-  Method** method_addr() { return &_method; }
-  void set_method(Method* method) { _method = method; }
+  Method* method();
 
   Kind kind()         const { return _kind; }
   uint id()           const { return _id; }
@@ -525,7 +519,6 @@ public:
   AOTCodeEntry* find_entry(AOTCodeEntry::Kind kind, uint id, uint comp_level = 0);
   void invalidate_entry(AOTCodeEntry* entry);
 
-  void mark_method_pointer(AOTCodeEntry* entries, int count);
   void store_cpu_features(char*& buffer, uint buffer_size);
 
   bool finish_write();


### PR DESCRIPTION
Currently AOTCodeEntry for nmethod uses a hash obtained from the method holder's name, method name and signature.   This is not very reliable.  With https://github.com/openjdk/leyden/pull/90, AOTCodeEntry is always linked to its corresponding Method, so we should be able to use the Method pointer as the hash for AOTCodeEntries for nmethod. However, the problem with pointers are not stable across runs. So instead of the pointer, we can use the offset of the Method in AOTCache. This should work because the Method is guaranteed to be in AOTCache.
This PR updates the code to use Method offset as the hash for AOTCodeEntries for nmethods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/91/head:pull/91` \
`$ git checkout pull/91`

Update a local copy of the PR: \
`$ git checkout pull/91` \
`$ git pull https://git.openjdk.org/leyden.git pull/91/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 91`

View PR using the GUI difftool: \
`$ git pr show -t 91`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/91.diff">https://git.openjdk.org/leyden/pull/91.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/91#issuecomment-3186026186)
</details>
