### PR TITLE
Refactor AOTCodeCache layout to store preload entries separately

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -1264,6 +1264,7 @@ bool AOTCodeCache::finish_write() {
     uint new_entries_offset = current - start;
     entries_size = entries_count * sizeof(AOTCodeEntry); // New size
     copy_bytes((_store_buffer + entries_offset), (address)current, entries_size);
+    mark_method_pointer((AOTCodeEntry*)current, entries_count);
     current += entries_size;
 
     log_stats_on_exit();

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -1246,7 +1246,7 @@ bool AOTCodeCache::finish_write() {
         } else if (kind == AOTCodeEntry::Stub) {
           stubs_count++;
         } else {
-          assert(kind == AOTCodeEntry::Code, "sanity");
+          assert(kind == AOTCodeEntry::Nmethod, "sanity");
           nmethods_count++;
         }
       }

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -592,7 +592,11 @@ AOTCodeCache::~AOTCodeCache() {
   // This lock held by ciEnv::register_method() which calls store_nmethod().
   MutexLocker ml(Compile_lock);
   if (for_dump()) { // Finalize cache
-    finish_write();
+    if (UseNewCode) {
+      finish_write_new();
+    } else {
+      finish_write();
+    }
   }
   _load_buffer = nullptr;
   if (_C_store_buffer != nullptr) {
@@ -1066,12 +1070,21 @@ void AOTCodeCache::invalidate_entry(AOTCodeEntry* entry) {
   bool found = false;
   uint i = 0;
   uint count = 0;
-  if (entry->for_preload()) {
-    count = _load_header->preload_entries_count();
-    AOTCodeEntry* preload_entry = (AOTCodeEntry*)addr(_load_header->preload_entries_offset());
-    for (; i < count; i++) {
-      if (entry == &preload_entry[i]) {
-        break;
+  if (UseNewCode) {
+    if (entry->for_preload()) {
+      count = _load_header->preload_entries_count();
+      AOTCodeEntry* preload_entry = (AOTCodeEntry*)addr(_load_header->preload_entries_offset());
+      for (; i < count; i++) {
+        if (entry == &preload_entry[i]) {
+          break;
+        }
+      }
+    } else {
+      count = _load_header->entries_count();
+      for(; i < count; i++) {
+        if (entry == &(_load_entries[i])) {
+          break;
+        }
       }
     }
   } else {
@@ -1127,6 +1140,187 @@ void AOTCodeCache::store_cpu_features(char*& buffer, uint buffer_size) {
 }
 
 bool AOTCodeCache::finish_write() {
+  if (!align_write()) {
+    return false;
+  }
+  uint strings_offset = _write_position;
+  int strings_count = store_strings();
+  if (strings_count < 0) {
+    return false;
+  }
+  if (!align_write()) {
+    return false;
+  }
+  uint strings_size = _write_position - strings_offset;
+
+  uint entries_count = 0; // Number of entrant (useful) code entries
+  uint entries_offset = _write_position;
+
+  uint code_count = _store_entries_cnt;
+  if (code_count > 0) {
+    _aot_code_directory = CachedCodeDirectory::create();
+    assert(_aot_code_directory != nullptr, "Sanity check");
+
+    uint header_size = (uint)align_up(sizeof(AOTCodeCache::Header), DATA_ALIGNMENT);
+    uint search_count = code_count * 2;
+    uint search_size = search_count * sizeof(uint);
+    uint entries_size = (uint)align_up(code_count * sizeof(AOTCodeEntry), DATA_ALIGNMENT); // In bytes
+    uint preload_entries_cnt = 0;
+    uint* preload_entries = NEW_C_HEAP_ARRAY(uint, code_count, mtCode);
+    uint preload_entries_size = code_count * sizeof(uint);
+    // _write_position should include code and strings
+    uint code_alignment = code_count * DATA_ALIGNMENT; // We align_up code size when storing it.
+    uint cpu_features_size = VM_Version::cpu_features_size();
+    uint total_cpu_features_size = sizeof(uint) + cpu_features_size; // sizeof(uint) to store cpu_features_size
+    uint total_size = _write_position + header_size + code_alignment +
+                      search_size + preload_entries_size + entries_size +
+                      align_up(total_cpu_features_size, DATA_ALIGNMENT);
+    assert(total_size < max_aot_code_size(), "AOT Code size (" UINT32_FORMAT " bytes) is greater than AOTCodeMaxSize(" UINT32_FORMAT " bytes).", total_size, max_aot_code_size());
+
+    // Allocate in AOT Cache buffer
+    char* buffer = (char *)AOTCacheAccess::allocate_aot_code_region(total_size + DATA_ALIGNMENT);
+    char* start = align_up(buffer, DATA_ALIGNMENT);
+    char* current = start + header_size; // Skip header
+
+    uint cpu_features_offset = current - start;
+    store_cpu_features(current, cpu_features_size);
+    assert(is_aligned(current, DATA_ALIGNMENT), "sanity check");
+    assert(current < start + total_size, "sanity check");
+
+    // Create ordered search table for entries [id, index];
+    uint* search = NEW_C_HEAP_ARRAY(uint, search_count, mtCode);
+
+    AOTCodeEntry* entries_address = _store_entries; // Pointer to latest entry
+    uint adapters_count = 0;
+    uint shared_blobs_count = 0;
+    uint C1_blobs_count = 0;
+    uint C2_blobs_count = 0;
+    uint stubs_count = 0;
+    uint nmethods_count = 0;
+    uint max_size = 0;
+    // AOTCodeEntry entries were allocated in reverse in store buffer.
+    // Process them in reverse order to cache first code first.
+    for (int i = code_count - 1; i >= 0; i--) {
+      AOTCodeEntry* entry = &entries_address[i];
+      if (entry->load_fail()) {
+        continue;
+      }
+      if (entry->not_entrant()) {
+        log_info(aot, codecache, exit)("Not entrant new entry comp_id: %d, comp_level: %d, hash: " UINT32_FORMAT_X_0 "%s",
+                                       entry->comp_id(), entry->comp_level(), entry->id(), (entry->has_clinit_barriers() ? ", has clinit barriers" : ""));
+        if (entry->for_preload()) {
+          // Skip not entrant preload code:
+          // we can't pre-load code which may have failing dependencies.
+          continue;
+        }
+        entry->set_entrant(); // Reset
+      } else if (entry->for_preload()) {
+        // record entrant first version code for pre-loading
+        preload_entries[preload_entries_cnt++] = entries_count;
+      }
+      {
+        uint size = align_up(entry->size(), DATA_ALIGNMENT);
+        if (size > max_size) {
+          max_size = size;
+        }
+        copy_bytes((_store_buffer + entry->offset()), (address)current, size);
+        entry->set_offset(current - start); // New offset
+        current += size;
+        uint n = write_bytes(entry, sizeof(AOTCodeEntry));
+        if (n != sizeof(AOTCodeEntry)) {
+          FREE_C_HEAP_ARRAY(uint, search);
+          return false;
+        }
+        search[entries_count*2 + 0] = entry->id();
+        search[entries_count*2 + 1] = entries_count;
+        entries_count++;
+        AOTCodeEntry::Kind kind = entry->kind();
+        if (kind == AOTCodeEntry::Adapter) {
+          adapters_count++;
+        } else if (kind == AOTCodeEntry::SharedBlob) {
+          shared_blobs_count++;
+        } else if (kind == AOTCodeEntry::C1Blob) {
+          C1_blobs_count++;
+        } else if (kind == AOTCodeEntry::C2Blob) {
+          C2_blobs_count++;
+        } else if (kind == AOTCodeEntry::Stub) {
+          stubs_count++;
+        } else {
+          assert(kind == AOTCodeEntry::Code, "sanity");
+          nmethods_count++;
+        }
+      }
+    }
+
+    if (entries_count == 0) {
+      log_info(aot, codecache, exit)("AOT Code Cache was not created: no entires");
+      FREE_C_HEAP_ARRAY(uint, search);
+      return true; // Nothing to write
+    }
+    assert(entries_count <= code_count, "%d > %d", entries_count, code_count);
+    // Write strings
+    if (strings_count > 0) {
+      copy_bytes((_store_buffer + strings_offset), (address)current, strings_size);
+      strings_offset = (current - start); // New offset
+      current += strings_size;
+    }
+    uint preload_entries_offset = (current - start);
+    preload_entries_size = preload_entries_cnt * sizeof(uint);
+    if (preload_entries_size > 0) {
+      copy_bytes((const char*)preload_entries, (address)current, preload_entries_size);
+      current += preload_entries_size;
+      log_info(aot, codecache, exit)("Wrote %d preload entries to AOT Code Cache", preload_entries_cnt);
+    }
+    if (preload_entries != nullptr) {
+      FREE_C_HEAP_ARRAY(uint, preload_entries);
+    }
+
+    uint search_table_offset = current - start;
+    // Sort and store search table
+    qsort(search, entries_count, 2*sizeof(uint), uint_cmp);
+    search_size = 2 * entries_count * sizeof(uint);
+    copy_bytes((const char*)search, (address)current, search_size);
+    FREE_C_HEAP_ARRAY(uint, search);
+    current += search_size;
+
+    // Write entries
+    current = align_up(current, DATA_ALIGNMENT);
+    uint new_entries_offset = current - start;
+    entries_size = entries_count * sizeof(AOTCodeEntry); // New size
+    copy_bytes((_store_buffer + entries_offset), (address)current, entries_size);
+    current += entries_size;
+
+    //log_stats_on_exit();
+
+    uint size = (current - start);
+    assert(size <= total_size, "%d > %d", size , total_size);
+    uint blobs_count = shared_blobs_count + C1_blobs_count + C2_blobs_count;
+    assert(nmethods_count == (entries_count - (stubs_count + blobs_count + adapters_count)), "sanity");
+    log_debug(aot, codecache, exit)("  Adapters: total=%u", adapters_count);
+    log_debug(aot, codecache, exit)("  Shared Blobs: total=%u", shared_blobs_count);
+    log_debug(aot, codecache, exit)("  C1 Blobs: total=%u", C1_blobs_count);
+    log_debug(aot, codecache, exit)("  C2 Blobs: total=%u", C2_blobs_count);
+    log_debug(aot, codecache, exit)("  Stubs:    total=%u", stubs_count);
+    log_debug(aot, codecache, exit)("  Nmethods: total=%u", nmethods_count);
+    log_debug(aot, codecache, exit)("  AOT code cache size: %u bytes, max entry's size: %u bytes", size, max_size);
+
+    // Finalize header
+    AOTCodeCache::Header* header = (AOTCodeCache::Header*)start;
+    header->init(size, (uint)strings_count, strings_offset,
+                 entries_count, search_table_offset, new_entries_offset,
+                 preload_entries_cnt, preload_entries_offset,
+                 adapters_count, shared_blobs_count,
+                 C1_blobs_count, C2_blobs_count,
+                 stubs_count, cpu_features_offset);
+
+    log_info(aot, codecache, exit)("Wrote %d AOT code entries to AOT Code Cache", entries_count);
+
+    _aot_code_directory->set_aot_code_data(size, start);
+  }
+  return true;
+}
+
+bool AOTCodeCache::finish_write_new() {
   if (!align_write()) {
     return false;
   }
@@ -1921,10 +2115,72 @@ void AOTCodeCache::preload_code(JavaThread* thread) {
   if ((DisableAOTCode & (1 << 3)) != 0) {
     return; // no preloaded code (level 5);
   }
-  _cache->preload_aot_code(thread);
+  if (UseNewCode) {
+    _cache->preload_aot_code_new(thread);
+  } else {
+    _cache->preload_aot_code(thread);
+  }
 }
 
 void AOTCodeCache::preload_aot_code(TRAPS) {
+  if (CompilationPolicy::compiler_count(CompLevel_full_optimization) == 0) {
+    // Since we reuse the CompilerBroker API to install AOT code, we're required to have a JIT compiler for the
+    // level we want (that is CompLevel_full_optimization).
+    return;
+  }
+  assert(_for_use, "sanity");
+  uint count = _load_header->entries_count();
+  if (_load_entries == nullptr) {
+    // Read it
+    _search_entries = (uint*)addr(_load_header->search_table_offset()); // [id, index]
+    _load_entries = (AOTCodeEntry*)addr(_load_header->entries_offset());
+    log_info(aot, codecache, init)("Read %d entries table at offset %d from AOT Code Cache", count, _load_header->entries_offset());
+  }
+  uint preload_entries_count = _load_header->preload_entries_count();
+  if (preload_entries_count > 0) {
+    uint* entries_index = (uint*)addr(_load_header->preload_entries_offset());
+    log_info(aot, codecache, init)("Load %d preload entries from AOT Code Cache", preload_entries_count);
+    uint count = MIN2(preload_entries_count, AOTCodeLoadStop);
+    for (uint i = AOTCodeLoadStart; i < count; i++) {
+      uint index = entries_index[i];
+      AOTCodeEntry* entry = &(_load_entries[index]);
+      if (entry->not_entrant()) {
+        continue;
+      }
+      methodHandle mh(THREAD, entry->method());
+      assert((mh.not_null() && MetaspaceShared::is_in_shared_metaspace((address)mh())), "sanity");
+      if (skip_preload(mh)) {
+        continue; // Exclude preloading for this method
+      }
+      assert(mh->method_holder()->is_loaded(), "");
+      if (!mh->method_holder()->is_linked()) {
+        assert(!HAS_PENDING_EXCEPTION, "");
+        mh->method_holder()->link_class(THREAD);
+        if (HAS_PENDING_EXCEPTION) {
+          LogStreamHandle(Info, aot, codecache) log;
+          if (log.is_enabled()) {
+            ResourceMark rm;
+            log.print("Linkage failed for %s: ", mh->method_holder()->external_name());
+            THREAD->pending_exception()->print_value_on(&log);
+            if (log_is_enabled(Debug, aot, codecache)) {
+              THREAD->pending_exception()->print_on(&log);
+            }
+          }
+          CLEAR_PENDING_EXCEPTION;
+        }
+      }
+      if (mh->aot_code_entry() != nullptr) {
+        // Second C2 compilation of the same method could happen for
+        // different reasons without marking first entry as not entrant.
+        continue; // Keep old entry to avoid issues
+      }
+      mh->set_aot_code_entry(entry);
+      CompileBroker::compile_method(mh, InvocationEntryBci, CompLevel_full_optimization, 0, false, CompileTask::Reason_Preload, CHECK);
+    }
+  }
+}
+
+void AOTCodeCache::preload_aot_code_new(TRAPS) {
   if (CompilationPolicy::compiler_count(CompLevel_full_optimization) == 0) {
     // Since we reuse the CompilerBroker API to install AOT code, we're required to have a JIT compiler for the
     // level we want (that is CompLevel_full_optimization).
@@ -4043,27 +4299,29 @@ void AOTCodeCache::print_on(outputStream* st) {
       return;
     }
 
-    st->print_cr("\nAOT Code Cache Preload entries");
+    if (UseNewCode) {
+      st->print_cr("\nAOT Code Cache Preload entries");
 
-    uint preload_count = opened_cache->_load_header->preload_entries_count();
-    AOTCodeEntry* preload_entries = (AOTCodeEntry*)opened_cache->addr(opened_cache->_load_header->preload_entries_offset());
-    for (uint i = 0; i < preload_count; i++) {
-      AOTCodeEntry* entry = &preload_entries[i];
+      uint preload_count = opened_cache->_load_header->preload_entries_count();
+      AOTCodeEntry* preload_entries = (AOTCodeEntry*)opened_cache->addr(opened_cache->_load_header->preload_entries_offset());
+      for (uint i = 0; i < preload_count; i++) {
+        AOTCodeEntry* entry = &preload_entries[i];
 
-      uint entry_position = entry->offset();
-      uint name_offset = entry->name_offset() + entry_position;
-      const char* saved_name = opened_cache->addr(name_offset);
+        uint entry_position = entry->offset();
+        uint name_offset = entry->name_offset() + entry_position;
+        const char* saved_name = opened_cache->addr(name_offset);
 
-      st->print_cr("%4u: %10s Id:%u L%u size=%u '%s' %s%s%s",
-                   i, aot_code_entry_kind_name[entry->kind()], entry->id(), entry->comp_level(),
-                   entry->size(),  saved_name,
-                   entry->has_clinit_barriers() ? " has_clinit_barriers" : "",
-                   entry->is_loaded()           ? " loaded"              : "",
-                   entry->not_entrant()         ? " not_entrant"         : "");
+        st->print_cr("%4u: %10s Id:%u L%u size=%u '%s' %s%s%s",
+                     i, aot_code_entry_kind_name[entry->kind()], entry->id(), entry->comp_level(),
+                     entry->size(),  saved_name,
+                     entry->has_clinit_barriers() ? " has_clinit_barriers" : "",
+                     entry->is_loaded()           ? " loaded"              : "",
+                     entry->not_entrant()         ? " not_entrant"         : "");
 
-      st->print_raw("         ");
-      AOTCodeReader reader(opened_cache, entry, nullptr);
-      reader.print_on(st);
+        st->print_raw("         ");
+        AOTCodeReader reader(opened_cache, entry, nullptr);
+        reader.print_on(st);
+      }
     }
 
     st->print_cr("\nAOT Code Cache entries");

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -507,12 +507,12 @@ AOTCodeCache::AOTCodeCache(bool is_dumping, bool is_using) :
       return;
     }
     log_info (aot, codecache, init)("Loaded %u AOT code entries from AOT Code Cache", _load_header->entries_count());
-    log_debug(aot, codecache, init)("  Adapters: total=%u", _load_header->adapters_count());
-    log_debug(aot, codecache, init)("  Shared Blobs: total=%u", _load_header->shared_blobs_count());
-    log_debug(aot, codecache, init)("  C1 Blobs: total=%u", _load_header->C1_blobs_count());
-    log_debug(aot, codecache, init)("  C2 Blobs: total=%u", _load_header->C2_blobs_count());
-    log_debug(aot, codecache, init)("  Stubs:    total=%u", _load_header->stubs_count());
-    log_debug(aot, codecache, init)("  Nmethods: total=%u", _load_header->nmethods_count());
+    log_debug(aot, codecache, init)("  %s: total=%u", aot_code_entry_kind_name[AOTCodeEntry::Adapter], _load_header->adapters_count());
+    log_debug(aot, codecache, init)("  %s: total=%u", aot_code_entry_kind_name[AOTCodeEntry::SharedBlob], _load_header->shared_blobs_count());
+    log_debug(aot, codecache, init)("  %s: total=%u", aot_code_entry_kind_name[AOTCodeEntry::C1Blob], _load_header->C1_blobs_count());
+    log_debug(aot, codecache, init)("  %s: total=%u", aot_code_entry_kind_name[AOTCodeEntry::C2Blob], _load_header->C2_blobs_count());
+    log_debug(aot, codecache, init)("  %s: total=%u", aot_code_entry_kind_name[AOTCodeEntry::Stub], _load_header->stubs_count());
+    log_debug(aot, codecache, init)("  %s: total=%u", aot_code_entry_kind_name[AOTCodeEntry::Nmethod], _load_header->nmethods_count());
     log_debug(aot, codecache, init)("  AOT code cache size: %u bytes", _load_header->cache_size());
 
     // Read strings
@@ -934,7 +934,7 @@ AOTCodeEntry* AOTCodeCache::find_code_entry(const methodHandle& method, uint com
   TraceTime t1("Total time to find AOT code", &_t_totalFind, enable_timers(), false);
   if (is_on() && _cache->cache_buffer() != nullptr) {
     uint id = AOTCacheAccess::convert_method_to_offset(method());
-    AOTCodeEntry* entry = _cache->find_entry(AOTCodeEntry::Code, id, comp_level);
+    AOTCodeEntry* entry = _cache->find_entry(AOTCodeEntry::Nmethod, id, comp_level);
     if (entry == nullptr) {
       LogStreamHandle(Info, aot, codecache, nmethod) log;
       if (log.is_enabled()) {
@@ -967,7 +967,7 @@ AOTCodeEntry* AOTCodeCache::find_code_entry(const methodHandle& method, uint com
 }
 
 Method* AOTCodeEntry::method() {
-  assert(_kind == Code, "invalid kind %d", _kind);
+  assert(_kind == Nmethod, "invalid kind %d", _kind);
   assert(AOTCodeCache::is_on_for_use(), "must be");
   return AOTCacheAccess::convert_offset_to_method(_id);
 }
@@ -979,7 +979,7 @@ void* AOTCodeEntry::operator new(size_t x, AOTCodeCache* cache) {
 static bool check_entry(AOTCodeEntry::Kind kind, uint id, uint comp_level, AOTCodeEntry* entry) {
   if (entry->kind() == kind) {
     assert(entry->id() == id, "sanity");
-    if (kind != AOTCodeEntry::Code || // addapters and stubs have only one version
+    if (kind != AOTCodeEntry::Nmethod || // addapters and stubs have only one version
         // Look only for normal AOT code entry, preload code is handled separately
         (!entry->not_entrant() && !entry->has_clinit_barriers() && (entry->comp_level() == comp_level))) {
       return true; // Found
@@ -1064,11 +1064,22 @@ void AOTCodeCache::invalidate_entry(AOTCodeEntry* entry) {
   }
   assert(entry->is_loaded() || entry->for_preload(), "invalidate only AOT code in use or a preload code");
   bool found = false;
-  uint count = _load_header->entries_count();
   uint i = 0;
-  for(; i < count; i++) {
-    if (entry == &(_load_entries[i])) {
-      break;
+  uint count = 0;
+  if (entry->for_preload()) {
+    count = _load_header->preload_entries_count();
+    AOTCodeEntry* preload_entry = (AOTCodeEntry*)addr(_load_header->preload_entries_offset());
+    for (; i < count; i++) {
+      if (entry == &preload_entry[i]) {
+        break;
+      }
+    }
+  } else {
+    count = _load_header->entries_count();
+    for(; i < count; i++) {
+      if (entry == &(_load_entries[i])) {
+        break;
+      }
     }
   }
   found = (i < count);
@@ -1142,14 +1153,12 @@ bool AOTCodeCache::finish_write() {
     uint search_size = search_count * sizeof(uint);
     uint entries_size = (uint)align_up(code_count * sizeof(AOTCodeEntry), DATA_ALIGNMENT); // In bytes
     uint preload_entries_cnt = 0;
-    uint* preload_entries = NEW_C_HEAP_ARRAY(uint, code_count, mtCode);
-    uint preload_entries_size = code_count * sizeof(uint);
     // _write_position should include code and strings
     uint code_alignment = code_count * DATA_ALIGNMENT; // We align_up code size when storing it.
     uint cpu_features_size = VM_Version::cpu_features_size();
     uint total_cpu_features_size = sizeof(uint) + cpu_features_size; // sizeof(uint) to store cpu_features_size
     uint total_size = _write_position + header_size + code_alignment +
-                      search_size + preload_entries_size + entries_size +
+                      search_size + entries_size +
                       align_up(total_cpu_features_size, DATA_ALIGNMENT);
     assert(total_size < max_aot_code_size(), "AOT Code size (" UINT32_FORMAT " bytes) is greater than AOTCodeMaxSize(" UINT32_FORMAT " bytes).", total_size, max_aot_code_size());
 
@@ -1167,68 +1176,82 @@ bool AOTCodeCache::finish_write() {
     uint* search = NEW_C_HEAP_ARRAY(uint, search_count, mtCode);
 
     AOTCodeEntry* entries_address = _store_entries; // Pointer to latest entry
-    uint adapters_count = 0;
-    uint shared_blobs_count = 0;
-    uint C1_blobs_count = 0;
-    uint C2_blobs_count = 0;
-    uint stubs_count = 0;
-    uint nmethods_count = 0;
+    AOTCodeStats stats;
     uint max_size = 0;
     // AOTCodeEntry entries were allocated in reverse in store buffer.
     // Process them in reverse order to cache first code first.
+
+    // Store AOTCodeEntry-s for preload code
+    current = align_up(current, DATA_ALIGNMENT);
+    uint preload_entries_offset = current - start;
+    AOTCodeEntry* preload_entries = (AOTCodeEntry*)current;
     for (int i = code_count - 1; i >= 0; i--) {
       AOTCodeEntry* entry = &entries_address[i];
       if (entry->load_fail()) {
         continue;
       }
-      if (entry->not_entrant()) {
-        log_info(aot, codecache, exit)("Not entrant new entry comp_id: %d, comp_level: %d, hash: " UINT32_FORMAT_X_0 "%s",
-                                       entry->comp_id(), entry->comp_level(), entry->id(), (entry->has_clinit_barriers() ? ", has clinit barriers" : ""));
-        if (entry->for_preload()) {
+      if (entry->for_preload()) {
+        if (entry->not_entrant()) {
           // Skip not entrant preload code:
           // we can't pre-load code which may have failing dependencies.
-          continue;
-        }
-        entry->set_entrant(); // Reset
-      } else if (entry->for_preload()) {
-        // record entrant first version code for pre-loading
-        preload_entries[preload_entries_cnt++] = entries_count;
-      }
-      {
-        uint size = align_up(entry->size(), DATA_ALIGNMENT);
-        if (size > max_size) {
-          max_size = size;
-        }
-        copy_bytes((_store_buffer + entry->offset()), (address)current, size);
-        entry->set_offset(current - start); // New offset
-        current += size;
-        uint n = write_bytes(entry, sizeof(AOTCodeEntry));
-        if (n != sizeof(AOTCodeEntry)) {
-          FREE_C_HEAP_ARRAY(uint, search);
-          return false;
-        }
-        search[entries_count*2 + 0] = entry->id();
-        search[entries_count*2 + 1] = entries_count;
-        entries_count++;
-        AOTCodeEntry::Kind kind = entry->kind();
-        if (kind == AOTCodeEntry::Adapter) {
-          adapters_count++;
-        } else if (kind == AOTCodeEntry::SharedBlob) {
-          shared_blobs_count++;
-        } else if (kind == AOTCodeEntry::C1Blob) {
-          C1_blobs_count++;
-        } else if (kind == AOTCodeEntry::C2Blob) {
-          C2_blobs_count++;
-        } else if (kind == AOTCodeEntry::Stub) {
-          stubs_count++;
+          log_info(aot, codecache, exit)("Not entrant new entry comp_id: %d, comp_level: %d, hash: " UINT32_FORMAT_X_0 "%s",
+                                         entry->comp_id(), entry->comp_level(), entry->id(), (entry->has_clinit_barriers() ? ", has clinit barriers" : ""));
         } else {
-          assert(kind == AOTCodeEntry::Code, "sanity");
-          nmethods_count++;
+          copy_bytes((const char*)entry, (address)current, sizeof(AOTCodeEntry));
+          stats.collect_entry_stats(entry);
+          current += sizeof(AOTCodeEntry);
+          preload_entries_cnt++;
         }
       }
     }
 
-    if (entries_count == 0) {
+    // Now write the data for preload AOTCodeEntry
+    for (int i = 0; i < (int)preload_entries_cnt; i++) {
+      AOTCodeEntry* entry = &preload_entries[i];
+      uint size = align_up(entry->size(), DATA_ALIGNMENT);
+      if (size > max_size) {
+        max_size = size;
+      }
+      copy_bytes((_store_buffer + entry->offset()), (address)current, size);
+      entry->set_offset(current - start); // New offset
+      current += size;
+    }
+
+    current = align_up(current, DATA_ALIGNMENT);
+    uint new_entries_offset = current - start;
+    AOTCodeEntry* code_entries = (AOTCodeEntry*)current;
+    // Now scan normal entries
+    for (int i = code_count - 1; i >= 0; i--) {
+      AOTCodeEntry* entry = &entries_address[i];
+      if (entry->load_fail() || entry->for_preload()) {
+        continue;
+      }
+      if (entry->not_entrant()) {
+        log_info(aot, codecache, exit)("Not entrant new entry comp_id: %d, comp_level: %d, hash: " UINT32_FORMAT_X_0 "%s",
+                                       entry->comp_id(), entry->comp_level(), entry->id(), (entry->has_clinit_barriers() ? ", has clinit barriers" : ""));
+        entry->set_entrant(); // Reset
+      }
+      copy_bytes((const char*)entry, (address)current, sizeof(AOTCodeEntry));
+      stats.collect_entry_stats(entry);
+      current += sizeof(AOTCodeEntry);
+      search[entries_count*2 + 0] = entry->id();
+      search[entries_count*2 + 1] = entries_count;
+      entries_count++;
+    }
+
+    // Now write the data for normal AOTCodeEntry
+    for (int i = 0; i < (int)entries_count; i++) {
+      AOTCodeEntry* entry = &code_entries[i];
+      uint size = align_up(entry->size(), DATA_ALIGNMENT);
+      if (size > max_size) {
+        max_size = size;
+      }
+      copy_bytes((_store_buffer + entry->offset()), (address)current, size);
+      entry->set_offset(current - start); // New offset
+      current += size;
+    }
+
+    if (preload_entries_cnt == 0 && entries_count == 0) {
       log_info(aot, codecache, exit)("AOT Code Cache was not created: no entires");
       FREE_C_HEAP_ARRAY(uint, search);
       return true; // Nothing to write
@@ -1240,16 +1263,6 @@ bool AOTCodeCache::finish_write() {
       strings_offset = (current - start); // New offset
       current += strings_size;
     }
-    uint preload_entries_offset = (current - start);
-    preload_entries_size = preload_entries_cnt * sizeof(uint);
-    if (preload_entries_size > 0) {
-      copy_bytes((const char*)preload_entries, (address)current, preload_entries_size);
-      current += preload_entries_size;
-      log_info(aot, codecache, exit)("Wrote %d preload entries to AOT Code Cache", preload_entries_cnt);
-    }
-    if (preload_entries != nullptr) {
-      FREE_C_HEAP_ARRAY(uint, preload_entries);
-    }
 
     uint search_table_offset = current - start;
     // Sort and store search table
@@ -1259,26 +1272,10 @@ bool AOTCodeCache::finish_write() {
     FREE_C_HEAP_ARRAY(uint, search);
     current += search_size;
 
-    // Write entries
-    current = align_up(current, DATA_ALIGNMENT);
-    uint new_entries_offset = current - start;
-    entries_size = entries_count * sizeof(AOTCodeEntry); // New size
-    copy_bytes((_store_buffer + entries_offset), (address)current, entries_size);
-    mark_method_pointer((AOTCodeEntry*)current, entries_count);
-    current += entries_size;
-
-    log_stats_on_exit();
+    log_stats_on_exit(stats);
 
     uint size = (current - start);
     assert(size <= total_size, "%d > %d", size , total_size);
-    uint blobs_count = shared_blobs_count + C1_blobs_count + C2_blobs_count;
-    assert(nmethods_count == (entries_count - (stubs_count + blobs_count + adapters_count)), "sanity");
-    log_debug(aot, codecache, exit)("  Adapters: total=%u", adapters_count);
-    log_debug(aot, codecache, exit)("  Shared Blobs: total=%u", shared_blobs_count);
-    log_debug(aot, codecache, exit)("  C1 Blobs: total=%u", C1_blobs_count);
-    log_debug(aot, codecache, exit)("  C2 Blobs: total=%u", C2_blobs_count);
-    log_debug(aot, codecache, exit)("  Stubs:    total=%u", stubs_count);
-    log_debug(aot, codecache, exit)("  Nmethods: total=%u", nmethods_count);
     log_debug(aot, codecache, exit)("  AOT code cache size: %u bytes, max entry's size: %u bytes", size, max_size);
 
     // Finalize header
@@ -1286,9 +1283,9 @@ bool AOTCodeCache::finish_write() {
     header->init(size, (uint)strings_count, strings_offset,
                  entries_count, search_table_offset, new_entries_offset,
                  preload_entries_cnt, preload_entries_offset,
-                 adapters_count, shared_blobs_count,
-                 C1_blobs_count, C2_blobs_count,
-                 stubs_count, cpu_features_offset);
+                 stats.entry_count(AOTCodeEntry::Adapter), stats.entry_count(AOTCodeEntry::SharedBlob),
+                 stats.entry_count(AOTCodeEntry::C1Blob), stats.entry_count(AOTCodeEntry::C2Blob),
+                 stats.entry_count(AOTCodeEntry::Stub), cpu_features_offset);
 
     log_info(aot, codecache, exit)("Wrote %d AOT code entries to AOT Code Cache", entries_count);
 
@@ -1752,7 +1749,7 @@ AOTCodeEntry* AOTCodeCache::write_nmethod(nmethod* nm, bool for_preload) {
 #endif /* PRODUCT */
 
   uint entry_size = _write_position - entry_position;
-  AOTCodeEntry* entry = new (this) AOTCodeEntry(AOTCodeEntry::Code, id,
+  AOTCodeEntry* entry = new (this) AOTCodeEntry(AOTCodeEntry::Nmethod, id,
                                                 entry_position, entry_size,
                                                 name_offset, name_size,
                                                 blob_offset, has_oop_maps,
@@ -1935,20 +1932,13 @@ void AOTCodeCache::preload_aot_code(TRAPS) {
   }
   assert(_for_use, "sanity");
   uint count = _load_header->entries_count();
-  if (_load_entries == nullptr) {
-    // Read it
-    _search_entries = (uint*)addr(_load_header->search_table_offset()); // [id, index]
-    _load_entries = (AOTCodeEntry*)addr(_load_header->entries_offset());
-    log_info(aot, codecache, init)("Read %d entries table at offset %d from AOT Code Cache", count, _load_header->entries_offset());
-  }
   uint preload_entries_count = _load_header->preload_entries_count();
   if (preload_entries_count > 0) {
-    uint* entries_index = (uint*)addr(_load_header->preload_entries_offset());
     log_info(aot, codecache, init)("Load %d preload entries from AOT Code Cache", preload_entries_count);
-    uint count = MIN2(preload_entries_count, AOTCodeLoadStop);
-    for (uint i = AOTCodeLoadStart; i < count; i++) {
-      uint index = entries_index[i];
-      AOTCodeEntry* entry = &(_load_entries[index]);
+    AOTCodeEntry* preload_entry = (AOTCodeEntry*)addr(_load_header->preload_entries_offset());
+    uint count = MIN2(preload_entries_count, AOTCodePreloadStop);
+    for (uint i = AOTCodePreloadStart; i < count; i++) {
+      AOTCodeEntry* entry = &preload_entry[i];
       if (entry->not_entrant()) {
         continue;
       }
@@ -3562,7 +3552,7 @@ void AOTCodeCache::load_strings() {
   uint strings_offset = _load_header->strings_offset();
   uint* string_lengths = (uint*)addr(strings_offset);
   strings_offset += (strings_count * sizeof(uint));
-  uint strings_size = _load_header->entries_offset() - strings_offset;
+  uint strings_size = _load_header->search_table_offset() - strings_offset;
   // We have to keep cached strings longer than _cache buffer
   // because they are refernced from compiled code which may
   // still be executed on VM exit after _cache is freed.
@@ -3932,47 +3922,17 @@ AOTCodeStats AOTCodeStats::add_aot_code_stats(AOTCodeStats stats1, AOTCodeStats 
   return result;
 }
 
-void AOTCodeCache::log_stats_on_exit() {
+void AOTCodeCache::log_stats_on_exit(AOTCodeStats& stats) {
   LogStreamHandle(Debug, aot, codecache, exit) log;
   if (log.is_enabled()) {
-    AOTCodeStats prev_stats;
-    AOTCodeStats current_stats;
-    AOTCodeStats total_stats;
-    uint max_size = 0;
-
-    uint load_count = (_load_header != nullptr) ? _load_header->entries_count() : 0;
-
-    for (uint i = 0; i < load_count; i++) {
-      prev_stats.collect_entry_stats(&_load_entries[i]);
-      if (max_size < _load_entries[i].size()) {
-        max_size = _load_entries[i].size();
-      }
-    }
-    for (uint i = 0; i < _store_entries_cnt; i++) {
-      current_stats.collect_entry_stats(&_store_entries[i]);
-      if (max_size < _store_entries[i].size()) {
-        max_size = _store_entries[i].size();
-      }
-    }
-    total_stats = AOTCodeStats::add_aot_code_stats(prev_stats, current_stats);
-
-    log.print_cr("Wrote %d AOTCodeEntry entries(%u max size) to AOT Code Cache",
-                 total_stats.total_count(), max_size);
     for (uint kind = AOTCodeEntry::None; kind < AOTCodeEntry::Kind_count; kind++) {
-      if (total_stats.entry_count(kind) > 0) {
-        log.print_cr("  %s: total=%u(old=%u+new=%u)",
-                     aot_code_entry_kind_name[kind], total_stats.entry_count(kind), prev_stats.entry_count(kind), current_stats.entry_count(kind));
-        if (kind == AOTCodeEntry::Code) {
-          for (uint lvl = CompLevel_none; lvl < AOTCompLevel_count; lvl++) {
-            if (total_stats.nmethod_count(lvl) > 0) {
-              log.print_cr("    Tier %d: total=%u(old=%u+new=%u)",
-                           lvl, total_stats.nmethod_count(lvl), prev_stats.nmethod_count(lvl), current_stats.nmethod_count(lvl));
-            }
-          }
+      log.print_cr("  %s: total=%u", aot_code_entry_kind_name[kind], stats.entry_count(kind));
+      if (kind == AOTCodeEntry::Nmethod) {
+        for (uint lvl = CompLevel_none; lvl < AOTCompLevel_count; lvl++) {
+          log.print_cr("    Tier %d: total=%u", lvl, stats.nmethod_count(lvl));
         }
       }
     }
-    log.print_cr("Total=%u(old=%u+new=%u)", total_stats.total_count(), prev_stats.total_count(), current_stats.total_count());
   }
 }
 
@@ -3990,11 +3950,16 @@ void AOTCodeCache::print_statistics_on(outputStream* st) {
       // Cache is closed, cannot touch anything.
       return;
     }
+    AOTCodeStats stats;
+
+    uint preload_count = cache->_load_header->preload_entries_count();
+    AOTCodeEntry* preload_entries = (AOTCodeEntry*)cache->addr(cache->_load_header->preload_entries_offset());
+    for (uint i = 0; i < preload_count; i++) {
+      stats.collect_all_stats(&preload_entries[i]);
+    }
 
     uint count = cache->_load_header->entries_count();
     AOTCodeEntry* load_entries = (AOTCodeEntry*)cache->addr(cache->_load_header->entries_offset());
-
-    AOTCodeStats stats;
     for (uint i = 0; i < count; i++) {
       stats.collect_all_stats(&load_entries[i]);
     }
@@ -4008,7 +3973,7 @@ void AOTCodeCache::print_statistics_on(outputStream* st) {
         print_helper1(st, "failed", stats.entry_load_failed_count(kind));
         st->cr();
       }
-      if (kind == AOTCodeEntry::Code) {
+      if (kind == AOTCodeEntry::Nmethod) {
         for (uint lvl = CompLevel_none; lvl < AOTCompLevel_count; lvl++) {
           if (stats.nmethod_count(lvl) > 0) {
             st->print("    AOT Code T%d", lvl);
@@ -4078,7 +4043,31 @@ void AOTCodeCache::print_on(outputStream* st) {
       return;
     }
 
-    st->print_cr("\nAOT Code Cache");
+    st->print_cr("\nAOT Code Cache Preload entries");
+
+    uint preload_count = opened_cache->_load_header->preload_entries_count();
+    AOTCodeEntry* preload_entries = (AOTCodeEntry*)opened_cache->addr(opened_cache->_load_header->preload_entries_offset());
+    for (uint i = 0; i < preload_count; i++) {
+      AOTCodeEntry* entry = &preload_entries[i];
+
+      uint entry_position = entry->offset();
+      uint name_offset = entry->name_offset() + entry_position;
+      const char* saved_name = opened_cache->addr(name_offset);
+
+      st->print_cr("%4u: %10s Id:%u L%u size=%u '%s' %s%s%s",
+                   i, aot_code_entry_kind_name[entry->kind()], entry->id(), entry->comp_level(),
+                   entry->size(),  saved_name,
+                   entry->has_clinit_barriers() ? " has_clinit_barriers" : "",
+                   entry->is_loaded()           ? " loaded"              : "",
+                   entry->not_entrant()         ? " not_entrant"         : "");
+
+      st->print_raw("         ");
+      AOTCodeReader reader(opened_cache, entry, nullptr);
+      reader.print_on(st);
+    }
+
+    st->print_cr("\nAOT Code Cache entries");
+
     uint count = opened_cache->_load_header->entries_count();
     uint* search_entries = (uint*)opened_cache->addr(opened_cache->_load_header->search_table_offset()); // [id, index]
     AOTCodeEntry* load_entries = (AOTCodeEntry*)opened_cache->addr(opened_cache->_load_header->entries_offset());
@@ -4110,7 +4099,7 @@ void AOTCodeCache::print_unused_entries_on(outputStream* st) {
   LogStreamHandle(Info, aot, codecache, init) info;
   if (info.is_enabled()) {
     AOTCodeCache::iterate([&](AOTCodeEntry* entry) {
-      if (entry->is_code() && !entry->is_loaded()) {
+      if (entry->is_nmethod() && !entry->is_loaded()) {
         MethodTrainingData* mtd = MethodTrainingData::find(methodHandle(Thread::current(), entry->method()));
         if (mtd != nullptr) {
           if (mtd->has_holder()) {

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -398,12 +398,14 @@ protected:
     uint C1_blobs_count() const { return _C1_blobs_count; }
     uint C2_blobs_count() const { return _C2_blobs_count; }
     uint stubs_count()    const { return _stubs_count; }
-    uint nmethods_count() const { return _preload_entries_count + _entries_count
+    uint nmethods_count() const { uint count = _entries_count
                                        - _stubs_count
                                        - _shared_blobs_count
                                        - _C1_blobs_count
                                        - _C2_blobs_count
-                                       - _adapters_count; }
+                                       - _adapters_count;
+                                  if (UseNewCode) count += _preload_entries_count;
+                                  return count; }
 
     bool verify(uint load_size)  const;
     bool verify_config(AOTCodeCache* cache) const { // Called after Universe initialized
@@ -519,6 +521,7 @@ public:
     return _store_entries;
   }
   void preload_aot_code(TRAPS);
+  void preload_aot_code_new(TRAPS);
 
   AOTCodeEntry* find_entry(AOTCodeEntry::Kind kind, uint id, uint comp_level = 0);
   void invalidate_entry(AOTCodeEntry* entry);
@@ -526,6 +529,7 @@ public:
   void store_cpu_features(char*& buffer, uint buffer_size);
 
   bool finish_write();
+  bool finish_write_new();
 
   void log_stats_on_exit(AOTCodeStats& stats);
 

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -82,7 +82,7 @@ enum class vmIntrinsicID : int;
   Fn(SharedBlob) \
   Fn(C1Blob) \
   Fn(C2Blob) \
-  Fn(Code) \
+  Fn(Nmethod) \
 
 // Descriptor of AOT Code Cache's entry
 class AOTCodeEntry {
@@ -220,7 +220,7 @@ public:
   static bool is_valid_entry_kind(Kind kind) { return kind > None && kind < Kind_count; }
   static bool is_blob(Kind kind) { return kind == SharedBlob || kind == C1Blob || kind == C2Blob; }
   static bool is_adapter(Kind kind) { return kind == Adapter; }
-  bool is_code()  { return _kind == Code; }
+  bool is_nmethod()  { return _kind == Nmethod; }
 };
 
 // Addresses of stubs, blobs and runtime finctions called from compiled code.
@@ -301,6 +301,8 @@ enum class DataKind: int {
   PlaLoader = 7, // java_platform_loader
   MethodCnts= 8
 };
+
+struct AOTCodeStats;
 
 class AOTCodeCache : public CHeapObj<mtCode> {
 
@@ -396,7 +398,7 @@ protected:
     uint C1_blobs_count() const { return _C1_blobs_count; }
     uint C2_blobs_count() const { return _C2_blobs_count; }
     uint stubs_count()    const { return _stubs_count; }
-    uint nmethods_count() const { return _entries_count
+    uint nmethods_count() const { return _preload_entries_count + _entries_count
                                        - _stubs_count
                                        - _shared_blobs_count
                                        - _C1_blobs_count
@@ -525,7 +527,7 @@ public:
 
   bool finish_write();
 
-  void log_stats_on_exit();
+  void log_stats_on_exit(AOTCodeStats& stats);
 
   static bool load_stub(StubCodeGenerator* cgen, vmIntrinsicID id, const char* name, address start) NOT_CDS_RETURN_(false);
   static bool store_stub(StubCodeGenerator* cgen, vmIntrinsicID id, const char* name, address start) NOT_CDS_RETURN_(false);
@@ -725,7 +727,7 @@ public:
 
   void collect_entry_stats(AOTCodeEntry* entry) {
     inc_entry_cnt(entry->kind());
-    if (entry->is_code()) {
+    if (entry->is_nmethod()) {
       entry->for_preload() ? inc_nmethod_cnt(AOTCompLevel_count-1)
                            : inc_nmethod_cnt(entry->comp_level());
       if (entry->has_clinit_barriers()) {
@@ -779,7 +781,7 @@ public:
 
   void inc_loaded_cnt(AOTCodeEntry* entry) {
     inc_entry_loaded_cnt(entry->kind());
-    if (entry->is_code()) {
+    if (entry->is_nmethod()) {
       entry->for_preload() ? inc_nmethod_loaded_cnt(AOTCompLevel_count-1)
                            : inc_nmethod_loaded_cnt(entry->comp_level());
     }
@@ -787,7 +789,7 @@ public:
 
   void inc_invalidated_cnt(AOTCodeEntry* entry) {
     inc_entry_invalidated_cnt(entry->kind());
-    if (entry->is_code()) {
+    if (entry->is_nmethod()) {
       entry->for_preload() ? inc_nmethod_invalidated_cnt(AOTCompLevel_count-1)
                            : inc_nmethod_invalidated_cnt(entry->comp_level());
     }
@@ -795,7 +797,7 @@ public:
 
   void inc_load_failed_cnt(AOTCodeEntry* entry) {
     inc_entry_load_failed_cnt(entry->kind());
-    if (entry->is_code()) {
+    if (entry->is_nmethod()) {
       entry->for_preload() ? inc_nmethod_load_failed_cnt(AOTCompLevel_count-1)
                            : inc_nmethod_load_failed_cnt(entry->comp_level());
     }

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -419,6 +419,12 @@
   product(uint, AOTCodeLoadStop, max_jint,                                  \
           "The id of the last AOT code to load")                            \
                                                                             \
+  product(uint, AOTCodePreloadStart, 0,                                     \
+          "The id of the first AOT code to preload")                        \
+                                                                            \
+  product(uint, AOTCodePreloadStop, max_jint,                               \
+          "The id of the last AOT code to preload")                         \
+                                                                            \
   product(bool, VerifyAOTCode, false, DIAGNOSTIC,                           \
           "Load AOT code but not publish")                                  \
                                                                             \

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
@@ -121,12 +121,12 @@ public class AOTCodeFlags {
                 switch (runMode) {
                 case RunMode.ASSEMBLY:
                 case RunMode.PRODUCTION:
-                    out.shouldNotMatch("Adapters:\\s+total");
-                    out.shouldNotMatch("Shared Blobs:\\s+total");
-                    out.shouldNotMatch("C1 Blobs:\\s+total");
-                    out.shouldNotMatch("C2 Blobs:\\s+total");
-                    out.shouldNotMatch("Stubs:\\s+total");
-                    out.shouldNotMatch("Nmethods:\\s+total");
+                    out.shouldNotMatch("Adapter:\\s+total");
+                    out.shouldNotMatch("SharedBlob:\\s+total");
+                    out.shouldNotMatch("C1Blob:\\s+total");
+                    out.shouldNotMatch("C2Blob:\\s+total");
+                    out.shouldNotMatch("Stub:\\s+total");
+                    out.shouldNotMatch("Nmethod:\\s+total");
                     break;
                 }
             } else {
@@ -135,7 +135,7 @@ public class AOTCodeFlags {
                     case RunMode.ASSEMBLY:
                     case RunMode.PRODUCTION:
                         // AOTAdapterCaching is on, non-zero adapters should be stored/loaded
-                        out.shouldMatch("Adapters:\\s+total=[1-9][0-9]+");
+                        out.shouldMatch("Adapter:\\s+total=[1-9][0-9]+");
                         break;
                     }
                 } else {
@@ -143,7 +143,7 @@ public class AOTCodeFlags {
                     case RunMode.ASSEMBLY:
                     case RunMode.PRODUCTION:
                         // AOTAdapterCaching is off, no adapters should be stored/loaded
-                        out.shouldMatch("Adapters:\\s+total=0");
+                        out.shouldMatch("Adapter:\\s+total=0");
                         break;
                     }
                 }
@@ -152,10 +152,10 @@ public class AOTCodeFlags {
                     case RunMode.ASSEMBLY:
                     case RunMode.PRODUCTION:
                         // AOTStubCaching is on, non-zero stubs should be stored/loaded
-                        out.shouldMatch("Shared Blobs:\\s+total=[1-9][0-9]+");
-                        out.shouldMatch("C1 Blobs:\\s+total=[1-9][0-9]+");
-                        out.shouldMatch("C2 Blobs:\\s+total=[1-9][0-9]+");
-                        out.shouldMatch("Stubs:\\s+total=[1-9]+");
+                        out.shouldMatch("SharedBlob:\\s+total=[1-9][0-9]+");
+                        out.shouldMatch("C1Blob:\\s+total=[1-9][0-9]+");
+                        out.shouldMatch("C2Blob:\\s+total=[1-9][0-9]+");
+                        out.shouldMatch("Stub:\\s+total=[1-9]+");
                         break;
                     }
                 } else {
@@ -163,10 +163,10 @@ public class AOTCodeFlags {
                     case RunMode.ASSEMBLY:
                     case RunMode.PRODUCTION:
                         // AOTStubCaching is off, no stubs should be stored/loaded
-                        out.shouldMatch("Shared Blobs:\\s+total=0");
-                        out.shouldMatch("C1 Blobs:\\s+total=0");
-                        out.shouldMatch("C2 Blobs:\\s+total=0");
-                        out.shouldMatch("Stubs:\\s+total=0");
+                        out.shouldMatch("SharedBlob:\\s+total=0");
+                        out.shouldMatch("C1Blob:\\s+total=0");
+                        out.shouldMatch("C2Blob:\\s+total=0");
+                        out.shouldMatch("Stub:\\s+total=0");
                         break;
                     }
                 }
@@ -175,7 +175,7 @@ public class AOTCodeFlags {
                     case RunMode.ASSEMBLY:
                     case RunMode.PRODUCTION:
                         // AOTAdapterCaching is on, non-zero adapters should be stored/loaded
-                        out.shouldMatch("Nmethods:\\s+total=[1-9]+");
+                        out.shouldMatch("Nmethod:\\s+total=[1-9]+");
                         break;
                     }
                 } else {
@@ -183,7 +183,7 @@ public class AOTCodeFlags {
                     case RunMode.ASSEMBLY:
                     case RunMode.PRODUCTION:
                         // AOTAdapterCaching is off, no adapters should be stored/loaded
-                        out.shouldMatch("Nmethods:\\s+total=0");
+                        out.shouldMatch("Nmethod:\\s+total=0");
                         break;
                     }
                 }


### PR DESCRIPTION
Currently the mechanism to lay out final AOTCodeCache entries in `AOTCodeCache::finish_write()` is a bit convoluted.
Code data is initially written in a temporary buffer and then assembled in the final buffer in `AOTCodeCache::finish_write()`.

In the temporary buffer AOTCodeEntry structs are added from the end of the buffer, and the payload (the actual compiled code) is added from the start of the buffer. That means the temporary buffer holds AOTCodeEntry in reverse order.

```
| payload | ... | ACE[n] | ACE[n-1] | ... | ACE[0] |
```

When assembling the final buffer, AOTCodeEntry structs are first copied in the temporary buffer to make the order correct:

```
| payload | ...| ACE[0] | ACE[1] | ... | ACE[n] |... | ACE[n] | ACE[n-1] | ... | ACE[0] |
```

and then the whole memory block is copied into the final buffer.
This means the size of the temporary buffer needs to be a bit more than required.

Another issue is the search table created in `finish_write`. This table includes entries marked for preload. However, preload entries are never searched; they get loaded at the start of the JVM in `preload_aot_code()`. Since the preload and other code entries are mixed together,  we also need a separate table to identify the preload entries.

This PR is an attempt to fix above issues. It does final assembly in following steps:
1. Process AOTCodeEntry structs in the temporary buffer in reverse order and write the ones marked for preload in the final buffer
2. Now the payload for the preload entries is marked
3. Next, add the AOTCodeEntry structs for non-preload code to the final buffer
4. Then add the payload for these entries
5. Finally add the search table

```
| ACE[0] | ... | ACE[m] | payload | ACE[0] | ... | ACE[n] | payload | search_table |
```

This layout separates the preload entries from rest of the code and these entries can then be processed sequentially when the cache is loaded. There is no need for a separate table to identify the preload entries.

I have added the new functionality in separate methods suffixed with `_new` (eg `finish_write_new` and `preload_aot_code_new`) and they are guarded by `UseNewCode` flag.
 