### PR TITLE
8368811: [Leyden] Use AOTRuntimeConstants table for card_table::_byte_map_base

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -4616,19 +4616,6 @@ operand immP_1()
   interface(CONST_INTER);
 %}
 
-// Card Table Byte Map Base
-operand immByteMapBase()
-%{
-  // Get base of card map
-  predicate(BarrierSet::barrier_set()->is_a(BarrierSet::CardTableBarrierSet) &&
-            is_card_table_address((address)(n->get_ptr())));
-  match(ConP);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
 // AOT Runtime Constants Address
 operand immAOTRuntimeConstantsAddress()
 %{
@@ -7000,22 +6987,6 @@ instruct loadConP1(iRegPNoSp dst, immP_1 con)
   format %{ "mov  $dst, $con\t# nullptr ptr" %}
 
   ins_encode(aarch64_enc_mov_p1(dst, con));
-
-  ins_pipe(ialu_imm);
-%}
-
-// Load Byte Map Base Constant
-
-instruct loadByteMapBase(iRegPNoSp dst, immByteMapBase con)
-%{
-  match(Set dst con);
-
-  ins_cost(INSN_COST);
-  format %{ "adr  $dst, $con\t# Byte Map Base" %}
-
-  ins_encode %{
-    __ load_byte_map_base($dst$$Register);
-  %}
 
   ins_pipe(ialu_imm);
 %}

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -527,18 +527,13 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
 
     case T_LONG: {
       assert(patch_code == lir_patch_none, "no patching handled here");
+#if INCLUDE_CDS
       if (AOTCodeCache::is_on_for_dump()) {
-        // AOT code needs relocation info for card table base
         address b = c->as_pointer();
-        if (is_card_table_address(b)) {
-          __ lea(dest->as_register_lo(), ExternalAddress(b));
-          break;
-        }
         if (b == (address)ThreadIdentifier::unsafe_offset()) {
           __ lea(dest->as_register_lo(), ExternalAddress(b));
           break;
         }
-#if INCLUDE_CDS
         if (AOTRuntimeConstants::contains(b)) {
           __ load_aotrc_address(dest->as_register_lo(), b);
           break;

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5786,21 +5786,20 @@ void MacroAssembler::adrp(Register reg1, const Address &dest, uint64_t &byte_off
 }
 
 void MacroAssembler::load_byte_map_base(Register reg) {
+#if INCLUDE_CDS
+  if (AOTCodeCache::is_on_for_dump()) {
+    address byte_map_base_adr = AOTRuntimeConstants::card_table_address();
+    lea(reg, ExternalAddress(byte_map_base_adr));
+    ldr(reg, Address(reg));
+    return;
+  }
+#endif
   CardTable::CardValue* byte_map_base =
     ((CardTableBarrierSet*)(BarrierSet::barrier_set()))->card_table()->byte_map_base();
 
   // Strictly speaking the byte_map_base isn't an address at all, and it might
   // even be negative. It is thus materialised as a constant.
-#if INCLUDE_CDS
-  if (AOTCodeCache::is_on_for_dump()) {
-    // AOT code needs relocation info for card table base
-    lea(reg, ExternalAddress(reinterpret_cast<address>(byte_map_base)));
-  } else {
-#endif
-    mov(reg, (uint64_t)byte_map_base);
-#if INCLUDE_CDS
-  }
-#endif
+  mov(reg, (uint64_t)byte_map_base);
 }
 
 void MacroAssembler::load_aotrc_address(Register reg, address a) {

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -131,6 +131,13 @@ constexpr Register rscratch2 = r11;  // volatile
 constexpr Register r12_heapbase = r12; // callee-saved
 constexpr Register r15_thread   = r15; // callee-saved
 
+// return a register that differs from reg1, reg2, reg3, reg4
+inline Register pick_different_reg(Register reg1, Register reg2, Register reg3, Register reg4) {
+  RegSet available = (RegSet::of(rscratch1, rscratch2, rax, rbx) + rdx -
+                      RegSet::of(reg1, reg2, reg3, reg4));
+  return *(available.begin());
+}
+
 // JSR 292
 // On x86, the SP does not have to be saved when invoking method handle intrinsics
 // or compiled lambda forms. We indicate that by setting rbp_mh_SP_save to noreg.

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -530,18 +530,13 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
 
     case T_LONG: {
       assert(patch_code == lir_patch_none, "no patching handled here");
+#if INCLUDE_CDS
       if (AOTCodeCache::is_on_for_dump()) {
-        // AOTCodeCache needs relocation info for card table base
         address b = c->as_pointer();
-        if (is_card_table_address(b)) {
-          __ lea(dest->as_register_lo(), ExternalAddress(b));
-          break;
-        }
         if (b == (address)ThreadIdentifier::unsafe_offset()) {
           __ lea(dest->as_register_lo(), ExternalAddress(b));
           break;
         }
-#if INCLUDE_CDS
         if (AOTRuntimeConstants::contains(b)) {
           __ load_aotrc_address(dest->as_register_lo(), b);
           break;

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2524,6 +2524,24 @@ void MacroAssembler::shrptr(Register dst, int imm8) {
   shrq(dst, imm8);
 }
 
+void MacroAssembler::shrptr_aotrc(Register reg, Register save, address adr) {
+#if INCLUDE_CDS
+  precond(AOTCodeCache::is_on_for_dump());
+  // all aotrc field addresses should be registered in the AOTCodeCache address table
+  assert(AOTRuntimeConstants::contains(adr), "address out of range for data area");
+  push_ppx(save);
+  movptr(save, reg); // reg could be rcx
+  push_ppx(rcx);
+  mov32(rcx, ExternalAddress(adr));
+  shrptr(save);
+  pop_ppx(rcx);
+  movptr(reg, save);
+  pop_ppx(save);
+#else
+  ShouldNotCallThis();
+#endif
+}
+
 void MacroAssembler::sign_extend_byte(Register reg) {
   movsbl(reg, reg); // movsxb
 }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -817,6 +817,8 @@ public:
   void shrptr(Register dst, int32_t shift);
   void shrptr(Register dst) { shrq(dst); }
 
+  void shrptr_aotrc(Register reg, Register save, address adr);
+
   void sarptr(Register dst) { sarq(dst); }
   void sarptr(Register dst, int32_t src) { sarq(dst, src); }
 

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -337,17 +337,6 @@ void AOTCodeCache::init2() {
     return;
   }
   // After Universe initialized
-  BarrierSet* bs = BarrierSet::barrier_set();
-  if (bs->is_a(BarrierSet::CardTableBarrierSet)) {
-    address byte_map_base = ci_card_table_address_as<address>();
-    if (is_on_for_dump() && !external_word_Relocation::can_be_relocated(byte_map_base)) {
-      // Bail out since we can't encode card table base address with relocation
-      log_warning(aot, codecache, init)("Can't create AOT Code Cache because card table base address is not relocatable: " INTPTR_FORMAT, p2i(byte_map_base));
-      close();
-      report_load_failure();
-      return;
-    }
-  }
   if (!opened_cache->verify_config_on_use()) { // Check on AOT code loading
     delete opened_cache;
     opened_cache = nullptr;
@@ -3043,13 +3032,6 @@ void AOTCodeAddressTable::init_extrs() {
 #endif
   }
 #endif // COMPILER2
-
-  // Record addresses of VM runtime methods and data structs
-  BarrierSet* bs = BarrierSet::barrier_set();
-  if (bs->is_a(BarrierSet::CardTableBarrierSet)) {
-    SET_ADDRESS(_extrs, ci_card_table_address_as<address>());
-  }
-
 #if INCLUDE_G1GC
   SET_ADDRESS(_extrs, G1BarrierSetRuntime::write_ref_field_post_entry);
   SET_ADDRESS(_extrs, G1BarrierSetRuntime::write_ref_field_pre_entry);
@@ -3725,13 +3707,7 @@ int AOTCodeAddressTable::id_for_address(address addr, RelocIterator reloc, CodeB
   }
   // Check card_table_base address first since it can point to any address
   BarrierSet* bs = BarrierSet::barrier_set();
-  if (bs->is_a(BarrierSet::CardTableBarrierSet)) {
-    if (addr == ci_card_table_address_as<address>()) {
-      id = search_address(addr, _extrs_addr, _extrs_length);
-      assert(id > 0 && _extrs_addr[id - _extrs_base] == addr, "sanity");
-      return id;
-    }
-  }
+  guarantee(!bs->is_a(BarrierSet::CardTableBarrierSet) || addr != ci_card_table_address_as<address>(), "sanity");
 
   // Seach for C string
   id = id_for_C_string(addr);
@@ -3828,18 +3804,20 @@ int AOTCodeAddressTable::id_for_address(address addr, RelocIterator reloc, CodeB
 #undef _C2_blobs_base
 #undef _blobs_end
 
+AOTRuntimeConstants AOTRuntimeConstants::_aot_runtime_constants;
+
 void AOTRuntimeConstants::initialize_from_runtime() {
   BarrierSet* bs = BarrierSet::barrier_set();
   if (bs->is_a(BarrierSet::CardTableBarrierSet)) {
-    CardTableBarrierSet* ctbs = ((CardTableBarrierSet*)bs);
+    CardTableBarrierSet* ctbs = barrier_set_cast<CardTableBarrierSet>(bs);
+    _aot_runtime_constants._card_table_address = ci_card_table_address_as<address>();
     _aot_runtime_constants._grain_shift = ctbs->grain_shift();
     _aot_runtime_constants._card_shift = ctbs->card_shift();
   }
 }
 
-AOTRuntimeConstants AOTRuntimeConstants::_aot_runtime_constants;
-
 address AOTRuntimeConstants::_field_addresses_list[] = {
+  card_table_address(),
   grain_shift_address(),
   card_shift_address(),
   nullptr

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -831,8 +831,9 @@ public:
 class AOTRuntimeConstants {
  friend class AOTCodeCache;
  private:
-  uint _grain_shift;
-  uint _card_shift;
+  address _card_table_address;
+  uint    _grain_shift;
+  uint    _card_shift;
   static address _field_addresses_list[];
   static AOTRuntimeConstants _aot_runtime_constants;
   // private constructor for unique singleton
@@ -846,6 +847,7 @@ class AOTRuntimeConstants {
     address hi = base + sizeof(AOTRuntimeConstants);
     return (base <= adr && adr < hi);
   }
+  static address card_table_address() { return (address)&_aot_runtime_constants._card_table_address; }
   static address grain_shift_address() { return (address)&_aot_runtime_constants._grain_shift; }
   static address card_shift_address() { return (address)&_aot_runtime_constants._card_shift; }
   static address* field_addresses_list() {
@@ -853,6 +855,7 @@ class AOTRuntimeConstants {
   }
 #else
   static bool contains(address adr)      { return false; }
+  static address card_table_address()    { return nullptr; }
   static address grain_shift_address()   { return nullptr; }
   static address card_shift_address()    { return nullptr; }
   static address* field_addresses_list() { return nullptr; }

--- a/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.hpp
@@ -27,6 +27,8 @@
 
 #include "gc/shared/c2/modRefBarrierSetC2.hpp"
 
+class IdealKit;
+
 class CardTableBarrierSetC2: public ModRefBarrierSetC2 {
 protected:
   virtual void post_barrier(GraphKit* kit,
@@ -35,7 +37,8 @@ protected:
                             Node* val,
                             bool use_precise) const;
 
-  Node* byte_map_base_node(GraphKit* kit) const;
+  Node* card_shift_node(IdealKit* kit) const;
+  Node* byte_map_base_node(IdealKit* kit) const;
 
 public:
   virtual void eliminate_gc_barrier(PhaseMacroExpand* macro, Node* node) const;

--- a/src/hotspot/share/opto/idealKit.cpp
+++ b/src/hotspot/share/opto/idealKit.cpp
@@ -360,6 +360,17 @@ Node* IdealKit::load(Node* ctl,
   return transform(ld);
 }
 
+// Load AOT runtime constant
+Node* IdealKit::load_aot_const(Node* adr, const Type* t) {
+  BasicType bt = t->basic_type();
+  const TypePtr* adr_type = nullptr; // debug-mode-only argument
+  DEBUG_ONLY(adr_type = C->get_adr_type(Compile::AliasIdxRaw));
+  Node* ctl = (Node*)C->root(); // Raw memory access needs control
+  Node* ld = LoadNode::make(_gvn, ctl, C->immutable_memory(), adr, adr_type, t, bt, MemNode::unordered,
+                            LoadNode::DependsOnlyOnTest, false, false, false, false, 0);
+  return transform(ld);
+}
+
 Node* IdealKit::store(Node* ctl, Node* adr, Node *val, BasicType bt,
                       int adr_idx,
                       MemNode::MemOrd mo, bool require_atomic_access,

--- a/src/hotspot/share/opto/idealKit.hpp
+++ b/src/hotspot/share/opto/idealKit.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -223,6 +223,9 @@ class IdealKit: public StackObj {
              bool require_atomic_access = false,
              MemNode::MemOrd mo = MemNode::unordered,
              LoadNode::ControlDependency control_dependency = LoadNode::DependsOnlyOnTest);
+
+  // Load AOT runtime constant
+  Node* load_aot_const(Node* adr, const Type* t);
 
   // Return the new StoreXNode
   Node* store(Node* ctl,


### PR DESCRIPTION
Currently we use `Relocation` info to patch `card_table::_byte_map_base` referenced in compiled code. This is not completely correct since this is not address. We currently have special check in `AOTCodeCache::init2()` to skip AOT code generation and usage if `byte_map_base` is not relocatable [aotCodeCache.cpp#L341](https://github.com/openjdk/leyden/blob/premain/src/hotspot/share/code/aotCodeCache.cpp#L341)

To avoid this we should use existing `AOTRuntimeConstants` table to load `byte_map_base` from it.

I also added few missing loads `card_shift` from `AOTRuntimeConstants` table. Actually I am not sure why we have it in `AOTRuntimeConstants` table.  From what I see, it is based on `GCCardSizeInBytes` flag [cardTable.cpp#L46](https://github.com/openjdk/leyden/blob/premain/src/hotspot/share/gc/shared/cardTable.cpp#L46) and never modified. The flags is not adjusted ergonomically.  So we can simple record the flag in AOT code configuration and verify it when loading AOT code. 

@adinn  what do you think about `card_shift` in `AOTRuntimeConstants` table? You added it there.

Changes were testing tier1-5.