### PR TITLE
8368595: [leyden] Enhance CPU features check

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -761,7 +761,7 @@ void VM_Version::store_cpu_features(void* buf) {
   *(uint64_t*)buf = _features;
 }
 
-bool VM_Version::supports_features(void* features_buffer) {
+bool VM_Version::supports_features(void* features_buffer, uint cpu_features_number) {
   uint64_t features_to_test = *(uint64_t*)features_buffer;
   return (_features & features_to_test) == features_to_test;
 }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -235,7 +235,7 @@ enum Ampere_CPU_Model {
   // Size of the buffer must be same as returned by cpu_features_size()
   static void store_cpu_features(void* buf);
 
-  static bool supports_features(void* features_to_test);
+  static bool supports_features(void* features_to_test, uint cpu_features_number);
 };
 
 #endif // CPU_AARCH64_VM_VERSION_AARCH64_HPP

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -3310,6 +3310,10 @@ int VM_Version::cpu_features_size() {
   return sizeof(VM_Features);
 }
 
+uint VM_Version::cpu_features_number() {
+  return _features.cpu_features_number();
+}
+
 void VM_Version::store_cpu_features(void* buf) {
   VM_Features copy = _features;
   copy.clear_feature(CPU_HT); // HT does not result in incompatibility of aot code cache

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -3316,7 +3316,7 @@ void VM_Version::store_cpu_features(void* buf) {
   memcpy(buf, &copy, sizeof(VM_Features));
 }
 
-bool VM_Version::supports_features(void* features_buffer) {
+bool VM_Version::supports_features(void* features_buffer, uint cpu_features_number) {
   VM_Features* features_to_test = (VM_Features*)features_buffer;
-  return _features.supports_features(features_to_test);
+  return _features.supports_features(features_to_test, cpu_features_number);
 }

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -510,8 +510,12 @@ protected:
       return (_features_bitmap[idx] & bit_mask(feature)) != 0;
     }
 
-    bool supports_features(VM_Features* features_to_test, uint cpu_features_number) {
-      if (cpu_features_number != MAX_CPU_FEATURES) {
+    uint cpu_features_number() {
+      return MAX_CPU_FEATURES;
+    }
+
+    bool supports_features(VM_Features* features_to_test, uint cpu_features_num) {
+      if (cpu_features_num != cpu_features_number()) {
         return false;
       }
       for (int i = 0; i < features_bitmap_element_count(); i++) {
@@ -1097,6 +1101,9 @@ public:
 
   // Returns number of bytes required to store cpu features representation
   static int cpu_features_size();
+
+  // Returns number of cpu features
+  static uint cpu_features_number();
 
   // Stores cpu features representation in the provided buffer. This representation is arch dependent.
   // Size of the buffer must be same as returned by cpu_features_size()

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -510,7 +510,10 @@ protected:
       return (_features_bitmap[idx] & bit_mask(feature)) != 0;
     }
 
-    bool supports_features(VM_Features* features_to_test) {
+    bool supports_features(VM_Features* features_to_test, uint cpu_features_number) {
+      if (cpu_features_number != MAX_CPU_FEATURES) {
+        return false;
+      }
       for (int i = 0; i < features_bitmap_element_count(); i++) {
         if ((_features_bitmap[i] & features_to_test->_features_bitmap[i]) != features_to_test->_features_bitmap[i]) {
           return false;
@@ -1099,7 +1102,7 @@ public:
   // Size of the buffer must be same as returned by cpu_features_size()
   static void store_cpu_features(void* buf);
 
-  static bool supports_features(void* features_to_test);
+  static bool supports_features(void* features_to_test, uint cpu_features_number);
 };
 
 #endif // CPU_X86_VM_VERSION_X86_HPP

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -745,10 +745,15 @@ bool AOTCodeCache::Config::verify(AOTCodeCache* cache) const {
 
   if (AOTCodeCPUFeatureCheck && !VM_Version::supports_features(cached_cpu_features_buffer, cpu_features_number)) {
     if (log.is_enabled()) {
-      ResourceMark rm; // required for stringStream::as_string()
-      stringStream ss;
-      VM_Version::get_missing_features_name(cached_cpu_features_buffer, ss);
-      log.print_cr("AOT Code Cache disabled: required cpu features are missing: %s", ss.as_string());
+      if (cpu_features_number != (uint)VM_Version::cpu_features_number()) {
+        log.print_cr("AOT Code Cache disabled: archived features number: %d, local features number: %d",
+                     cpu_features_number, (uint)VM_Version::cpu_features_number());
+      } else {
+        ResourceMark rm; // required for stringStream::as_string()
+        stringStream ss;
+        VM_Version::get_missing_features_name(cached_cpu_features_buffer, ss);
+        log.print_cr("AOT Code Cache disabled: required cpu features are missing: %s", ss.as_string());
+      }
     }
     return false;
   }

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -732,7 +732,7 @@ bool AOTCodeCache::Config::verify(AOTCodeCache* cache) const {
   assert(cpu_features_size == (uint)VM_Version::cpu_features_size(), "must be");
   offset += sizeof(uint);
   uint cpu_features_number = *(uint *)cache->addr(offset);
-  assert(cpu_features_number == (uint)VM_Version::cpu_features_number(), "must be");
+  assert(cpu_features_number == VM_Version::cpu_features_number(), "must be");
   offset += sizeof(uint);
 
   void* cached_cpu_features_buffer = (void *)cache->addr(offset);

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -521,7 +521,7 @@ public:
   AOTCodeEntry* find_entry(AOTCodeEntry::Kind kind, uint id, uint comp_level = 0);
   void invalidate_entry(AOTCodeEntry* entry);
 
-  void store_cpu_features(char*& buffer, uint buffer_size);
+  void store_cpu_features(char*& buffer, uint buffer_size, uint cpu_features_number);
 
   bool finish_write();
 

--- a/src/hotspot/share/runtime/abstract_vm_version.hpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.hpp
@@ -234,12 +234,15 @@ class Abstract_VM_Version: AllStatic {
   // Returns number of bytes required to store cpu features representation
   static int cpu_features_size() { return 0; }
 
+  // Returns number of cpu features
+  static int cpu_features_number() { return 0; }
+
   // Stores arch dependent cpu features representation in the provided buffer.
   // Size of the buffer must be same as returned by cpu_features_size()
   static void store_cpu_features(void* buf) { return; }
 
   // features_to_test is an opaque object that stores arch specific representation of cpu features
-  static bool supports_features(void* features_to_test) { return false; };
+  static bool supports_features(void* features_to_test, uint cpu_features_number) { return false; };
 };
 
 #endif // SHARE_RUNTIME_ABSTRACT_VM_VERSION_HPP

--- a/src/hotspot/share/runtime/abstract_vm_version.hpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.hpp
@@ -235,7 +235,7 @@ class Abstract_VM_Version: AllStatic {
   static int cpu_features_size() { return 0; }
 
   // Returns number of cpu features
-  static int cpu_features_number() { return 0; }
+  static uint cpu_features_number() { return 0; }
 
   // Stores arch dependent cpu features representation in the provided buffer.
   // Size of the buffer must be same as returned by cpu_features_size()


### PR DESCRIPTION
Hi,
Can you help to review this patch?

Current implementation of CPU features check compare the whole buffer of cpu features. This could introduce a potential issue when CPU features accumulate.

Consider this example.
If at JDK version X there are 5 CPU features, they are a(0), b(1), c(2), d(3), e(4), the number inside () is the feature index assigned (it could be explicitly or implicitly, depends on the implementation of VM_Version). In the future at JDK version Y there could be another feature f added, but f could be added at the middle of features list (reason could be to group some features together or order all cpu features in alphabetical way, so now it looks like a(0), b(1), c(2), f(3), d(4), e(5).
So, cpu features buffer of the version X in an archive could be 111110000..., which means all 5 features (a/b/c/d/e) are supported, and this archive could be used by a runtime of version Y, and the local CPU supports a/b/c/f/d, but not e, in this situation, the cpu features are also 111110000..., which means buffer comparison result is equal, but indeed they are not equal.

The solution could be to just introduce an cpu_feature_number, before comparing the buffer, compare if the number is equal, if not just fail the cpu feature comparison.
This solution is based on the assumption that we only add but not remove CPU features.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8368595](https://bugs.openjdk.org/browse/JDK-8368595): [leyden] Enhance CPU features check (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/100/head:pull/100` \
`$ git checkout pull/100`

Update a local copy of the PR: \
`$ git checkout pull/100` \
`$ git pull https://git.openjdk.org/leyden.git pull/100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 100`

View PR using the GUI difftool: \
`$ git pr show -t 100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/100.diff">https://git.openjdk.org/leyden/pull/100.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/100#issuecomment-3330508207)
</details>
