### PR TITLE
Minor cleanup and refactoring

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -983,26 +983,14 @@ void ciEnv::validate_compile_task_dependencies(ciMethod* target) {
   }
 }
 
-// aot_code_entry != nullptr implies loading compiled code from AOT code cache
-bool ciEnv::is_compilation_valid(JavaThread* thread, ciMethod* target, bool preload, bool install_code, CodeBuffer* code_buffer, AOTCodeEntry* aot_code_entry) {
+// is_aot_code = true implies loading compiled code from AOT code cache
+bool ciEnv::is_compilation_valid(JavaThread* thread, ciMethod* target, bool install_code, bool is_aot_code, bool preload) {
   methodHandle method(thread, target->get_Method());
 
   // We require method counters to store some method state (max compilation levels) required by the compilation policy.
   if (!preload && method->get_method_counters(thread) == nullptr) {
     record_failure("can't create method counters");
-    if (code_buffer != nullptr) {
-      code_buffer->free_blob();
-    }
     return false;
-  }
-
-  if (aot_code_entry != nullptr) {
-    // Invalid compilation states:
-    //  - AOTCodeCache is closed, AOTCode entry is garbage.
-    //  - AOTCode entry indicates this shared code was marked invalid while it was loaded.
-    if (!AOTCodeCache::is_on() || aot_code_entry->not_entrant()) {
-      return false;
-    }
   }
 
   // Change in Jvmti state may invalidate compilation.
@@ -1022,7 +1010,7 @@ bool ciEnv::is_compilation_valid(JavaThread* thread, ciMethod* target, bool prel
     record_failure("method holder is in error state");
   }
 
-  if (!failing() && (aot_code_entry == nullptr)) {
+  if (!failing() && !is_aot_code) {
     if (log() != nullptr) {
       // Log the dependencies which this compilation declares.
       dependencies()->log_all_dependencies();
@@ -1047,10 +1035,6 @@ bool ciEnv::is_compilation_valid(JavaThread* thread, ciMethod* target, bool prel
     MethodData* mdo = method()->method_data();
     if (mdo != nullptr && _inc_decompile_count_on_failure) {
       mdo->inc_decompile_count();
-    }
-
-    if (code_buffer != nullptr) {
-      code_buffer->free_blob();
     }
     return false;
   }
@@ -1150,7 +1134,12 @@ nmethod* ciEnv::register_aot_method(JavaThread* thread,
     MutexLocker ml(Compile_lock);
     NoSafepointVerifier nsv;
 
-    if (!is_compilation_valid(thread, target, preload, true /*install_code*/, nullptr /*code_buffer*/, aot_code_entry)) {
+    // AOTCode entry indicates this shared code was marked invalid while it was loaded.
+    if (aot_code_entry->not_entrant()) {
+      return nullptr;
+    }
+
+    if (!is_compilation_valid(thread, target, true /*install_code*/, true, preload)) {
       return nullptr;
     }
 
@@ -1205,13 +1194,11 @@ void ciEnv::register_method(ciMethod* target,
                             bool has_monitors,
                             bool has_scoped_access,
                             int immediate_oops_patched,
-                            bool install_code,
-                            AOTCodeEntry* aot_code_entry) {
+                            bool install_code) {
   VM_ENTRY_MARK;
   nmethod* nm = nullptr;
   {
     methodHandle method(THREAD, target->get_Method());
-    bool preload = task()->preload(); // Code is preloaded before Java method execution
 
     // Check if memory should be freed before allocation
     CodeCache::gc_on_allocation();
@@ -1225,7 +1212,8 @@ void ciEnv::register_method(ciMethod* target,
     MutexLocker ml(Compile_lock);
     NoSafepointVerifier nsv;
 
-    if (!is_compilation_valid(THREAD, target, preload, install_code, code_buffer, aot_code_entry)) {
+    if (!is_compilation_valid(THREAD, target, install_code, /*aot_code_entry*/ false, /*preload*/ false)) {
+      code_buffer->free_blob();
       return;
     }
 
@@ -1241,8 +1229,7 @@ void ciEnv::register_method(ciMethod* target,
                                  debug_info(), dependencies(), code_buffer,
                                  frame_words, oop_map_set,
                                  handler_table, inc_table,
-                                 compiler, CompLevel(task()->comp_level()),
-                                 aot_code_entry);
+                                 compiler, CompLevel(task()->comp_level()));
     }
     // Free codeBlobs
     code_buffer->free_blob();
@@ -1252,17 +1239,17 @@ void ciEnv::register_method(ciMethod* target,
       nm->set_has_wide_vectors(has_wide_vectors);
       nm->set_has_monitors(has_monitors);
       nm->set_has_scoped_access(has_scoped_access);
-      nm->set_preloaded(preload);
+      nm->set_preloaded(false);
       nm->set_has_clinit_barriers(has_clinit_barriers);
       assert(!method->is_synchronized() || nm->has_monitors(), "");
 
       if (task()->is_precompile()) {
-        aot_code_entry = AOTCodeCache::store_nmethod(nm, compiler, for_preload);
+        AOTCodeEntry* aot_code_entry = AOTCodeCache::store_nmethod(nm, compiler, for_preload);
         if (aot_code_entry != nullptr) {
           aot_code_entry->set_inlined_bytecodes(num_inlined_bytecodes());
         }
       }
-      make_code_usable(THREAD, target, preload, entry_bci, aot_code_entry, nm);
+      make_code_usable(THREAD, target, /* preload */ false, entry_bci, /* aot_code_entry */ nullptr, nm);
     }
   }
 

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -296,7 +296,7 @@ private:
 
   // Helper rountimes to factor out common code used by routines that register a method
   // i.e. register_aot_method() and register_method()
-  bool is_compilation_valid(JavaThread* thread, ciMethod* target, bool preload, bool install_code, CodeBuffer* code_buffer, AOTCodeEntry* aot_code_entry);
+  bool is_compilation_valid(JavaThread* thread, ciMethod* target, bool install_code, bool is_aot_code, bool preload);
   void make_code_usable(JavaThread* thread, ciMethod* target, bool preload, int entry_bci, AOTCodeEntry* aot_code_entry, nmethod* nm);
 
 public:
@@ -403,8 +403,7 @@ public:
                        bool                      has_monitors,
                        bool                      has_scoped_access,
                        int                       immediate_oops_patched,
-                       bool                      install_code,
-                       AOTCodeEntry*             entry = nullptr);
+                       bool                      install_code);
 
   // Access to certain well known ciObjects.
 #define VM_CLASS_FUNC(name, ignore_s) \

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1168,7 +1168,6 @@ nmethod* nmethod::new_nmethod(const methodHandle& method,
   ImplicitExceptionTable* nul_chk_table,
   AbstractCompiler* compiler,
   CompLevel comp_level
-  , AOTCodeEntry* aot_code_entry
 #if INCLUDE_JVMCI
   , char* speculations,
   int speculations_len,
@@ -1212,7 +1211,7 @@ nmethod* nmethod::new_nmethod(const methodHandle& method,
     nmethod(method(), compiler->type(), nmethod_size, immutable_data_size, mutable_data_size,
             compile_id, entry_bci, immutable_data, offsets, orig_pc_offset,
             debug_info, dependencies, code_buffer, frame_size, oop_maps,
-            handler_table, nul_chk_table, compiler, comp_level, aot_code_entry
+            handler_table, nul_chk_table, compiler, comp_level
 #if INCLUDE_JVMCI
             , speculations,
             speculations_len,
@@ -1541,7 +1540,6 @@ nmethod::nmethod(
   ImplicitExceptionTable* nul_chk_table,
   AbstractCompiler* compiler,
   CompLevel comp_level
-  , AOTCodeEntry* aot_code_entry
 #if INCLUDE_JVMCI
   , char* speculations,
   int speculations_len,
@@ -1561,7 +1559,7 @@ nmethod::nmethod(
     assert_locked_or_safepoint(CodeCache_lock);
 
     init_defaults(code_buffer, offsets);
-    _aot_code_entry          = aot_code_entry;
+    _aot_code_entry          = nullptr; // runtime compiled nmethod does not have AOTCodeEntry
     _method_profiling_count  = 0;
 
     _osr_entry_point = code_begin() + offsets->value(CodeOffsets::OSR_Entry);

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -339,7 +339,6 @@ class nmethod : public CodeBlob {
           ImplicitExceptionTable* nul_chk_table,
           AbstractCompiler* compiler,
           CompLevel comp_level
-          , AOTCodeEntry* aot_code_entry
 #if INCLUDE_JVMCI
           , char* speculations = nullptr,
           int speculations_len = 0,
@@ -602,7 +601,6 @@ public:
                               ImplicitExceptionTable* nul_chk_table,
                               AbstractCompiler* compiler,
                               CompLevel comp_level
-                              , AOTCodeEntry* aot_code_entry
 #if INCLUDE_JVMCI
                               , char* speculations = nullptr,
                               int speculations_len = 0,

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -2168,7 +2168,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
                                  debug_info, dependencies, code_buffer,
                                  frame_words, oop_map_set,
                                  handler_table, implicit_exception_table,
-                                 compiler, comp_level, nullptr /* AOTCodeEntry */,
+                                 compiler, comp_level,
                                  speculations, speculations_len, data);
 
 


### PR DESCRIPTION
Removed unused parameter `aot_code_entry` in `ciEnv::register_method`.
Removed `preload` local variable in `ciEnv::register_method` as it is always false.
Refactored `ciEnv::is_compilation_valid` a bit.