### PR TITLE
Update README with end recording command

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Generated source code for 51 classes and compiled them in 423 ms
 By default, training runs end when the application terminates.  You have two other options to end training runs:
 
 - `-XX:AOTEndTrainingOnMethodEntry=<method1,method2,...>[,count=100]`
-- `jcmd <pid> AOT.end_training`
+- `jcmd <pid> AOT.end_recording`
 
 Note that `-XX:AOTEndTrainingOnMethodEntry` uses the same format as `-XX:CompileOnly` and the default count is 1.
 


### PR DESCRIPTION
Fix documentation: replace AOT.end_training with AOT.end_recording

The documentation refers to jcmd <pid> AOT.end_training as the command to end a training run, but this command does not exist. The correct command is jcmd <pid> AOT.end_recording.

Running the documented command produces:


java.lang.IllegalArgumentException: Unknown diagnostic command
Verified on builds b487 and b489 (27-testing, 2026-03-18, linux/x86_64).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.org/leyden.git pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/112.diff">https://git.openjdk.org/leyden/pull/112.diff</a>

</details>
