### PR TITLE
Experiment with storing target method for static and opt-virtual callsites in reloc info

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -119,6 +119,22 @@ AddressLiteral::AddressLiteral(address target, relocInfo::relocType rtype) {
   }
 }
 
+AddressLiteral::AddressLiteral(address target, relocInfo::relocType rtype, int method_index, bool is_mhi) {
+  _is_lval = false;
+  _target = target;
+  switch (rtype) {
+  case relocInfo::opt_virtual_call_type:
+    _rspec = opt_virtual_call_Relocation::spec(method_index, is_mhi);
+    break;
+  case relocInfo::static_call_type:
+    _rspec = static_call_Relocation::spec(method_index, is_mhi);
+    break;
+  default:
+    ShouldNotReachHere();
+    break;
+  }
+}
+
 // Implementation of Address
 
 Address Address::make_array(ArrayAddress adr) {

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -355,6 +355,7 @@ class AddressLiteral {
 
 
   AddressLiteral(address target, relocInfo::relocType rtype);
+  AddressLiteral(address target, relocInfo::relocType rtype, int method_index, bool is_mhi);
 
   AddressLiteral(address target, RelocationHolder const& rspec)
     : _rspec(rspec),

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -958,8 +958,8 @@ void MacroAssembler::call(AddressLiteral entry, Register rscratch) {
   }
 }
 
-void MacroAssembler::ic_call(address entry, jint method_index) {
-  RelocationHolder rh = virtual_call_Relocation::spec(pc(), method_index);
+void MacroAssembler::ic_call(address entry, jint method_index, bool is_mhi) {
+  RelocationHolder rh = virtual_call_Relocation::spec(pc(), method_index, is_mhi);
   // Needs full 64-bit immediate for later patching.
   mov64(rax, (int64_t)Universe::non_oop_word());
   call(AddressLiteral(entry, rh));

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -891,7 +891,7 @@ public:
   void call(AddressLiteral entry, Register rscratch = rax);
 
   // Emit the CompiledIC call idiom
-  void ic_call(address entry, jint method_index = 0);
+  void ic_call(address entry, jint method_index = 0, bool is_mhi = false);
   static int ic_check_size();
   int ic_check(int end_alignment);
 

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -4515,8 +4515,8 @@ encode %{
       __ block_comment("call JVM_EnsureMaterializedForStackWalk (elided)");
     } else {
       int method_index = resolved_method_index(masm);
-      RelocationHolder rspec = _optimized_virtual ? opt_virtual_call_Relocation::spec(method_index)
-                                                  : static_call_Relocation::spec(method_index);
+      RelocationHolder rspec = _optimized_virtual ? opt_virtual_call_Relocation::spec(method_index, is_mhi())
+                                                  : static_call_Relocation::spec(method_index, is_mhi());
       address mark = __ pc();
       int call_offset = __ offset();
       __ call(AddressLiteral(CAST_FROM_FN_PTR(address, $meth$$method), rspec));
@@ -4538,7 +4538,7 @@ encode %{
   %}
 
   enc_class Java_Dynamic_Call(method meth) %{
-    __ ic_call((address)$meth$$method, resolved_method_index(masm));
+    __ ic_call((address)$meth$$method, resolved_method_index(masm), is_mhi());
     __ post_call_nop();
   %}
 

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2211,7 +2211,7 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
     }
   }
 
-  Invoke* result = new Invoke(code, result_type, recv, args, target, state_before);
+  Invoke* result = new Invoke(code, result_type, recv, args, target, state_before, cha_monomorphic_target);
   // push result
   append_split(result);
 

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -322,12 +322,13 @@ void BlockBegin::state_values_do(ValueVisitor* f) {
 
 
 Invoke::Invoke(Bytecodes::Code code, ValueType* result_type, Value recv, Values* args,
-               ciMethod* target, ValueStack* state_before)
+               ciMethod* target, ValueStack* state_before, ciMethod* cha_monomorphic_target)
   : StateSplit(result_type, state_before)
   , _code(code)
   , _recv(recv)
   , _args(args)
   , _target(target)
+  , _cha_monomorphic_target(cha_monomorphic_target)
 {
   set_flag(TargetIsLoadedFlag,   target->is_loaded());
   set_flag(TargetIsFinalFlag,    target_is_loaded() && target->is_final_method());

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1222,11 +1222,12 @@ LEAF(Invoke, StateSplit)
   Values*         _args;
   BasicTypeList*  _signature;
   ciMethod*       _target;
+  ciMethod*       _cha_monomorphic_target;
 
  public:
   // creation
   Invoke(Bytecodes::Code code, ValueType* result_type, Value recv, Values* args,
-         ciMethod* target, ValueStack* state_before);
+         ciMethod* target, ValueStack* state_before, ciMethod* cha_monomorphic_target = nullptr);
 
   // accessors
   Bytecodes::Code code() const                   { return _code; }
@@ -1236,6 +1237,7 @@ LEAF(Invoke, StateSplit)
   Value argument_at(int i) const                 { return _args->at(i); }
   BasicTypeList* signature() const               { return _signature; }
   ciMethod* target() const                       { return _target; }
+  ciMethod* cha_monomorphic_target() const       { return _cha_monomorphic_target; }
 
   ciType* declared_type() const;
 

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -1176,15 +1176,17 @@ class LIR_OpJavaCall: public LIR_OpCall {
  private:
   ciMethod* _method;
   LIR_Opr   _receiver;
+  ciMethod* _cha_monomorphic_target;
 
  public:
   LIR_OpJavaCall(LIR_Code code, ciMethod* method,
                  LIR_Opr receiver, LIR_Opr result,
                  address addr, LIR_OprList* arguments,
-                 CodeEmitInfo* info)
+                 CodeEmitInfo* info, ciMethod* cha_monomorphic_target = nullptr)
   : LIR_OpCall(code, addr, result, arguments, info)
   , _method(method)
   , _receiver(receiver)
+  , _cha_monomorphic_target(cha_monomorphic_target)
   { assert(is_in_range(code, begin_opJavaCall, end_opJavaCall), "code check"); }
 
   LIR_OpJavaCall(LIR_Code code, ciMethod* method,
@@ -1197,6 +1199,7 @@ class LIR_OpJavaCall: public LIR_OpCall {
 
   LIR_Opr receiver() const                       { return _receiver; }
   ciMethod* method() const                       { return _method;   }
+  ciMethod* cha_monomorphic_target() const       { return _cha_monomorphic_target; }
 
   // JSR 292 support.
   bool is_invokedynamic() const                  { return code() == lir_dynamic_call; }
@@ -2100,8 +2103,8 @@ class LIR_List: public CompilationResourceObj {
   //---------- instructions -------------
   void call_opt_virtual(ciMethod* method, LIR_Opr receiver, LIR_Opr result,
                         address dest, LIR_OprList* arguments,
-                        CodeEmitInfo* info) {
-    append(new LIR_OpJavaCall(lir_optvirtual_call, method, receiver, result, dest, arguments, info));
+                        CodeEmitInfo* info, ciMethod* cha_monomorphic_target) {
+    append(new LIR_OpJavaCall(lir_optvirtual_call, method, receiver, result, dest, arguments, info, cha_monomorphic_target));
   }
   void call_static(ciMethod* method, LIR_Opr result,
                    address dest, LIR_OprList* arguments, CodeEmitInfo* info) {

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -2741,7 +2741,7 @@ void LIRGenerator::do_Invoke(Invoke* x) {
       if (x->code() == Bytecodes::_invokespecial || x->target_is_final()) {
         __ call_opt_virtual(target, receiver, result_register,
                             SharedRuntime::get_resolve_opt_virtual_call_stub(),
-                            arg_list, info);
+                            arg_list, info, x->cha_monomorphic_target());
       } else {
         __ call_icvirtual(target, receiver, result_register,
                           SharedRuntime::get_resolve_virtual_call_stub(),

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -927,8 +927,8 @@ public:
 
   bool has_evol_metadata();
 
-  Method* attached_method(address call_pc);
-  Method* attached_method_before_pc(address pc);
+  Method* attached_method(address call_pc, bool& is_mhi);
+  Method* attached_method_before_pc(address pc, bool& is_mhi);
 
   // GC unloading support
   // Cleans unloaded klasses and unloaded nmethods in inline caches

--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -645,8 +645,8 @@ address virtual_call_Relocation::cached_value() {
 Method* virtual_call_Relocation::method_value() {
   nmethod* nm = code();
   if (nm == nullptr) return (Method*)nullptr;
-  Metadata* m = nm->metadata_at(_method_index);
-  assert(m != nullptr || _method_index == 0, "should be non-null for non-zero index");
+  Metadata* m = nm->metadata_at(method_index());
+  assert(m != nullptr || method_index() == 0, "should be non-null for non-zero index");
   assert(m == nullptr || m->is_method(), "not a method");
   return (Method*)m;
 }
@@ -671,8 +671,8 @@ void opt_virtual_call_Relocation::unpack_data() {
 Method* opt_virtual_call_Relocation::method_value() {
   nmethod* nm = code();
   if (nm == nullptr) return (Method*)nullptr;
-  Metadata* m = nm->metadata_at(_method_index);
-  assert(m != nullptr || _method_index == 0, "should be non-null for non-zero index");
+  Metadata* m = nm->metadata_at(method_index());
+  assert(m != nullptr || method_index() == 0, "should be non-null for non-zero index");
   assert(m == nullptr || m->is_method(), "not a method");
   return (Method*)m;
 }
@@ -701,8 +701,8 @@ address opt_virtual_call_Relocation::static_stub() {
 Method* static_call_Relocation::method_value() {
   nmethod* nm = code();
   if (nm == nullptr) return (Method*)nullptr;
-  Metadata* m = nm->metadata_at(_method_index);
-  assert(m != nullptr || _method_index == 0, "should be non-null for non-zero index");
+  Metadata* m = nm->metadata_at(method_index());
+  assert(m != nullptr || method_index() == 0, "should be non-null for non-zero index");
   assert(m == nullptr || m->is_method(), "not a method");
   return (Method*)m;
 }

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -157,6 +157,9 @@ JVMState* DirectCallGenerator::generate(JVMState* jvms) {
     // to the call site to make resolution logic work
     // (see SharedRuntime::resolve_static_call_C).
     call->set_override_symbolic_info(true);
+    call->set_mhi(true);
+  } else if (!method()->is_method_handle_intrinsic()) {
+    call->set_override_symbolic_info(true);
   }
   _call_node = call;  // Save the call node in case we need it later
   if (!is_static) {
@@ -265,6 +268,7 @@ JVMState* VirtualCallGenerator::generate(JVMState* jvms) {
     // about the method being invoked should be attached to the call site to
     // make resolution logic work (see SharedRuntime::resolve_{virtual,opt_virtual}_call_C).
     call->set_override_symbolic_info(true);
+    call->set_mhi(true);
   }
   _call_node = call;  // Save the call node in case we need it later
 

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -777,6 +777,7 @@ protected:
   virtual uint size_of() const; // Size is bigger
 
   ciMethod* _method;               // Method being direct called
+  bool    _is_mhi;
   bool    _optimized_virtual;
   bool    _override_symbolic_info; // Override symbolic call site info from bytecode
   bool    _arg_escape;             // ArgEscape in parameter list
@@ -784,6 +785,7 @@ public:
   CallJavaNode(const TypeFunc* tf , address addr, ciMethod* method)
     : CallNode(tf, addr, TypePtr::BOTTOM),
       _method(method),
+      _is_mhi(false),
       _optimized_virtual(false),
       _override_symbolic_info(false),
       _arg_escape(false)
@@ -794,6 +796,8 @@ public:
   virtual int   Opcode() const;
   ciMethod* method() const                 { return _method; }
   void  set_method(ciMethod *m)            { _method = m; }
+  void  set_mhi(bool f)                    { _is_mhi = f; }
+  bool  is_mhi() const                     { return _is_mhi; }
   void  set_optimized_virtual(bool f)      { _optimized_virtual = f; }
   bool  is_optimized_virtual() const       { return _optimized_virtual; }
   void  set_override_symbolic_info(bool f) { _override_symbolic_info = f; }

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4713,6 +4713,9 @@ LibraryCallKit::generate_method_call(vmIntrinsicID method_id, bool is_virtual, b
     // about the method being invoked should be attached to the call site to
     // make resolution logic work (see SharedRuntime::resolve_{virtual,opt_virtual}_call_C).
     slow_call->set_override_symbolic_info(true);
+    slow_call->set_mhi(true);
+  } else if (!method->is_method_handle_intrinsic() && (is_static || !is_virtual)) {
+    slow_call->set_override_symbolic_info(true);
   }
   set_arguments_for_java_call(slow_call);
   set_edges_for_java_call(slow_call);

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -958,6 +958,7 @@ protected:
   virtual uint size_of() const; // Size is bigger
 public:
   ciMethod* _method;                 // Method being direct called
+  bool      _is_mhi;                  // Tells if node is a call to method handle intrinsic
   bool      _override_symbolic_info; // Override symbolic call site info from bytecode
   bool      _optimized_virtual;      // Tells if node is a static call or an optimized virtual
   bool      _arg_escape;             // ArgEscape in parameter list
@@ -966,7 +967,7 @@ public:
   }
 
   virtual const RegMask &in_RegMask(uint) const;
-
+  bool is_mhi() const { return _is_mhi; }
   int resolved_method_index(C2_MacroAssembler *masm) const {
     if (_override_symbolic_info) {
       // Attach corresponding Method* to the call site, so VM can use it during resolution

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -1216,6 +1216,7 @@ MachNode *Matcher::match_sfpt( SafePointNode *sfpt ) {
       assert(call_java->validate_symbolic_info(), "inconsistent info");
       method = call_java->method();
       mcall_java->_method = method;
+      mcall_java->_is_mhi = call_java->is_mhi();
       mcall_java->_optimized_virtual = call_java->is_optimized_virtual();
       mcall_java->_override_symbolic_info = call_java->override_symbolic_info();
       mcall_java->_arg_escape = call_java->arg_escape();

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -48,10 +48,12 @@
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "metaprogramming/primitiveConversions.hpp"
+#include "oops/constantPool.inline.hpp"
 #include "oops/klass.hpp"
 #include "oops/method.inline.hpp"
 #include "oops/objArrayKlass.hpp"
 #include "oops/oop.inline.hpp"
+#include "oops/resolvedMethodEntry.hpp"
 #include "prims/forte.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/jvmtiThreadState.hpp"
@@ -108,6 +110,9 @@ PerfTickCounters* SharedRuntime::_perf_resolve_virtual_total_time     = nullptr;
 PerfTickCounters* SharedRuntime::_perf_resolve_static_total_time      = nullptr;
 PerfTickCounters* SharedRuntime::_perf_handle_wrong_method_total_time = nullptr;
 PerfTickCounters* SharedRuntime::_perf_ic_miss_total_time             = nullptr;
+
+uint SharedRuntime::_perf_resolve_static_cache_hit_ctr = 0;
+uint SharedRuntime::_perf_resolve_opt_virtual_cache_hit_ctr = 0;
 
 #if 0
 // TODO tweak global stub name generation to match this
@@ -230,6 +235,11 @@ void SharedRuntime::print_counters_on(outputStream* st) {
 
     }
     st->cr();
+    st->print("  %-28s %5d", "perf_resolve_static_cache_hit_ctr:", _perf_resolve_static_cache_hit_ctr);
+    st->cr();
+    st->print("  %-28s %5d", "perf_resolve_opt_virtual_cache_hit_ctr:", _perf_resolve_opt_virtual_cache_hit_ctr);
+    st->cr();
+
   } else {
     st->print_cr("  no data (UsePerfData is turned off)");
   }
@@ -1279,7 +1289,7 @@ Handle SharedRuntime::find_callee_info(Bytecodes::Code& bc, CallInfo& callinfo, 
   // last java frame on stack (which includes native call frames)
   vframeStream vfst(current, true);  // Do not skip and javaCalls
 
-  return find_callee_info_helper(vfst, bc, callinfo, THREAD);
+  return find_callee_info_helper(vfst, bc, callinfo, nullptr, THREAD);
 }
 
 Method* SharedRuntime::extract_attached_method(vframeStream& vfst) {
@@ -1288,16 +1298,47 @@ Method* SharedRuntime::extract_attached_method(vframeStream& vfst) {
   address pc = vfst.frame_pc();
   { // Get call instruction under lock because another thread may be busy patching it.
     CompiledICLocker ic_locker(caller);
-    return caller->attached_method_before_pc(pc);
+    bool is_mhi;
+    return caller->attached_method_before_pc(pc, is_mhi);
   }
   return nullptr;
+}
+
+Method* SharedRuntime::extract_attached_method_if_mhi(vframeStream& vfst) {
+  nmethod* caller = vfst.nm();
+
+  address pc = vfst.frame_pc();
+  { // Get call instruction under lock because another thread may be busy patching it.
+    CompiledICLocker ic_locker(caller);
+    bool is_mhi;
+    Method* attached_method = caller->attached_method_before_pc(pc, is_mhi);
+    if (is_mhi) {
+      return attached_method;
+    }
+  }
+  return nullptr;
+}
+
+Method* SharedRuntime::extract_attached_method_if_mhi(nmethod* caller, address pc) {
+  CompiledICLocker ic_locker(caller);
+  bool is_mhi;
+  Method* attached_method = caller->attached_method_before_pc(pc, is_mhi);
+  if (is_mhi) {
+    return attached_method;
+  }
+  return nullptr;
+}
+
+Method* SharedRuntime::extract_attached_method(nmethod* caller, address pc, bool& is_mhi) {
+  CompiledICLocker ic_locker(caller);
+  return caller->attached_method_before_pc(pc, is_mhi);
 }
 
 // Finds receiver, CallInfo (i.e. receiver method), and calling bytecode
 // for a call current in progress, i.e., arguments has been pushed on stack
 // but callee has not been invoked yet.  Caller frame must be compiled.
 Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Code& bc,
-                                              CallInfo& callinfo, TRAPS) {
+                                              CallInfo& callinfo, Method* attached_method, TRAPS) {
   Handle receiver;
   Handle nullHandle;  // create a handy null handle for exception returns
   JavaThread* current = THREAD;
@@ -1318,31 +1359,32 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
   int bytecode_index = bytecode.index();
   bc = bytecode.invoke_code();
 
-  methodHandle attached_method(current, extract_attached_method(vfst));
-  if (attached_method.not_null()) {
+  methodHandle attached_method_h(current, attached_method);
+  if (attached_method_h.not_null()) {
     Method* callee = bytecode.static_target(CHECK_NH);
     vmIntrinsics::ID id = callee->intrinsic_id();
     // When VM replaces MH.invokeBasic/linkTo* call with a direct/virtual call,
     // it attaches statically resolved method to the call site.
     if (MethodHandles::is_signature_polymorphic(id) &&
         MethodHandles::is_signature_polymorphic_intrinsic(id)) {
+
       bc = MethodHandles::signature_polymorphic_intrinsic_bytecode(id);
 
       // Adjust invocation mode according to the attached method.
       switch (bc) {
         case Bytecodes::_invokevirtual:
-          if (attached_method->method_holder()->is_interface()) {
+          if (attached_method_h->method_holder()->is_interface()) {
             bc = Bytecodes::_invokeinterface;
           }
           break;
         case Bytecodes::_invokeinterface:
-          if (!attached_method->method_holder()->is_interface()) {
+          if (!attached_method_h->method_holder()->is_interface()) {
             bc = Bytecodes::_invokevirtual;
           }
           break;
         case Bytecodes::_invokehandle:
-          if (!MethodHandles::is_signature_polymorphic_method(attached_method())) {
-            bc = attached_method->is_static() ? Bytecodes::_invokestatic
+          if (!MethodHandles::is_signature_polymorphic_method(attached_method_h())) {
+            bc = attached_method_h->is_static() ? Bytecodes::_invokestatic
                                               : Bytecodes::_invokevirtual;
           }
           break;
@@ -1370,7 +1412,7 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
     // Caller-frame is a compiled frame
     frame callerFrame = stubFrame.sender(&reg_map2);
 
-    if (attached_method.is_null()) {
+    if (attached_method_h.is_null()) {
       Method* callee = bytecode.static_target(CHECK_NH);
       if (callee == nullptr) {
         THROW_(vmSymbols::java_lang_NoSuchMethodException(), nullHandle);
@@ -1387,9 +1429,9 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
   }
 
   // Resolve method
-  if (attached_method.not_null()) {
+  if (attached_method_h.not_null()) {
     // Parameterized by attached method.
-    LinkResolver::resolve_invoke(callinfo, receiver, attached_method, bc, CHECK_NH);
+    LinkResolver::resolve_invoke(callinfo, receiver, attached_method_h, bc, CHECK_NH);
   } else {
     // Parameterized by bytecode.
     constantPoolHandle constants(current, caller->constants());
@@ -1402,9 +1444,9 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
     assert(receiver.not_null(), "should have thrown exception");
     Klass* receiver_klass = receiver->klass();
     Klass* rk = nullptr;
-    if (attached_method.not_null()) {
+    if (attached_method_h.not_null()) {
       // In case there's resolved method attached, use its holder during the check.
-      rk = attached_method->method_holder();
+      rk = attached_method_h->method_holder();
     } else {
       // Klass is already loaded.
       constantPoolHandle constants(current, caller->constants());
@@ -1451,7 +1493,8 @@ methodHandle SharedRuntime::find_callee_method(TRAPS) {
   } else {
     Bytecodes::Code bc;
     CallInfo callinfo;
-    find_callee_info_helper(vfst, bc, callinfo, CHECK_(methodHandle()));
+    Method* attached_method = extract_attached_method_if_mhi(vfst);
+    find_callee_info_helper(vfst, bc, callinfo, attached_method, CHECK_(methodHandle()));
     callee_method = methodHandle(current, callinfo.selected_method());
   }
   assert(callee_method()->is_method(), "must be");
@@ -1462,6 +1505,7 @@ methodHandle SharedRuntime::find_callee_method(TRAPS) {
 methodHandle SharedRuntime::resolve_helper(bool is_virtual, bool is_optimized, TRAPS) {
   JavaThread* current = THREAD;
   ResourceMark rm(current);
+
   RegisterMap cbl_map(current,
                       RegisterMap::UpdateMap::skip,
                       RegisterMap::ProcessFrames::include,
@@ -1472,12 +1516,44 @@ methodHandle SharedRuntime::resolve_helper(bool is_virtual, bool is_optimized, T
   guarantee(caller_cb != nullptr && caller_cb->is_nmethod(), "must be called from compiled method");
   nmethod* caller_nm = caller_cb->as_nmethod();
 
+  Method* attached_method = nullptr;
+
+  // tracing/debugging/statistics
+  uint *addr = (is_optimized) ? (&_resolve_opt_virtual_ctr) :
+                 (is_virtual) ? (&_resolve_virtual_ctr) :
+                                (&_resolve_static_ctr);
+  AtomicAccess::inc(addr);
+
+  if (UseNewCode2) {
+    bool is_mhi;
+    attached_method = extract_attached_method(caller_nm, caller_frame.pc(), is_mhi);
+    if (attached_method != nullptr && !attached_method->is_abstract() && !is_mhi) {
+      if (!is_virtual || is_optimized) {
+        methodHandle callee_method(current, attached_method);
+        CompiledICLocker ml(caller_nm);
+        // Callsite is a direct call - set it to the destination method
+        CompiledDirectCall* callsite = CompiledDirectCall::before(caller_frame.pc());
+        callsite->set(callee_method);
+        if (!is_virtual) {
+          AtomicAccess::inc(&_perf_resolve_static_cache_hit_ctr);
+        } else if (is_optimized) {
+          AtomicAccess::inc(&_perf_resolve_opt_virtual_cache_hit_ctr);
+        }
+        return callee_method;
+      }
+    }
+  } else {
+    attached_method = extract_attached_method_if_mhi(caller_nm, caller_frame.pc());
+  }
+
   // determine call info & receiver
   // note: a) receiver is null for static calls
   //       b) an exception is thrown if receiver is null for non-static calls
   CallInfo call_info;
   Bytecodes::Code invoke_code = Bytecodes::_illegal;
-  Handle receiver = find_callee_info(invoke_code, call_info, CHECK_(methodHandle()));
+  // last java frame on stack (which includes native call frames)
+  vframeStream vfst(current, true);  // Do not skip and javaCalls
+  Handle receiver = find_callee_info_helper(vfst, invoke_code, call_info, attached_method, CHECK_(methodHandle()));
 
   NoSafepointVerifier nsv;
 
@@ -1490,12 +1566,6 @@ methodHandle SharedRuntime::resolve_helper(bool is_virtual, bool is_optimized, T
          ( is_virtual && invoke_code != Bytecodes::_invokestatic ), "inconsistent bytecode");
 
   assert(!caller_nm->is_unloading(), "It should not be unloading");
-
-  // tracing/debugging/statistics
-  uint *addr = (is_optimized) ? (&_resolve_opt_virtual_ctr) :
-                 (is_virtual) ? (&_resolve_virtual_ctr) :
-                                (&_resolve_static_ctr);
-  AtomicAccess::inc(addr);
 
 #ifndef PRODUCT
   if (TraceCallFixup) {
@@ -1727,9 +1797,13 @@ methodHandle SharedRuntime::handle_ic_miss_helper(TRAPS) {
   CallInfo call_info;
   Bytecodes::Code bc;
 
+  // last java frame on stack (which includes native call frames)
+  vframeStream vfst(current, true);  // Do not skip and javaCalls
+
+  Method* attached_method = extract_attached_method_if_mhi(vfst);
   // receiver is null for static calls. An exception is thrown for null
   // receivers for non-static calls
-  Handle receiver = find_callee_info(bc, call_info, CHECK_(methodHandle()));
+  Handle receiver = find_callee_info_helper(vfst, bc, call_info, attached_method, CHECK_(methodHandle()));
 
   methodHandle callee_method(current, call_info.selected_method());
 

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -404,9 +404,12 @@ class SharedRuntime: AllStatic {
 
  private:
   static Handle find_callee_info(Bytecodes::Code& bc, CallInfo& callinfo, TRAPS);
-  static Handle find_callee_info_helper(vframeStream& vfst, Bytecodes::Code& bc, CallInfo& callinfo, TRAPS);
+  static Handle find_callee_info_helper(vframeStream& vfst, Bytecodes::Code& bc, CallInfo& callinfo, Method* attached_method, TRAPS);
 
   static Method* extract_attached_method(vframeStream& vfst);
+  static Method* extract_attached_method_if_mhi(vframeStream& vfst);
+  static Method* extract_attached_method_if_mhi(nmethod* caller, address pc);
+  static Method* extract_attached_method(nmethod* caller, address pc, bool& is_mhi);
 
 #if defined(X86) && defined(COMPILER1)
   // For Object.hashCode, System.identityHashCode try to pull hashCode from object header if available.
@@ -576,6 +579,10 @@ class SharedRuntime: AllStatic {
   static PerfTickCounters* _perf_resolve_static_total_time;
   static PerfTickCounters* _perf_handle_wrong_method_total_time;
   static PerfTickCounters* _perf_ic_miss_total_time;
+
+  static uint _perf_resolve_static_cache_hit_ctr;
+  static uint _perf_resolve_opt_virtual_cache_hit_ctr;
+
  public:
   static uint _ic_miss_ctr;                      // total # of IC misses
   static uint _wrong_method_ctr;


### PR DESCRIPTION
This work aims to reduce the time taken to perform call resolution by caching the result of direct calls (static and opt-virtual) in the reloc info during compilation of a method. 
Relocations for static and opt-virtual calls already have a field `method_index` which is used to store the "real" method to be invoked by the method handle. It is currently only used during c2 compilations.
This patch re-uses the `method_index` field for static and opt-virtual calls to store the target method. The runtime call (`SharedRuntime::resolve_helper`) used by the compiled code to perform the call site resolution can then optimize the resolution process by getting the target method from the reloc info and patches the callsite through CompiledDirectCall.
No special handling is needed for AOT code.

On a 4-cpu system there is around 3% improvement in `spring-boot-getting-started`. Numbers for JavacBench range between 0-3% improvement.

`spring-boot-getting-started`:
```
Run,Old CDS + AOT,New CDS + AOT
1,199,192
2,199,196
3,202,197
4,203,198
5,198,196
6,201,194
7,203,197
8,200,193
9,204,193
10,199,201
Geomean,200.79,195.68 (1.03x improvement)
Stdev,1.99,2.61
```

`-Xlog:init` shows the numbers for time spent in call resolution from the compiled code.
For `spring-boot-getting-started` before this patch:
```
[0.357s][info][init] SharedRuntime:
[0.357s][info][init]   resolve_opt_virtual_call:      8260us /  2249 events
[0.357s][info][init]   resolve_virtual_call:          6899us /  1297 events
[0.357s][info][init]   resolve_static_call:           4646us /  1723 events
[0.357s][info][init]   handle_wrong_method:            680us /   145 events
[0.357s][info][init]   ic_miss:                       2109us /   488 events
[0.357s][info][init] Total:                      22596us
[0.357s][info][init]   perf_resolve_static_cache_hit_ctr:     0
[0.357s][info][init]   perf_resolve_opt_virtual_cache_hit_ctr:     0
```

For `spring-boot-getting-started` after this patch:
```
[0.348s][info][init] SharedRuntime:
[0.348s][info][init]   resolve_opt_virtual_call:      2774us /  2251 events
[0.348s][info][init]   resolve_virtual_call:          5577us /  1294 events
[0.348s][info][init]   resolve_static_call:           1901us /  1728 events
[0.348s][info][init]   handle_wrong_method:            719us /   146 events
[0.348s][info][init]   ic_miss:                       2109us /   474 events
[0.348s][info][init] Total:                      13082us
[0.348s][info][init]   perf_resolve_static_cache_hit_ctr:  1704
[0.348s][info][init]   perf_resolve_opt_virtual_cache_hit_ctr:  2202
```

For JavacBench before this patch:
```
[0.406s][info][init] SharedRuntime:
[0.406s][info][init]   resolve_opt_virtual_call:      7146us /  2354 events
[0.406s][info][init]   resolve_virtual_call:          7160us /  2207 events
[0.406s][info][init]   resolve_static_call:           2992us /  1264 events
[0.406s][info][init]   handle_wrong_method:            728us /   186 events
[0.406s][info][init]   ic_miss:                       2389us /   675 events
[0.406s][info][init] Total:                      20416us
[0.406s][info][init]   perf_resolve_static_cache_hit_ctr:     0
[0.406s][info][init]   perf_resolve_opt_virtual_cache_hit_ctr:     0
```

For JavacBench after this patch:
```
[0.399s][info][init] SharedRuntime:
[0.399s][info][init]   resolve_opt_virtual_call:      2321us /  2346 events
[0.399s][info][init]   resolve_virtual_call:          7452us /  2213 events
[0.399s][info][init]   resolve_static_call:           1264us /  1258 events
[0.399s][info][init]   handle_wrong_method:            747us /   177 events
[0.399s][info][init]   ic_miss:                       2395us /   665 events
[0.399s][info][init] Total:                      14180us
[0.399s][info][init]   perf_resolve_static_cache_hit_ctr:  1212
[0.399s][info][init]   perf_resolve_opt_virtual_cache_hit_ctr:  2236
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/106/head:pull/106` \
`$ git checkout pull/106`

Update a local copy of the PR: \
`$ git checkout pull/106` \
`$ git pull https://git.openjdk.org/leyden.git pull/106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 106`

View PR using the GUI difftool: \
`$ git pr show -t 106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/106.diff">https://git.openjdk.org/leyden/pull/106.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/106#issuecomment-3634429189)
</details>
