### PR TITLE
8386108: [leyden] Implement JEP: Ahead-of-Time Code Compilation

### DIFF
--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -122,6 +122,7 @@ ifneq ($(call check-jvm-feature, cds), true)
       aotCodeCache.cpp \
       classLoaderDataShared.cpp \
       classLoaderExt.cpp \
+      aotCompileBroker.cpp \
       systemDictionaryShared.cpp \
       trainingData.cpp
   JVM_EXCLUDE_PATTERNS += cds/

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -2626,7 +2626,7 @@ bool C2_MacroAssembler::in_scratch_emit_size() {
   return MacroAssembler::in_scratch_emit_size();
 }
 
-static void abort_verify_int_in_range(uint idx, jint val, jint lo, jint hi) {
+void C2_MacroAssembler::abort_verify_int_in_range(uint idx, jint val, jint lo, jint hi) {
   fatal("Invalid CastII, idx: %u, val: %d, lo: %d, hi: %d", idx, val, lo, hi);
 }
 
@@ -2665,7 +2665,7 @@ void C2_MacroAssembler::verify_int_in_range(uint idx, const TypeInt* t, Register
   BLOCK_COMMENT("} verify_int_in_range");
 }
 
-static void abort_verify_long_in_range(uint idx, jlong val, jlong lo, jlong hi) {
+void C2_MacroAssembler::abort_verify_long_in_range(uint idx, jlong val, jlong lo, jlong hi) {
   fatal("Invalid CastLL, idx: %u, val: " JLONG_FORMAT ", lo: " JLONG_FORMAT ", hi: " JLONG_FORMAT, idx, val, lo, hi);
 }
 

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
@@ -233,6 +233,9 @@
   void vector_signum_sve(FloatRegister dst, FloatRegister src, FloatRegister zero,
                          FloatRegister one, FloatRegister vtmp, PRegister pgtmp, SIMD_RegVariant T);
 
+  static void abort_verify_int_in_range(uint idx, jint val, jint lo, jint hi);
+  static void abort_verify_long_in_range(uint idx, jlong val, jlong lo, jlong hi);
+
   void verify_int_in_range(uint idx, const TypeInt* t, Register val, Register tmp);
   void verify_long_in_range(uint idx, const TypeLong* t, Register val, Register tmp);
 

--- a/src/hotspot/cpu/aarch64/gc/g1/g1BarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/g1/g1BarrierSetAssembler_aarch64.cpp
@@ -244,7 +244,7 @@ static void generate_post_barrier(MacroAssembler* masm,
   assert_different_registers(store_addr, new_val, thread, tmp1, tmp2, noreg, rscratch1);
 
   // Does store cross heap regions?
- #if INCLUDE_CDS
+#if INCLUDE_CDS
   // AOT code needs to load the barrier grain shift from the aot
   // runtime constants area in the code cache otherwise we can compile
   // it as an immediate operand
@@ -301,7 +301,7 @@ static void generate_c2_barrier_runtime_call(MacroAssembler* masm, G1BarrierStub
     __ mov(c_rarg0, arg);
   }
   __ mov(c_rarg1, rthread);
-  __ mov(rscratch1, runtime_path);
+  __ lea(rscratch1, RuntimeAddress(runtime_path));
   __ blr(rscratch1);
 }
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -322,6 +322,16 @@ public:
     return 2;
   }
   static int immediate(address insn_addr, address &target) {
+    // Metadata pointers are either narrow (32 bits) or wide (48 bits).
+    // We encode narrow ones by setting the upper 16 bits in the first
+    // instruction.
+    if (Instruction_aarch64::extract(insn_at(insn_addr, 0), 31, 21) == 0b11010010101) {
+      assert(nativeInstruction_at(insn_addr+4)->is_movk(), "wrong insns in patch");
+      narrowKlass nk = CompressedKlassPointers::encode((Klass*)target);
+      Instruction_aarch64::patch(insn_addr, 20, 5, nk >> 16);
+      Instruction_aarch64::patch(insn_addr+4, 20, 5, nk & 0xffff);
+      return 2;
+    }
     assert(Instruction_aarch64::extract(insn_at(insn_addr, 0), 31, 21) == 0b11010010100, "must be");
     uint64_t dest = (uint64_t)target;
     // Move wide constant
@@ -449,6 +459,16 @@ public:
   }
   static int immediate(address insn_addr, address &target) {
     uint32_t *insns = (uint32_t *)insn_addr;
+    // Metadata pointers are either narrow (32 bits) or wide (48 bits).
+    // We encode narrow ones by setting the upper 16 bits in the first
+    // instruction.
+    if (Instruction_aarch64::extract(insns[0], 31, 21) == 0b11010010101) {
+      assert(nativeInstruction_at(insn_addr+4)->is_movk(), "wrong insns in patch");
+      narrowKlass nk = (narrowKlass)((uint32_t(Instruction_aarch64::extract(insns[0], 20, 5)) << 16)
+                                   +  uint32_t(Instruction_aarch64::extract(insns[1], 20, 5)));
+      target = (address)CompressedKlassPointers::decode(nk);
+      return 2;
+    }
     assert(Instruction_aarch64::extract(insns[0], 31, 21) == 0b11010010100, "must be");
     // Move wide constant: movz, movk, movk.  See movptr().
     assert(nativeInstruction_at(insns+1)->is_movk(), "wrong insns in patch");
@@ -2351,7 +2371,7 @@ void MacroAssembler::mov(Register r, Address dest) {
 // reach anywhere.
 void MacroAssembler::movptr(Register r, uintptr_t imm64) {
 #ifndef PRODUCT
-  {
+  if (!AOTCodeCache::is_on_for_dump()) {
     char buffer[64];
     os::snprintf_checked(buffer, sizeof(buffer), "0x%" PRIX64, (uint64_t)imm64);
     block_comment(buffer);
@@ -2409,7 +2429,7 @@ void MacroAssembler::mov(FloatRegister Vd, SIMD_Arrangement T, uint64_t imm64) {
 void MacroAssembler::mov_immediate64(Register dst, uint64_t imm64)
 {
 #ifndef PRODUCT
-  {
+  if (!AOTCodeCache::is_on_for_dump()) {
     char buffer[64];
     os::snprintf_checked(buffer, sizeof(buffer), "0x%" PRIX64, imm64);
     block_comment(buffer);
@@ -2522,7 +2542,7 @@ void MacroAssembler::mov_immediate64(Register dst, uint64_t imm64)
 void MacroAssembler::mov_immediate32(Register dst, uint32_t imm32)
 {
 #ifndef PRODUCT
-    {
+    if (!AOTCodeCache::is_on_for_dump()) {
       char buffer[64];
       os::snprintf_checked(buffer, sizeof(buffer), "0x%" PRIX32, imm32);
       block_comment(buffer);
@@ -5455,7 +5475,7 @@ void MacroAssembler::decode_klass_not_null_for_aot(Register dst, Register src) {
 }
 
 void  MacroAssembler::decode_klass_not_null(Register dst, Register src) {
-  if (AOTCodeCache::is_on_for_dump()) {
+  if (CompressedKlassPointers::base() != nullptr && AOTCodeCache::is_on_for_dump()) {
     decode_klass_not_null_for_aot(dst, src);
     return;
   }

--- a/src/hotspot/cpu/aarch64/relocInfo_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/relocInfo_aarch64.cpp
@@ -122,3 +122,11 @@ void poll_Relocation::fix_relocation_after_move(const CodeBuffer* src, CodeBuffe
 
 void metadata_Relocation::pd_fix_value(address x) {
 }
+
+address trampoline_stub_Relocation::pd_destination() {
+  return nativeCallTrampolineStub_at(addr())->destination();
+}
+
+void trampoline_stub_Relocation::pd_set_destination(address x) {
+  nativeCallTrampolineStub_at(addr())->set_destination(x);
+}

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -589,7 +589,7 @@ void C2_MacroAssembler::fast_unlock(Register obj, Register reg_rax, Register t, 
   // C2 uses the value of ZF to determine the continuation.
 }
 
-static void abort_verify_int_in_range(uint idx, jint val, jint lo, jint hi) {
+void C2_MacroAssembler::abort_verify_int_in_range(uint idx, jint val, jint lo, jint hi) {
   fatal("Invalid CastII, idx: %u, val: %d, lo: %d, hi: %d", idx, val, lo, hi);
 }
 
@@ -652,7 +652,7 @@ void C2_MacroAssembler::verify_int_in_range(uint idx, const TypeInt* t, Register
   BLOCK_COMMENT("} // CastII");
 }
 
-static void abort_verify_long_in_range(uint idx, jlong val, jlong lo, jlong hi) {
+void C2_MacroAssembler::abort_verify_long_in_range(uint idx, jlong val, jlong lo, jlong hi) {
   fatal("Invalid CastLL, idx: %u, val: " JLONG_FORMAT ", lo: " JLONG_FORMAT ", hi: " JLONG_FORMAT, idx, val, lo, hi);
 }
 
@@ -3575,9 +3575,9 @@ void C2_MacroAssembler::arrays_hashcode(Register ary1, Register cnt1, Register r
   // release bound
 
   // vresult *= IntVector.fromArray(I256, power_of_31_backwards, 1);
+  lea(tmp2, ExternalAddress(StubRoutines::x86::arrays_hashcode_powers_of_31() + (0 * sizeof(jint))));
   for (int idx = 0; idx < 4; idx++) {
-    lea(tmp2, ExternalAddress(StubRoutines::x86::arrays_hashcode_powers_of_31() + ((8 * idx + 1) * sizeof(jint))));
-    arrays_hashcode_elvload(vcoef[idx], Address(tmp2, 0), T_INT);
+    arrays_hashcode_elvload(vcoef[idx], Address(tmp2, (int)((8 * idx + 1) * sizeof(jint))), T_INT);
     vpmulld(vresult[idx], vresult[idx], vcoef[idx], Assembler::AVX_256bit);
   }
   // result += vresult.reduceLanes(ADD);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -39,6 +39,9 @@ public:
                  Register t, Register thread);
   void fast_unlock(Register obj, Register reg_rax, Register t, Register thread);
 
+  static void abort_verify_int_in_range(uint idx, jint val, jint lo, jint hi);
+  static void abort_verify_long_in_range(uint idx, jlong val, jlong lo, jlong hi);
+
   void verify_int_in_range(uint idx, const TypeInt* t, Register val);
   void verify_long_in_range(uint idx, const TypeLong* t, Register val, Register tmp);
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
@@ -25,6 +25,7 @@
 #include "asm/macroAssembler.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "oops/objArrayKlass.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -1013,8 +1013,8 @@ void CodeBuffer::verify_section_allocation() {
       }
       guarantee(other->disjoint(sect), "sanity");
     }
-    guarantee(sect->end() <= tend, "sanity");
-    guarantee(sect->end() <= sect->limit(), "sanity");
+    guarantee(sect->end() <= tend, "sanity, sect_end: " PTR_FORMAT " tend: " PTR_FORMAT " size: %d", p2i(sect->end()), p2i(tend), (int)_total_size);
+    guarantee(sect->end() <= sect->limit(), "sanity, sect_end: " PTR_FORMAT " sect_limit: " PTR_FORMAT, p2i(sect->end()), p2i(sect->limit()));
   }
 }
 
@@ -1115,7 +1115,10 @@ AsmRemarks::AsmRemarks() {
 }
 
 AsmRemarks::~AsmRemarks() {
-  assert(_remarks == nullptr, "Must 'clear()' before deleting!");
+  if (_remarks != nullptr) {
+    clear();
+  }
+  assert(_remarks == nullptr, "must be");
 }
 
 void AsmRemarks::init() {
@@ -1172,7 +1175,10 @@ DbgStrings::DbgStrings() {
 }
 
 DbgStrings::~DbgStrings() {
-  assert(_strings == nullptr, "Must 'clear()' before deleting!");
+  if (_strings != nullptr) {
+    clear();
+  }
+  assert(_strings == nullptr, "must be");
 }
 
 void DbgStrings::init() {
@@ -1213,6 +1219,7 @@ const char* AsmRemarkCollection::insert(uint offset, const char* remstr) {
   } else {
     _remarks->push_back(cell);
   }
+  log_trace(codestrings)("AsmRemark::insert: offset=%u '%s'.", offset, remstr);
   return cell->string();
 }
 

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -432,6 +432,9 @@ class AsmRemarks {
 
   void share(const AsmRemarks &src);
   void clear();
+  // Clear Collection reference when storing AOT code,
+  // new one will be created during AOT code load.
+  void clear_ref() { _remarks = nullptr; }
   uint print(uint offset, outputStream* strm = tty) const;
 
   // For testing purposes only.
@@ -460,6 +463,9 @@ class DbgStrings {
 
   void share(const DbgStrings &src);
   void clear();
+  // Clear Collection reference when storing AOT code,
+  // new one will be created during AOT code load.
+  void clear_ref() { _strings = nullptr; }
 
   // For testing purposes only.
   const DbgStringCollection* ref() const { return _strings; }

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -425,11 +425,14 @@ void Compilation::install_code(int frame_size) {
     exception_handler_table(),
     implicit_exception_table(),
     compiler(),
+    false, // has_clinit_barriers
+    false, // for_preload
     has_unsafe_access(),
     SharedRuntime::is_wide_vector(max_vector_size()),
     has_monitors(),
     has_scoped_access(),
-    _immediate_oops_patched
+    _immediate_oops_patched,
+    should_install_code()
   );
 }
 
@@ -474,8 +477,7 @@ void Compilation::compile_method() {
   // Note: make sure we mark the method as not compilable!
   CHECK_BAILOUT();
 
-  if (should_install_code()) {
-    // install code
+  { // install code
     PhaseTraceTime timeit(_t_codeinstall);
     install_code(frame_size);
   }

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -30,6 +30,7 @@
 #include "c1/c1_MacroAssembler.hpp"
 #include "c1/c1_Runtime1.hpp"
 #include "c1/c1_ValueType.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compilerDirectives.hpp"
 #include "interpreter/linkResolver.hpp"
@@ -252,6 +253,14 @@ bool Compiler::is_intrinsic_supported(vmIntrinsics::ID id) {
 }
 
 void Compiler::compile_method(ciEnv* env, ciMethod* method, int entry_bci, bool install_code, DirectiveSet* directive) {
+  CompileTask* task = env->task();
+  if (install_code && task->is_aot_load()) {
+    assert(!task->preload(), "Pre-loading AOT code is not implemented for C1 code");
+    AOTCodeCache::load_nmethod(env, method, entry_bci, this, CompLevel(task->comp_level()));
+    // We want to go quickly through AOT code load requests
+    // instead of spending time on normal compilation.
+    return;
+  }
   BufferBlob* buffer_blob = CompilerThread::current()->get_buffer_blob();
   assert(buffer_blob != nullptr, "Must exist");
   // invoke compilation

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -40,6 +40,7 @@
 #include "interpreter/bytecode.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "memory/resourceArea.hpp"
+#include "oops/oop.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "utilities/checkedCast.hpp"
 #include "utilities/macros.hpp"
@@ -1711,7 +1712,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
                               PatchALot;
 
   ValueStack* state_before = nullptr;
-  if (!holder->is_initialized() || needs_patching) {
+  if (!holder->is_initialized() || needs_patching || compilation()->env()->is_aot_compile()) {
     // save state before instruction for debug info when
     // deoptimization happens during patching
     state_before = copy_state_before();
@@ -2119,7 +2120,8 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
       callee_holder->is_loaded()) { // the effect of symbolic reference resolution
 
     // callee is known => check if we have static binding
-    if ((code == Bytecodes::_invokestatic && klass->is_initialized()) || // invokestatic involves an initialization barrier on declaring class
+    if ((code == Bytecodes::_invokestatic && klass->is_initialized() &&
+        !compilation()->env()->is_aot_compile()) || // invokestatic involves an initialization barrier on declaring class
         code == Bytecodes::_invokespecial ||
         (code == Bytecodes::_invokevirtual && target->is_final_method()) ||
         code == Bytecodes::_invokedynamic) {
@@ -3863,7 +3865,8 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
       !InlineSynchronizedMethods         ) INLINE_BAILOUT("callee is synchronized");
   if (!callee->holder()->is_linked())      INLINE_BAILOUT("callee's klass not linked yet");
   if (bc == Bytecodes::_invokestatic &&
-      !callee->holder()->is_initialized()) INLINE_BAILOUT("callee's klass not initialized yet");
+      (!callee->holder()->is_initialized() ||
+       compilation()->env()->is_aot_compile())) INLINE_BAILOUT("callee's klass not initialized yet");
   if (!callee->has_balanced_monitors())    INLINE_BAILOUT("callee's monitors do not match");
 
   // Proper inlining of methods with jsrs requires a little more work.

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -33,6 +33,7 @@
 #include "ci/ciInstance.hpp"
 #include "ci/ciObjArray.hpp"
 #include "ci/ciUtilities.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/compilerOracle.hpp"
 #include "gc/shared/barrierSet.hpp"
@@ -656,7 +657,8 @@ void LIRGenerator::new_instance(LIR_Opr dst, ciInstanceKlass* klass, bool is_unr
   if (UseFastNewInstance && klass->is_loaded()
       && !Klass::layout_helper_needs_slow_path(klass->layout_helper())) {
 
-    StubId stub_id = klass->is_initialized() ? StubId::c1_fast_new_instance_id : StubId::c1_fast_new_instance_init_check_id;
+    bool known_initialized = klass->is_initialized() && !compilation()->env()->is_aot_compile();
+    StubId stub_id = known_initialized ? StubId::c1_fast_new_instance_id : StubId::c1_fast_new_instance_init_check_id;
 
     CodeStub* slow_path = new NewInstanceStub(klass_reg, dst, klass, info, stub_id);
 
@@ -665,7 +667,7 @@ void LIRGenerator::new_instance(LIR_Opr dst, ciInstanceKlass* klass, bool is_unr
     assert(klass->size_helper() > 0, "illegal instance size");
     const int instance_size = align_object_size(klass->size_helper());
     __ allocate_object(dst, scratch1, scratch2, scratch3, scratch4,
-                       oopDesc::header_size(), instance_size, klass_reg, !klass->is_initialized(), slow_path);
+                       oopDesc::header_size(), instance_size, klass_reg, !known_initialized, slow_path);
   } else {
     CodeStub* slow_path = new NewInstanceStub(klass_reg, dst, klass, info, StubId::c1_new_instance_id);
     __ branch(lir_cond_always, slow_path);
@@ -3152,13 +3154,18 @@ void LIRGenerator::increment_event_counter_impl(CodeEmitInfo* info,
   int offset = -1;
   LIR_Opr counter_holder;
   if (level == CompLevel_limited_profile) {
-    MethodCounters* counters_adr = method->ensure_method_counters();
+    ciMetadata* counters_adr = method->ensure_method_counters();
     if (counters_adr == nullptr) {
       bailout("method counters allocation failed");
       return;
     }
-    counter_holder = new_pointer_register();
-    __ move(LIR_OprFact::intptrConst(counters_adr), counter_holder);
+    if (AOTCodeCache::is_dumping_code()) {
+      counter_holder = new_register(T_METADATA);
+      __ metadata2reg(counters_adr->constant_encoding(), counter_holder);
+    } else {
+      counter_holder = new_pointer_register();
+      __ move(LIR_OprFact::intptrConst(counters_adr->constant_encoding()), counter_holder);
+    }
     offset = in_bytes(backedge ? MethodCounters::backedge_counter_offset() :
                                  MethodCounters::invocation_counter_offset());
   } else if (level == CompLevel_full_profile) {

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -279,6 +279,9 @@ bool Runtime1::initialize(BufferBlob* blob) {
       return false;
     }
   }
+  BarrierSetC1* bs = BarrierSet::barrier_set()->barrier_set_c1();
+  bool success = bs->generate_c1_runtime_stubs(blob);
+
   // disallow any further c1 stub generation
   AOTCodeCache::set_c1_stubs_complete();
   // printing
@@ -295,8 +298,7 @@ bool Runtime1::initialize(BufferBlob* blob) {
     }
   }
 #endif
-  BarrierSetC1* bs = BarrierSet::barrier_set()->barrier_set_c1();
-  return bs->generate_c1_runtime_stubs(blob);
+  return success;
 }
 
 CodeBlob* Runtime1::blob_for(StubId id) {
@@ -832,7 +834,8 @@ static Klass* resolve_field_return_klass(const methodHandle& caller, int bci, TR
   // We must load class, initialize class and resolve the field
   fieldDescriptor result; // initialize class if needed
   constantPoolHandle constants(THREAD, caller->constants());
-  LinkResolver::resolve_field_access(result, constants, field_access.index(), caller, Bytecodes::java_code(code), CHECK_NULL);
+  LinkResolver::resolve_field_access(result, constants, field_access.index(), caller,
+                                     Bytecodes::java_code(code), ClassInitMode::init, CHECK_NULL);
   return result.field_holder();
 }
 
@@ -980,7 +983,8 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, StubId stub_id ))
     fieldDescriptor result; // initialize class if needed
     Bytecodes::Code code = field_access.code();
     constantPoolHandle constants(current, caller_method->constants());
-    LinkResolver::resolve_field_access(result, constants, field_access.index(), caller_method, Bytecodes::java_code(code), CHECK);
+    LinkResolver::resolve_field_access(result, constants, field_access.index(), caller_method,
+                                       Bytecodes::java_code(code), ClassInitMode::init, CHECK);
     patch_field_offset = result.offset();
     patch_field_type = result.field_type();
 

--- a/src/hotspot/share/cds/aotCacheAccess.cpp
+++ b/src/hotspot/share/cds/aotCacheAccess.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
  */
 
 #include "cds/aotCacheAccess.hpp"
-#include "cds/aotMetaspace.hpp"
 #include "cds/archiveBuilder.hpp"
 #include "cds/cdsConfig.hpp"
 #include "cds/filemap.hpp"
@@ -36,20 +35,70 @@
 #include "memory/virtualspace.hpp"
 #include "oops/instanceKlass.hpp"
 
+size_t _aot_code_region_size = 0;
+
+bool AOTCacheAccess::can_generate_aot_code(address addr) {
+  assert(CDSConfig::is_dumping_final_static_archive(), "must be");
+  return ArchiveBuilder::is_active() && ArchiveBuilder::current()->has_been_archived(addr);
+}
+
+bool AOTCacheAccess::can_generate_aot_code_for(InstanceKlass* ik) {
+  assert(CDSConfig::is_dumping_final_static_archive(), "must be");
+  if (!ArchiveBuilder::is_active()) {
+    return false;
+  }
+  ArchiveBuilder* builder = ArchiveBuilder::current();
+  if (!builder->has_been_archived((address)ik)) {
+    return false;
+  }
+  if (ik->defined_by_other_loaders()) {
+    return false;
+  }
+  return true;
+}
+
+#if INCLUDE_CDS_JAVA_HEAP
+int AOTCacheAccess::get_archived_object_permanent_index(oop obj) {
+  return HeapShared::get_root_index(obj); // -1 if obj is not a root.
+}
+
+oop AOTCacheAccess::get_archived_object(int permanent_index) {
+  oop o = HeapShared::get_root(permanent_index);
+  assert(oopDesc::is_oop_or_null(o), "sanity");
+  return o;
+}
+
+#endif // INCLUDE_CDS_JAVA_HEAP
+
 void* AOTCacheAccess::allocate_aot_code_region(size_t size) {
   assert(CDSConfig::is_dumping_final_static_archive(), "must be");
   return (void*)ArchiveBuilder::ac_region_alloc(size);
 }
 
 size_t AOTCacheAccess::get_aot_code_region_size() {
-  assert(CDSConfig::is_using_archive(), "must be");
-  FileMapInfo* mapinfo = FileMapInfo::current_info();
-  assert(mapinfo != nullptr, "must be");
-  return mapinfo->region_at(AOTMetaspace::ac)->used_aligned();
+  return _aot_code_region_size;
+}
+
+void AOTCacheAccess::set_aot_code_region_size(size_t sz) {
+  _aot_code_region_size = sz;
 }
 
 bool AOTCacheAccess::map_aot_code_region(ReservedSpace rs) {
   FileMapInfo* static_mapinfo = FileMapInfo::current_info();
   assert(UseSharedSpaces && static_mapinfo != nullptr, "must be");
   return static_mapinfo->map_aot_code_region(rs);
+}
+
+bool AOTCacheAccess::is_aot_code_region_empty() {
+  assert(CDSConfig::is_dumping_final_static_archive(), "must be");
+  return ArchiveBuilder::current()->ac_region()->is_empty();
+}
+
+void AOTCacheAccess::set_pointer(address* ptr, address value) {
+  ArchiveBuilder* builder = ArchiveBuilder::current();
+  if (value != nullptr && !builder->is_in_buffer_space(value)) {
+    value = builder->get_buffered_addr(value);
+  }
+  *ptr = value;
+  ArchivePtrMarker::mark_pointer(ptr);
 }

--- a/src/hotspot/share/cds/aotCacheAccess.hpp
+++ b/src/hotspot/share/cds/aotCacheAccess.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,23 +25,91 @@
 #ifndef SHARE_CDS_AOTCACHEACCESS_HPP
 #define SHARE_CDS_AOTCACHEACCESS_HPP
 
+#include "cds/aotCompressedPointers.hpp"
+#include "cds/aotMetaspace.hpp"
 #include "cds/archiveBuilder.hpp"
 #include "cds/archiveUtils.hpp"
+#include "cds/cdsConfig.hpp"
 #include "memory/allStatic.hpp"
 #include "oops/oopsHierarchy.hpp"
 #include "utilities/globalDefinitions.hpp"
 
+class InstanceKlass;
+class Klass;
+class Method;
 class ReservedSpace;
 
 // AOT Cache API for AOT compiler
 
 class AOTCacheAccess : AllStatic {
+  using narrowPtr = AOTCompressedPointers::narrowPtr;
+private:
+  static bool can_generate_aot_code(address addr) NOT_CDS_RETURN_(false);
 public:
+  static bool can_generate_aot_code(Method* m) {
+    return can_generate_aot_code((address)m);
+  }
+  static bool can_generate_aot_code(Klass* k) {
+    assert(!k->is_instance_klass(), "other method should be called");
+    return can_generate_aot_code((address)k);
+  }
+  static bool can_generate_aot_code_for(InstanceKlass* ik) NOT_CDS_RETURN_(false);
+
+  /*
+   * Used during an assembly run to encode metadata object pointer present in the AOT Cache.
+   * The input argument is the address of a metadata object (Method/Klass) loaded by the assembly JVM.
+   */
+  template <typename T>
+  static narrowPtr to_narrow_ptr(T addr) {
+    assert(CDSConfig::is_dumping_final_static_archive(), "must be");
+    assert(ArchiveBuilder::is_active(), "must be");
+    return AOTCompressedPointers::encode_not_null(addr);
+  }
+
+  /*
+   * Used during a production run to materialize a real pointer to a Klass from the encoded pointer located in a loaded AOT Cache.
+   * The encoded pointer is normally obtained by reading a value embedded in some other AOT-ed entry, like an AOT compiled code.
+   */
+  static Klass* narrow_ptr_to_klass(narrowPtr narrowp) {
+    Metadata* metadata = AOTCompressedPointers::decode_not_null<Metadata*>(narrowp);
+    assert(metadata->is_klass(), "sanity check");
+    return (Klass*)metadata;
+  }
+
+  /*
+   * Used during a production run to materialize a real pointer to a Method from the encoded pointer located in a loaded AOT Cache.
+   * The encoded pointer is normally obtained by reading a value embedded in some other AOT-ed entry, like an AOT compiled code.
+   */
+  static Method* narrow_ptr_to_method(narrowPtr narrowp) {
+    Metadata* metadata = AOTCompressedPointers::decode_not_null<Metadata*>(narrowp);
+    assert(metadata->is_method(), "sanity check");
+    return (Method*)metadata;
+  }
+
+  // Used during production run to convert a Method in AOTCache to encoded pointer
+  static narrowPtr method_to_narrow_ptr(Method* method) {
+    assert(CDSConfig::is_using_archive() && !CDSConfig::is_dumping_final_static_archive(), "must be");
+    assert(AOTMetaspace::in_aot_cache(method), "method %p is not in AOTCache", method);
+    return AOTCompressedPointers::encode_address_in_cache(method);
+  }
+
+  static int get_archived_object_permanent_index(oop obj) NOT_CDS_JAVA_HEAP_RETURN_(-1);
+  static oop get_archived_object(int permanent_index) NOT_CDS_JAVA_HEAP_RETURN_(nullptr);
+
   static void* allocate_aot_code_region(size_t size) NOT_CDS_RETURN_(nullptr);
 
   static size_t get_aot_code_region_size() NOT_CDS_RETURN_(0);
+  static void set_aot_code_region_size(size_t sz) NOT_CDS_RETURN;
 
   static bool map_aot_code_region(ReservedSpace rs) NOT_CDS_RETURN_(false);
+
+  static bool is_aot_code_region_empty() NOT_CDS_RETURN_(true);
+
+  template <typename T>
+  static void set_pointer(T** ptr, T* value) {
+    set_pointer((address*)ptr, (address)value);
+  }
+  static void set_pointer(address* ptr, address value);
 };
 
 #endif // SHARE_CDS_AOTCACHEACCESS_HPP

--- a/src/hotspot/share/cds/aotClassLinker.cpp
+++ b/src/hotspot/share/cds/aotClassLinker.cpp
@@ -136,6 +136,10 @@ bool AOTClassLinker::try_add_candidate(InstanceKlass* ik) {
     return true;
   }
 
+  if (!ik->is_linked() && SystemDictionaryShared::has_class_failed_verification(ik)) {
+    return false;
+  }
+
   if (ik->is_hidden()) {
     assert(!ik->defined_by_other_loaders(), "hidden classes are archived only for builtin loaders");
     if (!CDSConfig::is_dumping_method_handles()) {

--- a/src/hotspot/share/cds/aotCompressedPointers.hpp
+++ b/src/hotspot/share/cds/aotCompressedPointers.hpp
@@ -141,4 +141,6 @@ inline u4 cast_to_u4(AOTCompressedPointers::narrowPtr narrowp) {
   return checked_cast<u4>(narrowp);
 }
 
+using narrowPtr = AOTCompressedPointers::narrowPtr;
+
 #endif // SHARE_CDS_AOTCOMPRESSEDPOINTERS_HPP

--- a/src/hotspot/share/cds/aotConstantPoolResolver.cpp
+++ b/src/hotspot/share/cds/aotConstantPoolResolver.cpp
@@ -26,6 +26,8 @@
 #include "cds/aotConstantPoolResolver.hpp"
 #include "cds/archiveBuilder.hpp"
 #include "cds/cdsConfig.hpp"
+#include "cds/heapShared.hpp"
+#include "cds/lambdaFormInvokers.inline.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "classfile/systemDictionaryShared.hpp"
 #include "classfile/vmClasses.hpp"
@@ -147,6 +149,29 @@ void AOTConstantPoolResolver::preresolve_string_cp_entries(InstanceKlass* ik, TR
     case JVM_CONSTANT_String:
       resolve_string(cp, cp_index, CHECK); // may throw OOM when interning strings.
       break;
+    }
+  }
+
+  // Normally, we don't want to archive any CP entries that were not resolved
+  // in the training run. Otherwise the AOT/JIT may inline too much code that has not
+  // been executed.
+  //
+  // However, we want to aggressively resolve all klass/field/method constants for
+  // LambdaForm Invoker Holder classes, Lambda Proxy classes, and LambdaForm classes,
+  // so that the compiler can inline through them.
+  if (SystemDictionaryShared::is_builtin_loader(ik->class_loader_data())) {
+    bool eager_resolve = false;
+
+    if (LambdaFormInvokers::may_be_regenerated_class(ik->name())) {
+      eager_resolve = true;
+    }
+    if (ik->is_hidden() && HeapShared::is_archivable_hidden_klass(ik)) {
+      eager_resolve = true;
+    }
+
+    if (eager_resolve) {
+      preresolve_class_cp_entries(THREAD, ik, nullptr);
+      preresolve_field_and_method_cp_entries(THREAD, ik, nullptr);
     }
   }
 }

--- a/src/hotspot/share/cds/aotMetaspace.cpp
+++ b/src/hotspot/share/cds/aotMetaspace.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "cds/aotArtifactFinder.hpp"
+#include "cds/aotCacheAccess.hpp"
 #include "cds/aotClassInitializer.hpp"
 #include "cds/aotClassLinker.hpp"
 #include "cds/aotClassLocation.hpp"
@@ -61,6 +62,7 @@
 #include "classfile/vmSymbols.hpp"
 #include "code/aotCodeCache.hpp"
 #include "code/codeCache.hpp"
+#include "compiler/aotCompileBroker.hpp"
 #include "gc/shared/gcVMOperations.hpp"
 #include "interpreter/bytecodes.hpp"
 #include "interpreter/bytecodeStream.hpp"
@@ -79,6 +81,7 @@
 #include "oops/constantPool.inline.hpp"
 #include "oops/instanceMirrorKlass.hpp"
 #include "oops/klass.inline.hpp"
+#include "oops/method.inline.hpp"
 #include "oops/objArrayOop.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/oopHandle.hpp"
@@ -949,17 +952,16 @@ void AOTMetaspace::dump_static_archive(TRAPS) {
   ResourceMark rm(THREAD);
   HandleMark hm(THREAD);
 
- if (CDSConfig::is_dumping_final_static_archive()) {
-   if (AOTPrintTrainingInfo) {
-     tty->print_cr("==================== archived_training_data ** before dumping ====================");
-     TrainingData::print_archived_training_data_on(tty);
-   }
-   LogStreamHandle(Info, aot, training, data) log;
-   if (log.is_enabled()) {
-     TrainingData::print_archived_training_data_on(&log);
-   }
- }
-
+  if (CDSConfig::is_dumping_final_static_archive()) {
+    if (AOTPrintTrainingInfo) {
+      tty->print_cr("==================== archived_training_data ** before dumping ====================");
+      TrainingData::print_archived_training_data_on(tty);
+    }
+    LogStreamHandle(Info, aot, training, data) log;
+    if (log.is_enabled()) {
+      TrainingData::print_archived_training_data_on(&log);
+    }
+  }
 
   StaticArchiveBuilder builder;
   dump_static_archive_impl(builder, THREAD);
@@ -993,6 +995,8 @@ void AOTMetaspace::dump_static_archive(TRAPS) {
       } else {
         tty->print_cr("AOTCache creation is complete: %s " INT64_FORMAT " bytes", AOTCache, (int64_t)(st.st_size));
       }
+      print_statistics_before_exit();
+      ostream_exit(); // finalize VM log
       vm_direct_exit(0);
     }
   }
@@ -1007,8 +1011,11 @@ void AOTMetaspace::init_heap_settings() {
     } else if (CDSConfig::is_dumping_final_static_archive()) {
       // Obey the command-line switch. Do not override
     } else if (CDSConfig::is_using_archive()) {
-      precond(FileMapInfo::current_info() == nullptr);
-      FileMapInfo* static_mapinfo = open_static_archive();
+      FileMapInfo* static_mapinfo = FileMapInfo::current_info();
+      // may have been opened by get_aot_code_region_size()
+      if (static_mapinfo == nullptr) {
+        static_mapinfo = open_static_archive();
+      }
       if (static_mapinfo != nullptr && static_mapinfo->header()->compatible_oop_compression()) {
         // Use the same setting as recorded in the archive.
         FLAG_SET_ERGO(AOTCompatibleOopCompression, true);
@@ -1206,15 +1213,21 @@ void AOTMetaspace::dump_static_archive_impl(StaticArchiveBuilder& builder, TRAPS
   VM_PopulateDumpSharedSpace op(builder, _output_mapinfo);
   VMThread::execute(&op);
 
-  if (AOTCodeCache::is_on_for_dump() && CDSConfig::is_dumping_final_static_archive()) {
-    CDSConfig::enable_dumping_aot_code();
-    {
-      builder.start_ac_region();
-      // Write the contents to AOT code region before packing the region
-      AOTCodeCache::dump();
-      builder.end_ac_region();
+  if (AOTCodeCache::is_caching_enabled() && CDSConfig::is_dumping_final_static_archive()) {
+    // We have just created the final image. Now dump AOT adapters, stubs and compiled code.
+    builder.start_ac_region();
+    if (AOTCodeCache::is_dumping_code()) {
+      // Let's run the AOT compiler.
+      CDSConfig::enable_dumping_aot_code();
+      log_info(aot)("Compiling AOT code");
+      AOTCompileBroker::compile_aot_code(&builder, CHECK);
+      log_info(aot)("Finished compiling AOT code");
+      CDSConfig::disable_dumping_aot_code();
     }
-    CDSConfig::disable_dumping_aot_code();
+    // Write the contents to AOT code region before packing the region
+    AOTCodeCache::dump();
+    log_info(aot)("Dumped AOT code Cache");
+    builder.end_ac_region();
   }
 
   bool status = write_static_archive(&builder, _output_mapinfo, op.mapped_heap_info(), op.streamed_heap_info());
@@ -1422,7 +1435,7 @@ bool AOTMetaspace::try_link_class(JavaThread* current, InstanceKlass* ik) {
 void VM_PopulateDumpSharedSpace::dump_java_heap_objects() {
   if (CDSConfig::is_dumping_heap()) {
     HeapShared::write_heap(&_mapped_heap_info, &_streamed_heap_info);
-  } else {
+  } else if (!CDSConfig::is_dumping_preimage_static_archive()) {
     CDSConfig::log_reasons_for_not_dumping_heap();
   }
 }
@@ -1584,7 +1597,25 @@ void AOTMetaspace::initialize_runtime_shared_and_meta_spaces() {
     delete dynamic_mapinfo;
   }
   if (RequireSharedSpaces && has_failed) {
-      AOTMetaspace::unrecoverable_loading_error("Unable to map shared spaces");
+    // static archive mapped but dynamic archive failed
+    AOTMetaspace::unrecoverable_loading_error("Unable to map shared spaces");
+  }
+}
+
+// This is called very early at VM start up to get AOT cache header
+// and the size of the AOT code region during production run.
+// We need the size to reseve space in CodeCache to map code from AOT code region.
+void AOTMetaspace::get_aot_code_region_size() {
+  if (!AOTCodeCache::is_caching_enabled() || CDSConfig::is_dumping_final_static_archive()) {
+    return;
+  } else if (CDSConfig::is_using_archive()) { // production run with AOT code cache
+    precond(FileMapInfo::current_info() == nullptr);
+    precond(CodeCache::max_capacity() == 0);
+    FileMapInfo* static_mapinfo = open_static_archive();
+    if (static_mapinfo != nullptr) {
+      FileMapRegion* aot_code_region = static_mapinfo->region_at(AOTMetaspace::ac);
+      AOTCacheAccess::set_aot_code_region_size(aot_code_region->used_aligned());
+    }
   }
 }
 

--- a/src/hotspot/share/cds/aotMetaspace.hpp
+++ b/src/hotspot/share/cds/aotMetaspace.hpp
@@ -77,7 +77,7 @@ class AOTMetaspace : AllStatic {
 
   static void dump_static_archive(TRAPS) NOT_CDS_RETURN;
 #ifdef _LP64
- static void init_heap_settings() NOT_CDS_JAVA_HEAP_RETURN;
+  static void init_heap_settings() NOT_CDS_JAVA_HEAP_RETURN;
 #endif
 
 private:
@@ -93,6 +93,7 @@ public:
   static void initialize_for_static_dump() NOT_CDS_RETURN;
   static void initialize_runtime_shared_and_meta_spaces() NOT_CDS_RETURN;
   static void post_initialize(TRAPS) NOT_CDS_RETURN;
+  static void get_aot_code_region_size() NOT_CDS_RETURN;
 
   static void print_on(outputStream* st);
 

--- a/src/hotspot/share/cds/aotStreamedHeapLoader.cpp
+++ b/src/hotspot/share/cds/aotStreamedHeapLoader.cpp
@@ -798,6 +798,8 @@ void AOTStreamedHeapLoader::cleanup() {
   }
 
   FREE_C_HEAP_ARRAY(_object_index_to_heap_object_table);
+  _object_index_to_heap_object_table = nullptr;
+  _roots_archive = nullptr;
 
   // Unmap regions
   FileMapInfo::current_info()->unmap_region(AOTMetaspace::hp);

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -42,7 +42,6 @@
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionaryShared.hpp"
 #include "classfile/vmClasses.hpp"
-#include "code/aotCodeCache.hpp"
 #include "interpreter/abstractInterpreter.hpp"
 #include "jvm.h"
 #include "logging/log.hpp"
@@ -183,6 +182,7 @@ ArchiveBuilder::ArchiveBuilder() :
   _ptrmap(mtClassShared),
   _rw_ptrmap(mtClassShared),
   _ro_ptrmap(mtClassShared),
+  _ac_ptrmap(mtClassShared),
   _rw_src_objs(),
   _ro_src_objs(),
   _src_obj_table(INITIAL_TABLE_SIZE, MAX_TABLE_SIZE),
@@ -1136,11 +1136,12 @@ void ArchiveBuilder::write_archive(FileMapInfo* mapinfo, AOTMappedHeapInfo* mapp
   write_region(mapinfo, AOTMetaspace::ac, &_ac_region, /*read_only=*/false,/*allow_exec=*/false);
 
   // Split pointer map into read-write and read-only bitmaps
-  ArchivePtrMarker::initialize_rw_ro_maps(&_rw_ptrmap, &_ro_ptrmap);
+  ArchivePtrMarker::initialize_rw_ro_ac_maps(&_rw_ptrmap, &_ro_ptrmap, &_ac_ptrmap);
 
   size_t bitmap_size_in_bytes;
   char* bitmap = mapinfo->write_bitmap_region(ArchivePtrMarker::rw_ptrmap(),
                                               ArchivePtrMarker::ro_ptrmap(),
+                                              ArchivePtrMarker::ac_ptrmap(),
                                               mapped_heap_info,
                                               streamed_heap_info,
                                               bitmap_size_in_bytes);
@@ -1160,8 +1161,8 @@ void ArchiveBuilder::write_archive(FileMapInfo* mapinfo, AOTMappedHeapInfo* mapp
   mapinfo->write_header();
   mapinfo->close();
 
+  aot_log_info(aot)("Full module graph = %s", CDSConfig::is_dumping_full_module_graph() ? "enabled" : "disabled");
   if (log_is_enabled(Info, aot)) {
-    log_info(aot)("Full module graph = %s", CDSConfig::is_dumping_full_module_graph() ? "enabled" : "disabled");
     print_stats();
   }
 

--- a/src/hotspot/share/cds/archiveBuilder.hpp
+++ b/src/hotspot/share/cds/archiveBuilder.hpp
@@ -228,6 +228,7 @@ private:
   // _ptrmap is split into these two bitmaps which are written into the archive.
   CHeapBitMap _rw_ptrmap;   // marks pointers in the RW region
   CHeapBitMap _ro_ptrmap;   // marks pointers in the RO region
+  CHeapBitMap _ac_ptrmap;   // marks pointers in the CC region
 
   SourceObjList _rw_src_objs;                 // objs to put in rw region
   SourceObjList _ro_src_objs;                 // objs to put in ro region

--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -53,6 +53,7 @@
 CHeapBitMap* ArchivePtrMarker::_ptrmap = nullptr;
 CHeapBitMap* ArchivePtrMarker::_rw_ptrmap = nullptr;
 CHeapBitMap* ArchivePtrMarker::_ro_ptrmap = nullptr;
+CHeapBitMap* ArchivePtrMarker::_ac_ptrmap = nullptr;
 VirtualSpace* ArchivePtrMarker::_vs;
 
 bool ArchivePtrMarker::_compacted;
@@ -61,6 +62,7 @@ void ArchivePtrMarker::initialize(CHeapBitMap* ptrmap, VirtualSpace* vs) {
   assert(_ptrmap == nullptr, "initialize only once");
   assert(_rw_ptrmap == nullptr, "initialize only once");
   assert(_ro_ptrmap == nullptr, "initialize only once");
+  assert(_ac_ptrmap == nullptr, "initialize only once");
   _vs = vs;
   _compacted = false;
   _ptrmap = ptrmap;
@@ -76,29 +78,34 @@ void ArchivePtrMarker::initialize(CHeapBitMap* ptrmap, VirtualSpace* vs) {
   _ptrmap->initialize(estimated_archive_size / sizeof(intptr_t));
 }
 
-void ArchivePtrMarker::initialize_rw_ro_maps(CHeapBitMap* rw_ptrmap, CHeapBitMap* ro_ptrmap) {
+void ArchivePtrMarker::initialize_rw_ro_ac_maps(CHeapBitMap* rw_ptrmap, CHeapBitMap* ro_ptrmap, CHeapBitMap* ac_ptrmap) {
   address* buff_bottom = (address*)ArchiveBuilder::current()->buffer_bottom();
   address* rw_bottom   = (address*)ArchiveBuilder::current()->rw_region()->base();
   address* ro_bottom   = (address*)ArchiveBuilder::current()->ro_region()->base();
+  address* ac_bottom   = (address*)ArchiveBuilder::current()->ac_region()->base();
 
-  // The bit in _ptrmap that cover the very first word in the rw/ro regions.
+  // The bit in _ptrmap that cover the very first word in the rw/ro/ac regions.
   size_t rw_start = rw_bottom - buff_bottom;
   size_t ro_start = ro_bottom - buff_bottom;
+  size_t ac_start = ac_bottom - buff_bottom;
 
   // The number of bits used by the rw/ro ptrmaps. We might have lots of zero
   // bits at the bottom and top of rw/ro ptrmaps, but these zeros will be
   // removed by FileMapInfo::write_bitmap_region().
   size_t rw_size = ArchiveBuilder::current()->rw_region()->used() / sizeof(address);
   size_t ro_size = ArchiveBuilder::current()->ro_region()->used() / sizeof(address);
+  size_t ac_size = ArchiveBuilder::current()->ac_region()->used() / sizeof(address);
 
   // The last (exclusive) bit in _ptrmap that covers the rw/ro regions.
   // Note: _ptrmap is dynamically expanded only when an actual pointer is written, so
   // it may not be as large as we want.
   size_t rw_end = MIN2<size_t>(rw_start + rw_size, _ptrmap->size());
   size_t ro_end = MIN2<size_t>(ro_start + ro_size, _ptrmap->size());
+  size_t ac_end = MIN2<size_t>(ac_start + ac_size, _ptrmap->size());
 
   rw_ptrmap->initialize(rw_size);
   ro_ptrmap->initialize(ro_size);
+  ac_ptrmap->initialize(ac_size);
 
   for (size_t rw_bit = rw_start; rw_bit < rw_end; rw_bit++) {
     rw_ptrmap->at_put(rw_bit - rw_start, _ptrmap->at(rw_bit));
@@ -108,8 +115,13 @@ void ArchivePtrMarker::initialize_rw_ro_maps(CHeapBitMap* rw_ptrmap, CHeapBitMap
     ro_ptrmap->at_put(ro_bit - ro_start, _ptrmap->at(ro_bit));
   }
 
+  for (size_t ac_bit = ac_start; ac_bit < ac_end; ac_bit++) {
+    ac_ptrmap->at_put(ac_bit - ac_start, _ptrmap->at(ac_bit));
+  }
+
   _rw_ptrmap = rw_ptrmap;
   _ro_ptrmap = ro_ptrmap;
+  _ac_ptrmap = ac_ptrmap;
 }
 
 void ArchivePtrMarker::mark_pointer(address* ptr_loc) {
@@ -475,8 +487,6 @@ void DumpRegion::pack(DumpRegion* next) {
     _end = (char*)align_up(_top, AOTMetaspace::core_region_alignment());
     _is_packed = true;
   }
-  _end = (char*)align_up(_top, AOTMetaspace::core_region_alignment());
-  _is_packed = true;
   if (next != nullptr) {
     next->_rs = _rs;
     next->_vs = _vs;

--- a/src/hotspot/share/cds/archiveUtils.hpp
+++ b/src/hotspot/share/cds/archiveUtils.hpp
@@ -55,6 +55,7 @@ class ArchivePtrMarker : AllStatic {
   static CHeapBitMap*  _ptrmap;
   static CHeapBitMap*  _rw_ptrmap;
   static CHeapBitMap*  _ro_ptrmap;
+  static CHeapBitMap*  _ac_ptrmap;
   static VirtualSpace* _vs;
 
   // Once _ptrmap is compacted, we don't allow bit marking anymore. This is to
@@ -66,7 +67,7 @@ class ArchivePtrMarker : AllStatic {
 
 public:
   static void initialize(CHeapBitMap* ptrmap, VirtualSpace* vs);
-  static void initialize_rw_ro_maps(CHeapBitMap* rw_ptrmap, CHeapBitMap* ro_ptrmap);
+  static void initialize_rw_ro_ac_maps(CHeapBitMap* rw_ptrmap, CHeapBitMap* ro_ptrmap, CHeapBitMap* ac_ptrmap);
   static void mark_pointer(address* ptr_loc);
   static void clear_pointer(address* ptr_loc);
   static void compact(address relocatable_base, address relocatable_end);
@@ -95,10 +96,15 @@ public:
     return _ro_ptrmap;
   }
 
+  static CHeapBitMap* ac_ptrmap() {
+    return _ac_ptrmap;
+  }
+
   static void reset_map_and_vs() {
     _ptrmap = nullptr;
     _rw_ptrmap = nullptr;
     _ro_ptrmap = nullptr;
+    _ac_ptrmap = nullptr;
     _vs = nullptr;
   }
 };

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -24,17 +24,22 @@
 
 #include "cds/aotLogging.hpp"
 #include "cds/aotMapLogger.hpp"
+#include "cds/aotMetaspace.hpp"
+#include "cds/cds_globals.hpp"
 #include "cds/cdsConfig.hpp"
 #include "cds/classListWriter.hpp"
 #include "cds/filemap.hpp"
 #include "cds/heapShared.inline.hpp"
 #include "classfile/classLoaderDataShared.hpp"
 #include "classfile/moduleEntry.hpp"
+#include "classfile/systemDictionaryShared.hpp"
 #include "code/aotCodeCache.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "include/jvm_io.h"
 #include "logging/log.hpp"
 #include "memory/universe.hpp"
 #include "prims/jvmtiAgentList.hpp"
+#include "prims/jvmtiExport.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
@@ -110,6 +115,26 @@ void CDSConfig::ergo_initialize() {
   AOTMapLogger::ergo_initialize();
 
   setup_compiler_args();
+
+#ifdef _LP64
+  //
+  // By default, when using AOTClassLinking, use the CompressedOops::HeapBasedNarrowOop
+  // mode so that AOT code can always work regardless of runtime heap range.
+  //
+  // If you are *absolutely sure* that the CompressedOops::mode() will be the same
+  // between training and production runs (e.g., if you specify -Xmx128m for
+  // both training and production runs, and you know the OS will always reserve
+  // the heap under 4GB), you can explicitly disable this with:
+  //     java -XX:+UnlockDiagnosticVMOptions -XX:-AOTCompatibleOopCompression ...
+  // However, this is risky and there's a chance that the production run will be slower
+  // than expected because it is unable to load the AOT code cache.
+  //
+  if (UseCompressedOops && AOTCodeCache::is_caching_enabled()) {
+    FLAG_SET_ERGO_IF_DEFAULT(AOTCompatibleOopCompression, true);
+  } else {
+    FLAG_SET_ERGO(AOTCompatibleOopCompression, false);
+  }
+#endif // _LP64
 
   if (is_dumping_full_module_graph()) {
     precond(allow_only_single_java_thread());
@@ -651,11 +676,17 @@ bool CDSConfig::check_vm_args_consistency(bool patch_mod_javabase, bool mode_fla
   }
 
   if (AOTClassLinking) {
-    // If AOTClassLinking is specified, enable all AOT optimizations by default.
+    // If AOTClassLinking is specified, enable all these optimizations by default.
     FLAG_SET_ERGO_IF_DEFAULT(AOTInvokeDynamicLinking, true);
   } else {
-    // AOTInvokeDynamicLinking depends on AOTClassLinking.
+    // All of these *might* depend on AOTClassLinking. Better be safe than sorry.
     FLAG_SET_ERGO(AOTInvokeDynamicLinking, false);
+
+    if (CDSConfig::is_dumping_archive()) {
+      FLAG_SET_ERGO(AOTRecordTraining, false);
+      FLAG_SET_ERGO(AOTReplayTraining, false);
+      AOTCodeCache::disable_caching();
+    }
   }
 
   if (is_dumping_static_archive()) {
@@ -733,7 +764,8 @@ bool CDSConfig::check_vm_args_consistency(bool patch_mod_javabase, bool mode_fla
 
 void CDSConfig::setup_compiler_args() {
   // AOT profiles and AOT-compiled code are supported only in the JEP 483 workflow.
-  bool can_dump_profile_and_compiled_code = AOTClassLinking && new_aot_flags_used();
+  bool can_dump_profile_and_compiled_code = !CompilerConfig::is_interpreter_only() && AOTClassLinking && new_aot_flags_used();
+  bool can_use_profile_and_compiled_code = !CompilerConfig::is_interpreter_only() && new_aot_flags_used();
 
   if (is_dumping_preimage_static_archive() && can_dump_profile_and_compiled_code) {
     // JEP 483 workflow -- training
@@ -744,13 +776,24 @@ void CDSConfig::setup_compiler_args() {
     // JEP 483 workflow -- assembly
     FLAG_SET_ERGO(AOTRecordTraining, false);
     FLAG_SET_ERGO_IF_DEFAULT(AOTReplayTraining, true);
-    AOTCodeCache::enable_caching(); // Generate AOT code during assembly phase.
+    // Generate AOT code only when training data enabled
+    if (AOTReplayTraining) {
+      AOTCodeCache::enable_caching();
+    } else {
+      AOTCodeCache::disable_caching();
+    }
     disable_dumping_aot_code();     // Don't dump AOT code until metadata and heap are dumped.
-  } else if (is_using_archive() && new_aot_flags_used()) {
+  } else if (is_using_archive() && can_use_profile_and_compiled_code) {
     // JEP 483 workflow -- production
     FLAG_SET_ERGO(AOTRecordTraining, false);
     FLAG_SET_ERGO_IF_DEFAULT(AOTReplayTraining, true);
-    AOTCodeCache::enable_caching();
+    // Use AOT code only when training data enabled
+    if (AOTReplayTraining) {
+      AOTCodeCache::enable_caching();
+    } else {
+      AOTCodeCache::disable_caching();
+      // Use separate compilation queues and threads for AOT code loading
+    }
   } else {
     FLAG_SET_ERGO(AOTReplayTraining, false);
     FLAG_SET_ERGO(AOTRecordTraining, false);
@@ -837,7 +880,7 @@ bool CDSConfig::is_using_only_default_archive() {
 }
 
 bool CDSConfig::is_logging_lambda_form_invokers() {
-  return ClassListWriter::is_enabled() || is_dumping_dynamic_archive();
+  return ClassListWriter::is_enabled() || is_dumping_dynamic_archive() || is_dumping_preimage_static_archive();
 }
 
 bool CDSConfig::is_dumping_regenerated_lambdaform_invokers() {

--- a/src/hotspot/share/cds/cds_globals.hpp
+++ b/src/hotspot/share/cds/cds_globals.hpp
@@ -150,10 +150,13 @@
   product(bool, AOTVerifyTrainingData, trueInDebug, DIAGNOSTIC,             \
           "Verify archived training data")                                  \
                                                                             \
-  product(bool, AOTCompileEagerly, false, EXPERIMENTAL,                     \
-          "Compile methods as soon as possible")                            \
+  product(bool, AOTCompileEagerly, false, DIAGNOSTIC,                       \
+          "Compile methods as soon as possible during production run")      \
                                                                             \
   /* AOT Code flags */                                                      \
+                                                                            \
+  product(bool, AOTCodeCaching, false, DIAGNOSTIC,                          \
+          "Enable saving and restoring JIT compiled code in AOT cache")     \
                                                                             \
   product(bool, AOTAdapterCaching, false, DIAGNOSTIC,                       \
           "Enable saving and restoring i2c2i adapters in AOT cache")        \
@@ -161,7 +164,7 @@
   product(bool, AOTStubCaching, false, DIAGNOSTIC,                          \
           "Enable saving and restoring stubs and code blobs in AOT cache")  \
                                                                             \
-  product(uint, AOTCodeMaxSize, 10*M, DIAGNOSTIC,                           \
+  product(uint, AOTCodeMaxSize, 512*M, DIAGNOSTIC,                          \
           "Buffer size in bytes for AOT code caching")                      \
           range(1*M, CODE_CACHE_SIZE_LIMIT)                                 \
                                                                             \

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -324,6 +324,7 @@ void FileMapHeader::print(outputStream* st) {
   st->print_cr("- use_optimized_module_handling:            %d", _use_optimized_module_handling);
   st->print_cr("- has_full_module_graph                     %d", _has_full_module_graph);
   st->print_cr("- has_aot_linked_classes                    %d", _has_aot_linked_classes);
+  st->print_cr("- ptrmap_size_in_bits:                      %zu", _ptrmap_size_in_bits);
 }
 
 bool FileMapInfo::validate_class_location() {
@@ -967,6 +968,7 @@ size_t FileMapInfo::remove_bitmap_zeros(CHeapBitMap* map) {
 
 char* FileMapInfo::write_bitmap_region(CHeapBitMap* rw_ptrmap,
                                        CHeapBitMap* ro_ptrmap,
+                                       CHeapBitMap* ac_ptrmap,
                                        AOTMappedHeapInfo* mapped_heap_info,
                                        AOTStreamedHeapInfo* streamed_heap_info,
                                        size_t &size_in_bytes) {
@@ -974,7 +976,7 @@ char* FileMapInfo::write_bitmap_region(CHeapBitMap* rw_ptrmap,
   size_t removed_ro_leading_zeros = remove_bitmap_zeros(ro_ptrmap);
   header()->set_rw_ptrmap_start_pos(removed_rw_leading_zeros);
   header()->set_ro_ptrmap_start_pos(removed_ro_leading_zeros);
-  size_in_bytes = rw_ptrmap->size_in_bytes() + ro_ptrmap->size_in_bytes();
+  size_in_bytes = rw_ptrmap->size_in_bytes() + ro_ptrmap->size_in_bytes() + ac_ptrmap->size_in_bytes();
 
   if (mapped_heap_info != nullptr && mapped_heap_info->is_used()) {
     // Remove leading and trailing zeros
@@ -992,9 +994,10 @@ char* FileMapInfo::write_bitmap_region(CHeapBitMap* rw_ptrmap,
     size_in_bytes += streamed_heap_info->oopmap()->size_in_bytes();
   }
 
-  // The bitmap region contains up to 4 parts:
+  // The bitmap region contains up to 5 parts:
   // rw_ptrmap:                  metaspace pointers inside the read-write region
   // ro_ptrmap:                  metaspace pointers inside the read-only region
+  // ac_ptrmap:                  metaspace pointers inside the AOT code cache region
   // *_heap_info->oopmap():      Java oop pointers in the heap region
   // mapped_heap_info->ptrmap(): metaspace pointers in the heap region
   char* buffer = NEW_C_HEAP_ARRAY(char, size_in_bytes, mtClassShared);
@@ -1005,6 +1008,11 @@ char* FileMapInfo::write_bitmap_region(CHeapBitMap* rw_ptrmap,
 
   region_at(AOTMetaspace::ro)->init_ptrmap(written, ro_ptrmap->size());
   written = write_bitmap(ro_ptrmap, buffer, written);
+
+  if (ac_ptrmap->size() > 0) {
+    region_at(AOTMetaspace::ac)->init_ptrmap(written, ac_ptrmap->size());
+    written = write_bitmap(ac_ptrmap, buffer, written);
+  }
 
   if (mapped_heap_info != nullptr && mapped_heap_info->is_used()) {
     assert(HeapShared::is_writing_mapping_mode(), "unexpected dumping mode");
@@ -1272,8 +1280,10 @@ MapArchiveResult FileMapInfo::map_region(int i, intx addr_delta, char* mapped_ba
     // Note that this may either be a "fresh" mapping into unreserved address
     // space (Windows, first mapping attempt), or a mapping into pre-reserved
     // space (Posix). See also comment in AOTMetaspace::map_archives().
+    bool read_only = r->read_only() && !CDSConfig::is_dumping_final_static_archive();
+
     char* base = map_memory(_fd, _full_path, r->file_offset(),
-                            requested_addr, size, r->read_only(),
+                            requested_addr, size, read_only,
                             r->allow_exec(), mtClassShared);
     if (base != requested_addr) {
       AOTMetaspace::report_loading_error("Unable to map %s shared space at " INTPTR_FORMAT,
@@ -1375,11 +1385,58 @@ bool FileMapInfo::map_aot_code_region(ReservedSpace rs) {
 
     r->set_mapped_from_file(true);
     r->set_mapped_base(mapped_base);
+    relocate_pointers_in_aot_code_region();
     aot_log_info(aot)("Mapped static  region #%d at base " INTPTR_FORMAT " top " INTPTR_FORMAT " (%s)",
                   AOTMetaspace::ac, p2i(r->mapped_base()), p2i(r->mapped_end()),
                   shared_region_name[AOTMetaspace::ac]);
     return true;
   }
+}
+
+class CachedCodeRelocator: public BitMapClosure {
+  address _code_requested_base;
+  address* _patch_base;
+  intx _code_delta;
+  intx _metadata_delta;
+
+public:
+  CachedCodeRelocator(address code_requested_base, address code_mapped_base,
+                      intx metadata_delta) {
+    _code_requested_base = code_requested_base;
+    _patch_base = (address*)code_mapped_base;
+    _code_delta = code_mapped_base - code_requested_base;
+    _metadata_delta = metadata_delta;
+  }
+
+  bool do_bit(size_t offset) {
+    address* p = _patch_base + offset;
+    address requested_ptr = *p;
+    if (requested_ptr < _code_requested_base) {
+      *p = requested_ptr + _metadata_delta;
+    } else {
+      *p = requested_ptr + _code_delta;
+    }
+    return true; // keep iterating
+  }
+};
+
+void FileMapInfo::relocate_pointers_in_aot_code_region() {
+  FileMapRegion* r = region_at(AOTMetaspace::ac);
+  char* bitmap_base = map_bitmap_region();
+
+  BitMapView ac_ptrmap = ptrmap_view(AOTMetaspace::ac);
+  if (ac_ptrmap.size() == 0) {
+    return;
+  }
+
+  address core_regions_requested_base = (address)header()->requested_base_address();
+  address core_regions_mapped_base = (address)header()->mapped_base_address();
+  address ac_region_requested_base = core_regions_requested_base + r->mapping_offset();
+  address ac_region_mapped_base = (address)r->mapped_base();
+
+  CachedCodeRelocator patcher(ac_region_requested_base, ac_region_mapped_base,
+                              core_regions_mapped_base - core_regions_requested_base);
+  ac_ptrmap.iterate(&patcher);
 }
 
 class SharedDataRelocationTask : public ArchiveWorkerTask {

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -144,6 +144,7 @@ private:
                                         // some expensive operations.
   bool   _has_aot_linked_classes;       // Was the CDS archive created with -XX:+AOTClassLinking
   bool   _has_full_module_graph;        // Does this CDS archive contain the full archived module graph?
+  size_t _ptrmap_size_in_bits;          // Size of pointer relocation bitmap
   size_t _rw_ptrmap_start_pos;          // The first bit in the ptrmap corresponds to this position in the rw region
   size_t _ro_ptrmap_start_pos;          // The first bit in the ptrmap corresponds to this position in the ro region
 
@@ -198,6 +199,7 @@ public:
   char* mapped_base_address()              const { return _mapped_base_address; }
   bool has_platform_or_app_classes()       const { return _has_platform_or_app_classes; }
   bool has_aot_linked_classes()            const { return _has_aot_linked_classes; }
+  size_t ptrmap_size_in_bits()             const { return _ptrmap_size_in_bits; }
   bool compressed_oops()                   const { return _compressed_oops; }
   bool compatible_oop_compression()        const { return _compatible_oop_compression; }
   int narrow_klass_pointer_bits()          const { return _narrow_klass_pointer_bits; }
@@ -370,6 +372,7 @@ public:
   size_t remove_bitmap_zeros(CHeapBitMap* map);
   char* write_bitmap_region(CHeapBitMap* rw_ptrmap,
                             CHeapBitMap* ro_ptrmap,
+                            CHeapBitMap* ac_ptrmap,
                             AOTMappedHeapInfo* mapped_heap_info,
                             AOTStreamedHeapInfo* streamed_heap_info,
                             size_t &size_in_bytes);
@@ -453,6 +456,7 @@ public:
 
   MapArchiveResult map_region(int i, intx addr_delta, char* mapped_base_address, ReservedSpace rs);
   bool  relocate_pointers_in_core_regions(intx addr_delta);
+  void  relocate_pointers_in_aot_code_region();
   char* map_auxiliary_region(int region_index, bool read_only);
 
 public:

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -51,6 +51,7 @@
 #include "classfile/systemDictionaryShared.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
+#include "code/aotCodeCache.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/gcLocker.hpp"
 #include "gc/shared/gcVMOperations.hpp"
@@ -634,6 +635,10 @@ bool HeapShared::archive_object(oop obj, oop referrer, KlassSubGraphInfo* subgra
         InstanceKlass* method_holder = m->method_holder();
         AOTArtifactFinder::add_cached_class(method_holder);
       }
+    } else if (AOTCodeCache::is_dumping_code() &&
+               (java_lang_invoke_MethodHandle::is_instance(obj) || is_interned_string(obj))) {
+      // Needed by AOT compiler.
+      append_root(obj);
     }
   }
 
@@ -1060,7 +1065,11 @@ void KlassSubGraphInfo::add_subgraph_entry_field(int static_field_offset, oop v)
       new (mtClass) GrowableArray<int>(10, mtClass);
   }
   _subgraph_entry_fields->append(static_field_offset);
-  _subgraph_entry_fields->append(HeapShared::append_root(v));
+  if (v == nullptr) {
+    _subgraph_entry_fields->append(-1);
+  } else {
+    _subgraph_entry_fields->append(HeapShared::append_root(v));
+  }
 }
 
 // Add the Klass* for an object in the current KlassSubGraphInfo's subgraphs.
@@ -1363,16 +1372,35 @@ void HeapShared::resolve_classes_for_subgraph_of(JavaThread* current, Klass* k) 
   }
 }
 
+static const char* java_lang_invoke_core_klasses[] = {
+  "java/lang/invoke/Invokers$Holder",
+  "java/lang/invoke/MethodHandle",
+  "java/lang/invoke/MethodHandleNatives",
+  "java/lang/invoke/DirectMethodHandle$Holder",
+  "java/lang/invoke/DelegatingMethodHandle$Holder",
+  "java/lang/invoke/LambdaForm$Holder",
+  "java/lang/invoke/BoundMethodHandle$Species_L",
+};
+
 void HeapShared::initialize_java_lang_invoke(TRAPS) {
   if (CDSConfig::is_using_aot_linked_classes() || CDSConfig::is_dumping_method_handles()) {
-    resolve_or_init("java/lang/invoke/Invokers$Holder", true, CHECK);
-    resolve_or_init("java/lang/invoke/MethodHandle", true, CHECK);
-    resolve_or_init("java/lang/invoke/MethodHandleNatives", true, CHECK);
-    resolve_or_init("java/lang/invoke/DirectMethodHandle$Holder", true, CHECK);
-    resolve_or_init("java/lang/invoke/DelegatingMethodHandle$Holder", true, CHECK);
-    resolve_or_init("java/lang/invoke/LambdaForm$Holder", true, CHECK);
-    resolve_or_init("java/lang/invoke/BoundMethodHandle$Species_L", true, CHECK);
+    int len = sizeof(java_lang_invoke_core_klasses)/sizeof(char*);
+    for (int i = 0; i < len; i++) {
+      resolve_or_init(java_lang_invoke_core_klasses[i], true, CHECK);
+    }
   }
+}
+
+bool HeapShared::is_core_java_lang_invoke_klass(InstanceKlass* klass) {
+  ResourceMark rm;
+  char* s2 = klass->name()->as_C_string();
+  int len = sizeof(java_lang_invoke_core_klasses)/sizeof(char*);
+  for (int i = 0; i < len; i++) {
+    if (strcmp(java_lang_invoke_core_klasses[i], s2) == 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // Initialize the InstanceKlasses of objects that are reachable from the following roots:
@@ -1551,7 +1579,12 @@ void HeapShared::init_archived_fields_for(Klass* k, const ArchivedKlassSubGraphI
       int root_index = entry_field_records->at(i+1);
       // Load the subgraph entry fields from the record and store them back to
       // the corresponding fields within the mirror.
-      oop v = get_root(root_index, /*clear=*/true);
+      oop v;
+      if (root_index < 0) {
+        v = nullptr;
+      } else {
+        v = get_root(root_index, /*clear=*/true);
+      }
       oop m = k->java_mirror();
       if (k->has_aot_initialized_mirror()) {
         assert(v == m->obj_field(field_offset), "must be aot-initialized");

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -477,6 +477,7 @@ private:
   static void initialize_java_lang_invoke(TRAPS) NOT_CDS_JAVA_HEAP_RETURN;
   static void init_classes_for_special_subgraph(Handle loader, TRAPS) NOT_CDS_JAVA_HEAP_RETURN;
 
+  static bool is_core_java_lang_invoke_klass(InstanceKlass* ik) NOT_CDS_JAVA_HEAP_RETURN_(false);
   static bool is_lambda_form_klass(InstanceKlass* ik) NOT_CDS_JAVA_HEAP_RETURN_(false);
   static bool is_lambda_proxy_klass(InstanceKlass* ik) NOT_CDS_JAVA_HEAP_RETURN_(false);
   static bool is_string_concat_klass(InstanceKlass* ik) NOT_CDS_JAVA_HEAP_RETURN_(false);

--- a/src/hotspot/share/ci/ciConstant.cpp
+++ b/src/hotspot/share/ci/ciConstant.cpp
@@ -61,6 +61,19 @@ bool ciConstant::is_loaded() const {
 }
 
 // ------------------------------------------------------------------
+// ciConstant::should_be_constant
+bool ciConstant::should_be_constant() const {
+  if (is_valid()) {
+    if (is_reference_type(basic_type())) {
+      return as_object()->should_be_constant();
+    } else {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ------------------------------------------------------------------
 // ciConstant::print
 void ciConstant::print() {
   tty->print("<ciConstant type=%s value=",

--- a/src/hotspot/share/ci/ciConstant.hpp
+++ b/src/hotspot/share/ci/ciConstant.hpp
@@ -117,6 +117,8 @@ public:
 
   bool is_loaded() const;
 
+  bool should_be_constant() const;
+
   // Debugging output
   void print();
 };

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -22,6 +22,9 @@
  *
  */
 
+#include "cds/aotCacheAccess.hpp"
+#include "cds/aotConstantPoolResolver.hpp"
+#include "cds/heapShared.hpp"
 #include "ci/ciConstant.hpp"
 #include "ci/ciEnv.hpp"
 #include "ci/ciField.hpp"
@@ -37,6 +40,7 @@
 #include "classfile/systemDictionary.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/codeCache.hpp"
 #include "code/scopeDesc.hpp"
 #include "compiler/compilationLog.hpp"
@@ -65,6 +69,7 @@
 #include "oops/oop.inline.hpp"
 #include "oops/resolvedIndyEntry.hpp"
 #include "oops/symbolHandle.hpp"
+#include "oops/trainingData.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/methodHandles.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
@@ -117,6 +122,7 @@ ciEnv::ciEnv(CompileTask* task)
   _debug_info = nullptr;
   _dependencies = nullptr;
   _inc_decompile_count_on_failure = true;
+  _codecache_full = false;
   _compilable = MethodCompilable;
   _break_at_compile = false;
   _compiler_data = nullptr;
@@ -251,6 +257,7 @@ ciEnv::ciEnv(Arena* arena) : _ciEnv_arena(mtCompiler, Arena::Tag::tag_cienv) {
   _debug_info = nullptr;
   _dependencies = nullptr;
   _inc_decompile_count_on_failure = true;
+  _codecache_full = false;
   _compilable = MethodCompilable_never;
   _break_at_compile = false;
   _compiler_data = nullptr;
@@ -667,7 +674,7 @@ ciConstant ciEnv::get_constant_by_index_impl(const constantPoolHandle& cpool,
                                              ciInstanceKlass* accessor) {
   if (obj_index >= 0) {
     ciConstant con = get_resolved_constant(cpool, obj_index);
-    if (con.is_valid()) {
+    if (con.should_be_constant()) {
       return con;
     }
   }
@@ -821,7 +828,15 @@ ciMethod* ciEnv::get_method_by_index_impl(const constantPoolHandle& cpool,
     // Patch the call site to the nmethod entry point of the static compiled lambda form.
     // As with other two-component call sites, both values must be independently verified.
     assert(index < cpool->cache()->resolved_indy_entries_length(), "impossible");
-    Method* adapter = cpool->resolved_indy_entry_at(index)->method();
+    ResolvedIndyEntry* indy_info = cpool->resolved_indy_entry_at(index);
+    Method* adapter = indy_info->method();
+#if INCLUDE_CDS
+    if (is_aot_compile() && !AOTConstantPoolResolver::is_resolution_deterministic(cpool(), indy_info->constant_pool_index())) {
+      // This is an indy callsite that was resolved as a side effect of VM bootstrap, but
+      // it cannot be cached in the resolved state, so AOT code should not reference it.
+      adapter = nullptr;
+    }
+#endif
     // Resolved if the adapter is non null.
     if (adapter != nullptr) {
       return get_method(adapter);
@@ -868,11 +883,11 @@ ciMethod* ciEnv::get_method_by_index_impl(const constantPoolHandle& cpool,
       constantTag tag = cpool->tag_ref_at(index, bc);
       assert(accessor->get_instanceKlass() == cpool->pool_holder(), "not the pool holder?");
       Method* m = lookup_method(accessor, holder, name_sym, sig_sym, bc, tag);
-      if (m != nullptr &&
-          (bc == Bytecodes::_invokestatic
-           ?  m->method_holder()->is_not_initialized()
-           : !m->method_holder()->is_loaded())) {
-        m = nullptr;
+      if (m != nullptr) {
+        ciInstanceKlass* cik = get_instance_klass(m->method_holder());
+        if ((bc == Bytecodes::_invokestatic && cik->is_not_initialized()) || !cik->is_loaded()) {
+          m = nullptr;
+        }
       }
       if (m != nullptr && ReplayCompiles && !ciReplay::is_loaded(m)) {
         m = nullptr;
@@ -953,7 +968,7 @@ bool ciEnv::is_in_vm() {
 // Check for changes during compilation (e.g. class loads, evolution,
 // breakpoints, call site invalidation).
 void ciEnv::validate_compile_task_dependencies(ciMethod* target) {
-  if (failing())  return;  // no need for further checks
+  assert(!failing(), "should not call this when failing");
 
   Dependencies::DepType result = dependencies()->validate_dependencies(_task);
   if (result != Dependencies::end_marker) {
@@ -968,8 +983,199 @@ void ciEnv::validate_compile_task_dependencies(ciMethod* target) {
   }
 }
 
+// is_loading_aot_code = true implies loading compiled code from AOT code cache
+bool ciEnv::is_compilation_valid(JavaThread* thread, ciMethod* target, bool install_code, bool is_loading_aot_code, bool preload) {
+  methodHandle method(thread, target->get_Method());
+
+  // Change in Jvmti state may invalidate compilation.
+  if (!failing() && jvmti_state_changed()) {
+    record_failure("Jvmti state change invalidated dependencies");
+  }
+
+  // Change in DTrace flags may invalidate compilation.
+  if (!failing() &&
+      ( (!dtrace_method_probes() && DTraceMethodProbes) ||
+        (!dtrace_alloc_probes() && DTraceAllocProbes) )) {
+    record_failure("DTrace flags change invalidated dependencies");
+  }
+
+  if (!failing() && target->needs_clinit_barrier() &&
+      target->holder()->is_in_error_state()) {
+    record_failure("method holder is in error state");
+  }
+
+  if (!failing() && !is_loading_aot_code) {
+    if (log() != nullptr) {
+      // Log the dependencies which this compilation declares.
+      dependencies()->log_all_dependencies();
+    }
+
+    // Encode the dependencies now, so we can check them right away.
+    dependencies()->encode_content_bytes();
+  }
+  // Check for {class loads, evolution, breakpoints, ...} during compilation.
+  // This check is skipped for RepeatCompilation request.
+  // Execute this check for VerifyAOTCode when loading AOT code.
+  // Note, RepeatCompilation request is ignored for AOT code load.
+  if (!failing() && (install_code || is_loading_aot_code)) {
+    // Check for {class loads, evolution, breakpoints, ...} during compilation
+    validate_compile_task_dependencies(target);
+    if (failing() && preload) {
+      ResourceMark rm;
+      char* method_name = method->name_and_sig_as_C_string();
+      log_info(aot, codecache, nmethod)("preload code for '%s' failed dependency check", method_name);
+    }
+  }
+
+  if (failing()) {
+    // While not a true deoptimization, it is a preemptive decompile.
+    MethodData* mdo = method()->method_data();
+    if (mdo != nullptr && _inc_decompile_count_on_failure) {
+      mdo->inc_decompile_count();
+    }
+    return false;
+  }
+  return true;
+}
+
+void ciEnv::make_code_usable(JavaThread* thread, ciMethod* target, bool preload, int entry_bci, AOTCodeEntry* aot_code_entry, nmethod* nm) {
+  methodHandle method(thread, target->get_Method());
+
+  if (entry_bci == InvocationEntryBci) {
+    if (TieredCompilation) {
+      // If there is an old version we're done with it
+      nmethod* old = method->code();
+      if (TraceMethodReplacement && old != nullptr) {
+        ResourceMark rm;
+        char *method_name = method->name_and_sig_as_C_string();
+        tty->print_cr("Replacing method %s", method_name);
+      }
+      if (old != nullptr) {
+        old->make_not_used();
+      }
+    }
+
+    LogTarget(Info, nmethod, install) lt;
+    if (lt.is_enabled()) {
+      ResourceMark rm;
+      char *method_name = method->name_and_sig_as_C_string();
+      lt.print("Installing method (L%d) %s id=%d aot=%s%s%u",
+               task()->comp_level(), method_name, compile_id(),
+               task()->is_aot_load() ? "A" : "", preload ? "P" : "",
+               (aot_code_entry != nullptr ? aot_code_entry->offset() : 0));
+    }
+    // Allow the code to be executed
+    MutexLocker ml(NMethodState_lock, Mutex::_no_safepoint_check_flag);
+    if (nm->make_in_use()) {
+      assert(!preload || method->method_holder()->is_linked(), "AOT code preloaded only for linked method holder");
+      method->set_code(method, nm);
+#if INCLUDE_CDS
+      if (preload) {
+        MethodCounters* mc = method->get_method_counters(thread);
+        assert(mc != nullptr, "CompileBroker should create MethodCounters if it is missing");
+        mc->set_aot_preload_code_entry(aot_code_entry);
+        nm->set_preloaded(true);
+      }
+#endif
+    }
+  } else {
+    LogTarget(Info, nmethod, install) lt;
+    if (lt.is_enabled()) {
+      assert(aot_code_entry == nullptr && !task()->is_aot_load(), "OSR nmethods are not AOT compiled");
+      ResourceMark rm;
+      char *method_name = method->name_and_sig_as_C_string();
+      lt.print("Installing osr method (L%d) %s @ %d id=%u",
+               task()->comp_level(), method_name, entry_bci, compile_id());
+    }
+    MutexLocker ml(NMethodState_lock, Mutex::_no_safepoint_check_flag);
+    if (nm->make_in_use()) {
+      method->method_holder()->add_osr_nmethod(nm);
+    }
+  }
+}
+
+#if INCLUDE_CDS
+// Register method loaded from AOT code cache
+nmethod* ciEnv::register_aot_method(JavaThread* thread,
+                                ciMethod* target,
+                                AbstractCompiler* compiler,
+                                nmethod* archived_nm,
+                                AOTCodeReader* aot_code_reader,
+                                bool install_code)
+{
+  AOTCodeEntry* aot_code_entry = task()->aot_code_entry();
+  precond(aot_code_entry != nullptr);
+  nmethod* nm = nullptr;
+  {
+    methodHandle method(thread, target->get_Method());
+    bool preload = task()->preload(); // Code is preloaded before Java method execution
+
+    // We require method counters to store some method state (max compilation levels) required by the compilation policy.
+    if (method->get_method_counters(thread) == nullptr) {
+      record_failure("can't create method counters");
+      return nullptr;
+    }
+
+    // Check if memory should be freed before allocation
+    CodeCache::gc_on_allocation();
+
+    // To prevent compile queue updates.
+    MutexLocker locker(thread, MethodCompileQueue_lock);
+
+    // Prevent InstanceKlass::add_to_hierarchy from running
+    // and invalidating our dependencies until we install this method.
+    // No safepoints are allowed. Otherwise, class redefinition can occur in between.
+    MutexLocker ml(Compile_lock);
+    NoSafepointVerifier nsv;
+
+    // AOTCode entry indicates this shared code was marked invalid while it was loaded.
+    if (aot_code_entry->not_entrant()) {
+      record_failure("AOT entry was marked not-entrant");
+      return nullptr;
+    }
+
+    if (!is_compilation_valid(thread, target, install_code, /*is_loading_aot_code*/ true, preload)) {
+      return nullptr;
+    }
+
+    if (install_code) {
+      nm = nmethod::new_nmethod(archived_nm, method, compiler, aot_code_reader);
+    }
+    if (nm != nullptr) {
+#ifdef ASSERT
+      LogStreamHandle(Trace, aot, codecache, nmethod) log;
+      if (log.is_enabled()) {
+        ResourceMark rm;
+        stringStream ss;
+        ss.print_cr("=== loaded AOT nmethod code ===");
+        FlagSetting fs(PrintRelocations, true);
+        nm->print_on_impl(&ss);
+        nm->decode(&ss);
+        ss.print_cr("===============================");
+        log.print_cr("%s", ss.freeze());
+      }
+#endif
+      aot_code_entry->set_loaded();
+      assert(nm->has_clinit_barriers() == aot_code_entry->has_clinit_barriers(), "should match");
+      make_code_usable(thread, target, preload, InvocationEntryBci, aot_code_entry, nm);
+    }
+  }
+
+  NoSafepointVerifier nsv;
+  if (nm != nullptr) {
+    // Compilation succeeded, post what we know about it
+    nm->post_compiled_method(task());
+  } else if (install_code) {
+    // The CodeCache is full.
+    record_codecache_full();
+  }
+  return nm;
+  // safepoints are allowed again
+}
+#endif
+
 // ------------------------------------------------------------------
-// ciEnv::register_method
+// Register the result of a compilation including AOT compilation
 void ciEnv::register_method(ciMethod* target,
                             int entry_bci,
                             CodeOffsets* offsets,
@@ -980,11 +1186,14 @@ void ciEnv::register_method(ciMethod* target,
                             ExceptionHandlerTable* handler_table,
                             ImplicitExceptionTable* inc_table,
                             AbstractCompiler* compiler,
+                            bool has_clinit_barriers,
+                            bool for_preload,
                             bool has_unsafe_access,
                             bool has_wide_vectors,
                             bool has_monitors,
                             bool has_scoped_access,
-                            int immediate_oops_patched) {
+                            int immediate_oops_patched,
+                            bool install_code) {
   VM_ENTRY_MARK;
   nmethod* nm = nullptr;
   {
@@ -1012,46 +1221,7 @@ void ciEnv::register_method(ciMethod* target,
     MutexLocker ml(Compile_lock);
     NoSafepointVerifier nsv;
 
-    // Change in Jvmti state may invalidate compilation.
-    if (!failing() && jvmti_state_changed()) {
-      record_failure("Jvmti state change invalidated dependencies");
-    }
-
-    // Change in DTrace flags may invalidate compilation.
-    if (!failing() &&
-        ( (!dtrace_method_probes() && DTraceMethodProbes) ||
-          (!dtrace_alloc_probes() && DTraceAllocProbes) )) {
-      record_failure("DTrace flags change invalidated dependencies");
-    }
-
-    if (!failing() && target->needs_clinit_barrier() &&
-        target->holder()->is_in_error_state()) {
-      record_failure("method holder is in error state");
-    }
-
-    if (!failing()) {
-      if (log() != nullptr) {
-        // Log the dependencies which this compilation declares.
-        dependencies()->log_all_dependencies();
-      }
-
-      // Encode the dependencies now, so we can check them right away.
-      dependencies()->encode_content_bytes();
-
-      // Check for {class loads, evolution, breakpoints, ...} during compilation
-      validate_compile_task_dependencies(target);
-    }
-
-    if (failing()) {
-      // While not a true deoptimization, it is a preemptive decompile.
-      MethodData* mdo = method()->method_data();
-      if (mdo != nullptr && _inc_decompile_count_on_failure) {
-        mdo->inc_decompile_count();
-      }
-
-      // All buffers in the CodeBuffer are allocated in the CodeCache.
-      // If the code buffer is created on each compile attempt
-      // as in C2, then it must be freed.
+    if (!is_compilation_valid(THREAD, target, install_code, /*is_loading_aot_code*/ false, /*preload*/ false)) {
       code_buffer->free_blob();
       return;
     }
@@ -1061,62 +1231,72 @@ void ciEnv::register_method(ciMethod* target,
     assert(compiler->type() == compiler_c2 ||
            offsets->value(CodeOffsets::Exceptions) != -1, "must have exception entry");
 
-    nm =  nmethod::new_nmethod(method,
-                               compile_id(),
-                               entry_bci,
-                               offsets,
-                               orig_pc_offset,
-                               debug_info(), dependencies(), code_buffer,
-                               frame_words, oop_map_set,
-                               handler_table, inc_table,
-                               compiler, CompLevel(task()->comp_level()),
-                               nmethod::Flags(has_unsafe_access, has_wide_vectors, has_monitors, has_scoped_access));
-
+    if (install_code) {
+      nm =  nmethod::new_nmethod(method,
+                                 compile_id(),
+                                 entry_bci,
+                                 offsets,
+                                 orig_pc_offset,
+                                 debug_info(), dependencies(), code_buffer,
+                                 frame_words, oop_map_set,
+                                 handler_table, inc_table,
+                                 compiler, CompLevel(task()->comp_level()),
+                                 nmethod::Flags(has_unsafe_access,
+                                                has_wide_vectors,
+                                                has_monitors,
+                                                has_scoped_access,
+                                                has_clinit_barriers));
+    }
     // Free codeBlobs
     code_buffer->free_blob();
 
     if (nm != nullptr) {
       assert(!method->is_synchronized() || nm->has_monitors(), "");
 
-      if (entry_bci == InvocationEntryBci) {
-        if (TieredCompilation) {
-          // If there is an old version we're done with it
-          nmethod* old = method->code();
-          if (TraceMethodReplacement && old != nullptr) {
-            ResourceMark rm;
-            char *method_name = method->name_and_sig_as_C_string();
-            tty->print_cr("Replacing method %s", method_name);
-          }
-          if (old != nullptr) {
-            old->make_not_used();
-          }
-        }
-
-        LogTarget(Info, nmethod, install) lt;
-        if (lt.is_enabled()) {
+#if INCLUDE_CDS
+      if (task()->is_aot_compile()) {
+#ifdef ASSERT
+        LogStreamHandle(Trace, aot, codecache, nmethod) log;
+        if (log.is_enabled()) {
           ResourceMark rm;
-          char *method_name = method->name_and_sig_as_C_string();
-          lt.print("Installing method (%d) %s ",
-                    task()->comp_level(), method_name);
+          stringStream ss;
+          ss.print_cr("=== storing AOT nmethod code ===");
+          FlagSetting fs(PrintRelocations, true);
+          nm->print_on_impl(&ss);
+          nm->decode(&ss);
+          ss.print_cr("===============================");
+          log.print_cr("%s", ss.freeze());
         }
-        // Allow the code to be executed
-        MutexLocker ml(NMethodState_lock, Mutex::_no_safepoint_check_flag);
-        if (nm->make_in_use()) {
-          method->set_code(method, nm);
+#endif
+        AOTCodeEntry* aot_code_entry = AOTCodeCache::store_nmethod(nm, compiler, for_preload);
+        if (aot_code_entry != nullptr) {
+          nm->set_aot_code_entry(aot_code_entry);
+          aot_code_entry->set_inlined_bytecodes(num_inlined_bytecodes());
+          // Inline size was recorded during training.
+          CompileTrainingData* ctd = nullptr;
+          {
+            TrainingData::TrainingDataLocker l;
+            MethodTrainingData* mtd = MethodTrainingData::find(method);
+            assert(mtd != nullptr, "AOT compiled method should have MethodTrainingData");
+            ctd = mtd->compile_data_for_aot_code(nm->comp_level());
+          }
+          assert(ctd != nullptr, "AOT compiled method should have CompileTrainingData");
+          int inline_size = ctd->inline_instructions_size();
+          aot_code_entry->set_inline_instructions_size(inline_size);
+          if (for_preload) {
+            // To have reference from method to AOT preload code
+            // during assembly phase.
+            MethodCounters* mc = method->get_method_counters(thread);
+            assert(mc != nullptr, "CompileBroker should create MethodCounters if it is missing");
+            mc->set_aot_preload_code_entry(aot_code_entry);
+            // Set it only for printing purpose, otherwise it is unused
+            // during assembly phase.
+            nm->set_preloaded(true);
+          }
         }
-      } else {
-        LogTarget(Info, nmethod, install) lt;
-        if (lt.is_enabled()) {
-          ResourceMark rm;
-          char *method_name = method->name_and_sig_as_C_string();
-          lt.print("Installing osr method (%d) %s @ %d",
-                    task()->comp_level(), method_name, entry_bci);
-        }
-        MutexLocker ml(NMethodState_lock, Mutex::_no_safepoint_check_flag);
-        if (nm->make_in_use()) {
-          method->method_holder()->add_osr_nmethod(nm);
-        }
-      }
+      } else // No need to make AOT code usable during assembly phase
+#endif
+      make_code_usable(THREAD, target, /* preload */ false, entry_bci, /* aot_code_entry */ nullptr, nm);
     }
   }
 
@@ -1125,9 +1305,11 @@ void ciEnv::register_method(ciMethod* target,
     // Compilation succeeded, post what we know about it
     nm->post_compiled_method(task());
     task()->set_num_inlined_bytecodes(num_inlined_bytecodes());
-  } else {
+  } else if (install_code) {
     // The CodeCache is full.
-    record_failure("code cache is full");
+    record_codecache_full();
+  } else {
+    task()->set_num_inlined_bytecodes(num_inlined_bytecodes());
   }
 
   // safepoints are allowed again
@@ -1227,6 +1409,11 @@ void ciEnv::record_method_not_compilable(const char* reason, bool all_tiers) {
 void ciEnv::record_out_of_memory_failure() {
   // If memory is low, we stop compiling methods.
   record_method_not_compilable("out of memory");
+}
+
+void ciEnv::record_codecache_full() {
+  _codecache_full = true;
+  record_failure("code cache is full");
 }
 
 ciInstance* ciEnv::unloaded_ciinstance() {
@@ -1697,3 +1884,77 @@ void ciEnv::dump_inline_data(int compile_id) {
 void ciEnv::dump_replay_data_version(outputStream* out) {
   out->print_cr("version %d", REPLAY_VERSION);
 }
+
+#if INCLUDE_CDS
+
+bool ciEnv::is_aot_compile() {
+  return (task() != nullptr) && task()->is_aot_compile();
+}
+
+InstanceKlass::ClassState ciEnv::compute_init_state_for_aot_compile(InstanceKlass* ik) {
+  ASSERT_IN_VM;
+  ResourceMark rm;
+  assert(is_aot_compile(), "should be called only for AOT compialtion in assembly phase");
+  assert(!ik->is_in_error_state(), "comp_id: %d, klass %s", task()->compile_id(), ik->external_name());
+
+  if (!AOTCacheAccess::can_generate_aot_code_for(ik)) {
+    log_debug(aot, compilation)("%d: klass (%s) %s is not archived", task()->compile_id(), InstanceKlass::state2name(ik->init_state()), ik->external_name());
+    // Skip this class
+    return InstanceKlass::ClassState::initialization_error;
+  }
+  if (task()->method()->method_holder() == ik) {
+    log_trace(aot, compilation)("%d: method_holder: (%s) %s", task()->compile_id(), InstanceKlass::state2name(ik->init_state()), ik->external_name());
+    if (task()->method()->is_static_initializer()) { // Happens with -Xcomp
+       return InstanceKlass::ClassState::being_initialized;
+    } else {
+       return InstanceKlass::ClassState::fully_initialized;
+    }
+  }
+
+  switch (task()->compile_reason()) {
+    case CompileTask::Reason_AOTCompile: {
+      // Check init dependencies
+      MethodTrainingData* mtd = nullptr;
+      GUARDED_VM_ENTRY(mtd = MethodTrainingData::find(methodHandle(Thread::current(), task()->method())); )
+      if (mtd != nullptr) {
+        CompileTrainingData* ctd = mtd->compile_data_for_aot_code(task()->comp_level());
+        if (ctd != nullptr) {
+          for (int i = 0; i < ctd->init_dep_count(); i++) {
+            KlassTrainingData* ktd = ctd->init_dep(i);
+            if (ktd->has_holder() && (ktd->holder() == ik)) {
+              log_trace(aot, compilation)("%d: init_dependency: (%s) %s", task()->compile_id(), InstanceKlass::state2name(ik->init_state()), ik->external_name());
+              return InstanceKlass::ClassState::fully_initialized; // init dependency present
+            }
+          }
+        }
+      }
+
+      // Core java/lang/invoke classes are peculiar. They include LF invokers, which
+      // are initialized in production run, but they are not recorded as init dependencies.
+      // CI query should report their status as if in production run, otherwise AOT
+      // code would have uncommon traps at invokedynamic calls.
+      if (HeapShared::is_core_java_lang_invoke_klass(ik)) {
+        log_trace(aot, compilation)("%d: core_java_lang_invoke: (%s) %s", task()->compile_id(), InstanceKlass::state2name(ik->init_state()), ik->external_name());
+        return InstanceKlass::ClassState::fully_initialized;
+      }
+
+      // Class may be not present during TD creation for this method.
+      // It could happen when profiled data for inlined method
+      // was updated after this method was compiled during training.
+      break;
+    }
+    case CompileTask::Reason_AOTCompileForPreload: {
+      // Preload AOT code does not depend on Training Data,
+      // it has class init barriers to initialize class by
+      // going into interpreter or directly calling runtime.
+      log_trace(aot, compilation)("%d: for_preload: (%s) %s", task()->compile_id(), InstanceKlass::state2name(ik->init_state()), ik->external_name());
+      return InstanceKlass::ClassState::fully_initialized;
+    }
+    default: fatal("%s", CompileTask::reason_name(task()->compile_reason()));
+  }
+  log_debug(aot, compilation)("%d: klass (%s) %s is not recorded for this compilation", task()->compile_id(), InstanceKlass::state2name(ik->init_state()), ik->external_name());
+  // Skip this class
+  return InstanceKlass::ClassState::initialization_error;
+}
+
+#endif // INCLUDE_CDS

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -34,11 +34,14 @@
 #include "compiler/cHeapStringHolder.hpp"
 #include "compiler/compiler_globals.hpp"
 #include "compiler/compilerThread.hpp"
+#include "oops/methodCounters.hpp"
 #include "oops/methodData.hpp"
 #include "runtime/javaThread.hpp"
 
 class CompileTask;
 class OopMapSet;
+class AOTCodeEntry;
+class AOTCodeReader;
 
 // ciEnv
 //
@@ -59,9 +62,10 @@ private:
   DebugInformationRecorder* _debug_info;
   Dependencies*    _dependencies;
   CHeapStringHolder _failure_reason;
+  bool             _codecache_full;
   bool             _inc_decompile_count_on_failure;
-  int              _compilable;
   bool             _break_at_compile;
+  int              _compilable;
   int              _num_inlined_bytecodes;
   CompileTask*     _task;           // faster access to CompilerThread::task
   CompileLog*      _log;            // faster access to CompilerThread::log
@@ -223,6 +227,10 @@ private:
     if (o == nullptr) return nullptr;
     return get_metadata(o)->as_method_data();
   }
+  ciMetadata* get_method_counters(MethodCounters* o) {
+    if (o == nullptr) return nullptr;
+    return get_metadata((Metadata*)o);
+  }
 
   ciMethod* get_method_from_handle(Method* method);
 
@@ -236,6 +244,7 @@ private:
     ciInstanceKlass* declared_holder = get_instance_klass_for_declared_method_holder(holder);
     return _factory->get_unloaded_method(declared_holder, name, signature, accessor);
   }
+
   InstanceKlass::ClassState get_cached_init_state(uint id) {
     return (InstanceKlass::ClassState)_factory->cached_init_state(id);
   }
@@ -294,6 +303,12 @@ private:
   // Helper routine for determining the validity of a compilation with
   // respect to method dependencies (e.g. concurrent class loading).
   void validate_compile_task_dependencies(ciMethod* target);
+
+  // Helper routines to factor out common code used by routines that register a method
+  // i.e. register_aot_method() and register_method()
+  bool is_compilation_valid(JavaThread* thread, ciMethod* target, bool install_code, bool is_loading_aot_code, bool preload);
+  void make_code_usable(JavaThread* thread, ciMethod* target, bool preload, int entry_bci, AOTCodeEntry* aot_code_entry, nmethod* nm);
+
 public:
   enum {
     MethodCompilable,
@@ -321,6 +336,8 @@ public:
 
   // Reason this compilation is failing, such as "too many basic blocks".
   const char* failure_reason() const { return _failure_reason.get(); }
+
+  bool codecache_full() const { return _codecache_full; }
 
   // Return state of appropriate compatibility
   int compilable() { return _compilable; }
@@ -366,6 +383,15 @@ public:
   int comp_level();   // task()->comp_level()
   int compile_id();  // task()->compile_id()
 
+#if INCLUDE_CDS
+  // Register method loaded from AOT code cache
+  nmethod* register_aot_method(JavaThread* thread,
+                               ciMethod* target,
+                               AbstractCompiler* compiler,
+                               nmethod* archived_nm,
+                               AOTCodeReader* aot_code_reader,
+                               bool install_code);
+#endif
   // Register the result of a compilation.
   void register_method(ciMethod*                 target,
                        int                       entry_bci,
@@ -377,11 +403,14 @@ public:
                        ExceptionHandlerTable*    handler_table,
                        ImplicitExceptionTable*   inc_table,
                        AbstractCompiler*         compiler,
+                       bool                      has_clinit_barriers,
+                       bool                      for_preload,
                        bool                      has_unsafe_access,
                        bool                      has_wide_vectors,
                        bool                      has_monitors,
                        bool                      has_scoped_access,
-                       int                       immediate_oops_patched);
+                       int                       immediate_oops_patched,
+                       bool                      install_code);
 
   // Access to certain well known ciObjects.
 #define VM_CLASS_FUNC(name, ignore_s) \
@@ -467,6 +496,7 @@ public:
   void report_failure(const char* reason);      // Report failure immediately
   void record_method_not_compilable(const char* reason, bool all_tiers = false);
   void record_out_of_memory_failure();
+  void record_codecache_full();
 
   // RedefineClasses support
   void metadata_do(MetadataClosure* f) { _factory->metadata_do(f); }
@@ -515,6 +545,9 @@ public:
   void process_invokedynamic(const constantPoolHandle &cp, int index, JavaThread* thread);
   void process_invokehandle(const constantPoolHandle &cp, int index, JavaThread* thread);
   void find_dynamic_call_sites();
+
+  bool is_aot_compile() NOT_CDS_RETURN_(false);
+  InstanceKlass::ClassState compute_init_state_for_aot_compile(InstanceKlass* ik) NOT_CDS_RETURN_((InstanceKlass::ClassState)0);
 };
 
 #endif // SHARE_CI_CIENV_HPP

--- a/src/hotspot/share/ci/ciField.cpp
+++ b/src/hotspot/share/ci/ciField.cpp
@@ -28,6 +28,7 @@
 #include "ci/ciUtilities.inline.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/vmClasses.hpp"
+#include "code/aotCodeCache.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "interpreter/linkResolver.hpp"
 #include "oops/klass.inline.hpp"
@@ -291,6 +292,9 @@ ciConstant ciField::constant_value() {
   if (FoldStableValues && is_stable() && _constant_value.is_null_or_zero()) {
     return ciConstant();
   }
+  if (CURRENT_ENV->is_aot_compile()) { // Restrict only when we generate AOT code
+    return ciConstant();
+  }
   return _constant_value;
 }
 
@@ -302,6 +306,9 @@ ciConstant ciField::constant_value_of(ciObject* object) {
   assert(object->is_instance(), "must be instance");
   ciConstant field_value = object->as_instance()->field_value(this);
   if (FoldStableValues && is_stable() && field_value.is_null_or_zero()) {
+    return ciConstant();
+  }
+  if (CURRENT_ENV->is_aot_compile()) { // Restrict only when we generate AOT code
     return ciConstant();
   }
   return field_value;

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -53,14 +53,22 @@ ciInstanceKlass::ciInstanceKlass(Klass* k) :
   ciKlass(k)
 {
   assert(get_Klass()->is_instance_klass(), "wrong type");
-  assert(get_instanceKlass()->is_loaded(), "must be at least loaded");
+
   InstanceKlass* ik = get_instanceKlass();
+
+#ifdef ASSERT
+  if (!ik->is_loaded()) {
+    ResourceMark rm;
+    ik->print_on(tty);
+    assert(false, "must be at least loaded: %s", ik->name()->as_C_string());
+  }
+#endif // ASSERT
 
   AccessFlags access_flags = ik->access_flags();
   _flags = ciFlags(access_flags);
   _has_finalizer = ik->has_finalizer();
   _has_subklass = flags().is_final() ? subklass_false : subklass_unknown;
-  _init_state = ik->init_state();
+  _init_state = compute_init_state(ik);
   _has_nonstatic_fields = ik->has_nonstatic_fields();
   _has_nonstatic_concrete_methods = ik->has_nonstatic_concrete_methods();
   _is_hidden = ik->is_hidden();
@@ -141,9 +149,26 @@ InstanceKlass::ClassState ciInstanceKlass::compute_init_state() {
     // Return cached init state of shared klass
     ciEnv* env = CURRENT_ENV;
     assert(env->task() != nullptr, "only calls from compilation are expected here");
-    return env->get_cached_init_state(ident());
+    if (env->is_aot_compile()) {
+      GUARDED_VM_ENTRY( return env->compute_init_state_for_aot_compile(get_instanceKlass()); )
+    } else {
+      return env->get_cached_init_state(ident());
+    }
   }
   return _init_state;
+}
+
+InstanceKlass::ClassState ciInstanceKlass::compute_init_state(InstanceKlass* ik) {
+  ASSERT_IN_VM;
+#if INCLUDE_CDS
+  ciEnv* env = CURRENT_ENV;
+  if (env != nullptr && env->is_aot_compile()) {
+    return env->compute_init_state_for_aot_compile(ik);
+  } else
+#endif
+  {
+    return ik->init_state();
+  }
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -112,6 +112,8 @@ protected:
   GrowableArray<ciField*>* compute_nonstatic_fields_impl(GrowableArray<ciField*>* super_fields);
   bool compute_has_trusted_loader();
 
+  static InstanceKlass::ClassState compute_init_state(InstanceKlass* ik);
+
 public:
   // Has this klass been initialized?
   bool                   is_initialized() {

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include "cds/aotLinkedClassBulkLoader.hpp"
 #include "ci/ciCallProfile.hpp"
 #include "ci/ciExceptionHandler.hpp"
 #include "ci/ciInstanceKlass.hpp"
@@ -33,6 +34,7 @@
 #include "ci/ciSymbol.hpp"
 #include "ci/ciSymbols.hpp"
 #include "ci/ciUtilities.inline.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/abstractCompiler.hpp"
 #include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/compilerOracle.hpp"
@@ -144,6 +146,7 @@ ciMethod::ciMethod(const methodHandle& h_m, ciInstanceKlass* holder) :
   constantPoolHandle cpool(Thread::current(), h_m->constants());
   _signature = new (env->arena()) ciSignature(_holder, cpool, sig_symbol);
   _method_data = nullptr;
+  _method_data_recorded = nullptr;
   // Take a snapshot of these values, so they will be commensurate with the MDO.
   if (ProfileInterpreter || CompilerConfig::is_c1_profiling()) {
     int invcnt = h_m->interpreter_invocation_count();
@@ -175,6 +178,7 @@ ciMethod::ciMethod(ciInstanceKlass* holder,
   _name(                   name),
   _holder(                 holder),
   _method_data(            nullptr),
+  _method_data_recorded(   nullptr),
   _method_blocks(          nullptr),
   _intrinsic_id(           vmIntrinsics::_none),
   _inline_instructions_size(-1),
@@ -1004,15 +1008,19 @@ bool ciMethod::has_member_arg() const {
 //
 // Generate new MethodData* objects at compile time.
 // Return true if allocation was successful or no MDO is required.
-bool ciMethod::ensure_method_data(const methodHandle& h_m) {
+bool ciMethod::ensure_method_data(const methodHandle& h_m, bool training_data_only) {
   EXCEPTION_CONTEXT;
   if (is_native() || is_abstract() || h_m()->is_accessor()) {
     return true;
   }
   if (h_m()->method_data() == nullptr) {
-    Method::build_profiling_method_data(h_m, THREAD);
-    if (HAS_PENDING_EXCEPTION) {
-      CLEAR_PENDING_EXCEPTION;
+    if (training_data_only) {
+      Method::install_training_method_data(h_m);
+    } else {
+      Method::build_profiling_method_data(h_m, THREAD);
+      if (HAS_PENDING_EXCEPTION) {
+        CLEAR_PENDING_EXCEPTION;
+      }
     }
   }
   if (h_m()->method_data() != nullptr) {
@@ -1025,12 +1033,12 @@ bool ciMethod::ensure_method_data(const methodHandle& h_m) {
 }
 
 // public, retroactive version
-bool ciMethod::ensure_method_data() {
+bool ciMethod::ensure_method_data(bool training_data_only) {
   bool result = true;
   if (_method_data == nullptr || _method_data->is_empty()) {
     GUARDED_VM_ENTRY({
       methodHandle mh(Thread::current(), get_Method());
-      result = ensure_method_data(mh);
+      result = ensure_method_data(mh, training_data_only);
     });
   }
   return result;
@@ -1041,22 +1049,49 @@ bool ciMethod::ensure_method_data() {
 // ciMethod::method_data
 //
 ciMethodData* ciMethod::method_data() {
+#if INCLUDE_CDS
+  if (CURRENT_ENV->is_aot_compile() && CURRENT_ENV->task()->comp_level() == CompLevel_full_optimization) {
+    if (_method_data_recorded == nullptr) {
+      VM_ENTRY_MARK;
+      methodHandle h_m(thread, get_Method());
+      MethodTrainingData* mtd = MethodTrainingData::find(h_m);
+      MethodData* mdo = (mtd != nullptr ? mtd->final_profile() : nullptr);
+      int comp_id = CURRENT_ENV->task()->compile_id();
+      if (mdo == nullptr) {
+        ResourceMark rm;
+        log_debug(aot, compilation)("%d: No profile for %s", comp_id, h_m->name_and_sig_as_C_string());
+        _method_data_recorded = CURRENT_ENV->get_empty_methodData();
+      } else {
+        if (mdo->extra_data_lock() == nullptr) {
+          assert(!HAS_PENDING_EXCEPTION, "");
+          mdo->restore_unshareable_info(thread);
+          assert(!HAS_PENDING_EXCEPTION, "");
+        }
+        _method_data_recorded = CURRENT_ENV->get_method_data(mdo);
+        _method_data_recorded->load_data();
+        {
+          ResourceMark rm;
+          log_debug(aot, compilation)("%d: Recorded profile " PTR_FORMAT " for %s", comp_id, p2i(mdo), h_m->name_and_sig_as_C_string());
+        }
+      }
+    }
+    assert(_method_data_recorded != nullptr, "");
+    return _method_data_recorded;
+  }
+#endif
   if (_method_data != nullptr) {
     return _method_data;
   }
   VM_ENTRY_MARK;
-  ciEnv* env = CURRENT_ENV;
-  Thread* my_thread = JavaThread::current();
-  methodHandle h_m(my_thread, get_Method());
-
-  if (h_m()->method_data() != nullptr) {
-    _method_data = CURRENT_ENV->get_method_data(h_m()->method_data());
+  methodHandle h_m(thread, get_Method());
+  MethodData* mdo = h_m()->method_data();
+  if (mdo != nullptr) {
+    _method_data = CURRENT_ENV->get_method_data(mdo);
     _method_data->load_data();
   } else {
     _method_data = CURRENT_ENV->get_empty_methodData();
   }
   return _method_data;
-
 }
 
 // ------------------------------------------------------------------
@@ -1074,12 +1109,15 @@ ciMethodData* ciMethod::method_data_or_null() {
 // ------------------------------------------------------------------
 // ciMethod::ensure_method_counters
 //
-MethodCounters* ciMethod::ensure_method_counters() {
+ciMetadata* ciMethod::ensure_method_counters() {
   check_is_loaded();
   VM_ENTRY_MARK;
   methodHandle mh(THREAD, get_Method());
-  MethodCounters* method_counters = mh->get_method_counters(CHECK_NULL);
-  return method_counters;
+  MethodCounters* method_counters = mh->get_method_counters(THREAD);
+  if (method_counters != nullptr) {
+    return CURRENT_ENV->get_method_counters(method_counters);
+  }
+  return nullptr;
 }
 
 // ------------------------------------------------------------------
@@ -1157,7 +1195,7 @@ int ciMethod::inline_instructions_size() {
         methodHandle top_level_mh(Thread::current(), CURRENT_ENV->task()->method());
         MethodTrainingData* mtd = MethodTrainingData::find(top_level_mh);
         if (mtd != nullptr) {
-          CompileTrainingData* ctd = mtd->last_toplevel_compile(level);
+          CompileTrainingData* ctd = mtd->compile_data_for_aot_code(level);
           if (ctd != nullptr) {
             methodHandle mh(Thread::current(), get_Method());
             MethodTrainingData* this_mtd = MethodTrainingData::find(mh);
@@ -1176,7 +1214,8 @@ int ciMethod::inline_instructions_size() {
     GUARDED_VM_ENTRY(
       nmethod* code = get_Method()->code();
       if (code != nullptr && (code->comp_level() == CompLevel_full_optimization)) {
-        int isize = code->insts_end() - code->verified_entry_point() - code->skipped_instructions_size();
+        int isize = code->is_aot() ? code->aot_code_entry()->inline_instructions_size()
+                                   : code->inline_instructions_size();
         _inline_instructions_size = isize > 0 ? isize : 0;
       } else {
         _inline_instructions_size = 0;
@@ -1217,6 +1256,19 @@ bool ciMethod::is_not_reached(int bci) {
 // ------------------------------------------------------------------
 // ciMethod::was_never_executed
 bool ciMethod::was_executed_more_than(int times) {
+#if INCLUDE_CDS
+  if (CURRENT_ENV->is_aot_compile()) { // Look only on training data
+    // Invocation counter is reset when the Method* is compiled.
+    // If the method has compiled code we therefore assume it has
+    // be executed more than n times.
+    if (is_accessor() || is_empty() || has_compiled_code()) {
+      // interpreter doesn't bump invocation counter of trivial methods
+      // compiler does not bump invocation counter of compiled methods
+      return true;
+    }
+    return (method_data()->invocation_count() > times);
+  }
+#endif
   VM_ENTRY_MARK;
   return get_Method()->was_executed_more_than(times);
 }

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -72,7 +72,8 @@ class ciMethod : public ciMetadata {
   ciInstanceKlass* _holder;
   ciSignature*     _signature;
   ciMethodData*    _method_data;
-  ciMethodBlocks*   _method_blocks;
+  ciMethodData*    _method_data_recorded;
+  ciMethodBlocks*  _method_blocks;
 
   // Code attributes.
   int _code_size;
@@ -117,7 +118,7 @@ class ciMethod : public ciMetadata {
 
   void load_code();
 
-  bool ensure_method_data(const methodHandle& h_m);
+  bool ensure_method_data(const methodHandle& h_m, bool training_data_only);
 
   void code_at_put(int bci, Bytecodes::Code code) {
     Bytecodes::check(code);
@@ -314,8 +315,8 @@ class ciMethod : public ciMetadata {
   bool has_unloaded_classes_in_signature();
   bool is_klass_loaded(int refinfo_index, Bytecodes::Code bc, bool must_be_resolved) const;
   bool check_call(int refinfo_index, bool is_static) const;
-  bool ensure_method_data();  // make sure it exists in the VM also
-  MethodCounters* ensure_method_counters();
+  bool ensure_method_data(bool training_data_only = false);  // make sure it exists in the VM also
+  ciMetadata* ensure_method_counters();
 
   int inline_instructions_size();
   int scale_count(int count, float prof_factor = 1.);  // make MDO count commensurate with IIC

--- a/src/hotspot/share/ci/ciObject.cpp
+++ b/src/hotspot/share/ci/ciObject.cpp
@@ -24,6 +24,7 @@
 
 #include "ci/ciObject.hpp"
 #include "ci/ciUtilities.inline.hpp"
+#include "code/aotCodeCache.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/jniHandles.inline.hpp"
@@ -202,20 +203,24 @@ void ciObject::add_to_constant_value_cache(int off, ciConstant val) {
 // ------------------------------------------------------------------
 // ciObject::should_be_constant()
 bool ciObject::should_be_constant() {
-  if (ScavengeRootsInCode >= 2)  return true;  // force everybody to be a constant
-  if (is_null_object()) return true;
-
+  if (ScavengeRootsInCode >= 2 && !(AOTCodeCache::is_dumping_code())) {
+    return true;  // force everybody to be a constant
+  }
+  if (is_null_object()) {
+    return true;
+  }
   ciEnv* env = CURRENT_ENV;
 
-    // We want Strings and Classes to be embeddable by default since
-    // they used to be in the perm world.  Not all Strings used to be
-    // embeddable but there's no easy way to distinguish the interned
-    // from the regulars ones so just treat them all that way.
-    if (klass() == env->String_klass() || klass() == env->Class_klass()) {
-      return true;
-    }
-  if (klass()->is_subclass_of(env->MethodHandle_klass()) ||
-      klass()->is_subclass_of(env->CallSite_klass())) {
+  // We want Strings and Classes to be embeddable by default since
+  // they used to be in the perm world.  Not all Strings used to be
+  // embeddable but there's no easy way to distinguish the interned
+  // from the regulars ones so just treat them all that way.
+  if (klass() == env->String_klass() || klass() == env->Class_klass()) {
+    return true;
+  }
+  if ((klass()->is_subclass_of(env->MethodHandle_klass()) ||
+       klass()->is_subclass_of(env->CallSite_klass())) &&
+      !(AOTCodeCache::is_dumping_code())) { // For now disable it when compiling AOT code.
     // We want to treat these aggressively.
     return true;
   }

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -109,7 +109,7 @@ ciObjectFactory::ciObjectFactory(Arena* arena,
       ciMetadata* obj = _ci_metadata.at(i);
       if (obj->is_loaded() && obj->is_instance_klass()) {
         ciInstanceKlass* cik = obj->as_instance_klass();
-        precond(cik->is_shared());
+        assert(cik->is_shared(), "only shared instances are expected here");
         InstanceKlass::ClassState current_state = cik->_init_state;
         InstanceKlass::ClassState state = InstanceKlass::fully_initialized;
         if (current_state != state) {
@@ -178,10 +178,10 @@ void ciObjectFactory::init_shared_objects() {
   ciEnv::_null_object_instance = new (_arena) ciNullObject();
   init_ident_of(ciEnv::_null_object_instance);
 
-#define VM_CLASS_DEFN(name, ignore_s)                              \
-  if (vmClasses::name##_is_loaded()) \
-    ciEnv::_##name = get_metadata(vmClasses::name())->as_instance_klass();
-
+#define VM_CLASS_DEFN(name, ignore_s)  \
+  if (vmClasses::name##_is_loaded()) { \
+    ciEnv::_##name = get_metadata(vmClasses::name())->as_instance_klass(); \
+  }
   VM_CLASSES_DO(VM_CLASS_DEFN)
 #undef VM_CLASS_DEFN
 
@@ -263,7 +263,9 @@ ciObject* ciObjectFactory::get(oop key) {
 
   NonPermObject* &bucket = find_non_perm(keyHandle);
   if (bucket != nullptr) {
-    return bucket->object();
+    ciObject* obj = bucket->object();
+    notice_new_object(obj);
+    return obj;
   }
 
   // The ciObject does not yet exist.  Create it and insert it
@@ -279,6 +281,7 @@ ciObject* ciObjectFactory::get(oop key) {
   return new_object;
 }
 
+#if INCLUDE_CDS
 void ciObjectFactory::notice_new_object(ciBaseObject* new_object) {
   if (TrainingData::need_data()) {
     ciEnv* env = ciEnv::current();
@@ -291,6 +294,7 @@ void ciObjectFactory::notice_new_object(ciBaseObject* new_object) {
     }
   }
 }
+#endif
 
 int ciObjectFactory::metadata_compare(Metadata* const& key, ciMetadata* const& elt) {
   Metadata* value = elt->constant_encoding();
@@ -374,7 +378,9 @@ ciMetadata* ciObjectFactory::get_metadata(Metadata* key) {
     notice_new_object(new_object);
     return new_object;
   }
-  return _ci_metadata.at(index)->as_metadata();
+  ciMetadata* metadata = _ci_metadata.at(index)->as_metadata();
+  notice_new_object(metadata);
+  return metadata;
 }
 
 // ------------------------------------------------------------------
@@ -438,9 +444,11 @@ ciMetadata* ciObjectFactory::create_new_metadata(Metadata* o) {
     ciInstanceKlass* holder = env->get_instance_klass(h_m()->method_holder());
     return new (arena()) ciMethod(h_m, holder);
   } else if (o->is_methodData()) {
-    // Hold methodHandle alive - might not be necessary ???
-    methodHandle h_m(THREAD, ((MethodData*)o)->method());
+    // Callers ciMethod::ensure_method_data() and ::method_data() have MH already.
     return new (arena()) ciMethodData((MethodData*)o);
+  } else if (o->is_methodCounters()) {
+    // Caller ciMethod::ensure_method_counters() has MH already.
+    return new (arena()) ciMetadata(o);
   }
 
   // The Metadata* is of some type not supported by the compiler interface.

--- a/src/hotspot/share/ci/ciObjectFactory.hpp
+++ b/src/hotspot/share/ci/ciObjectFactory.hpp
@@ -114,7 +114,7 @@ public:
   static ciSymbol* vm_symbol_at(vmSymbolID index);
 
   // Called on every new object made.
-  void notice_new_object(ciBaseObject* new_object);
+  void notice_new_object(ciBaseObject* new_object) NOT_CDS_RETURN;
 
   // Get the ciMethod representing an unloaded/unfound method.
   ciMethod* get_unloaded_method(ciInstanceKlass* holder,

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -806,7 +806,7 @@ class CompileReplay : public StackObj {
     }
     replay_state = this;
     CompileBroker::compile_method(methodHandle(THREAD, method), entry_bci, comp_level,
-                                  0, CompileTask::Reason_Replay, THREAD);
+                                  0, nullptr, CompileTask::Reason_Replay, THREAD);
     replay_state = nullptr;
   }
 

--- a/src/hotspot/share/classfile/classLoaderDataShared.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataShared.cpp
@@ -122,7 +122,7 @@ void ArchivedClassLoaderData::remove_unshareable_info() {
 }
 
 void ArchivedClassLoaderData::restore(ClassLoaderData* loader_data, bool do_entries, bool do_oops) {
-  assert(CDSConfig::is_using_archive(), "must be");
+  assert(CDSConfig::is_using_full_module_graph(), "must be");
   assert_valid(loader_data);
   if (_modules != nullptr) { // Could be null if we have archived no modules for platform/system loaders
     ModuleEntryTable* modules = loader_data->modules();
@@ -146,7 +146,7 @@ void ArchivedClassLoaderData::restore(ClassLoaderData* loader_data, bool do_entr
 }
 
 void ArchivedClassLoaderData::clear_archived_oops() {
-  assert(CDSConfig::is_using_archive(), "must be");
+  assert(!CDSConfig::is_using_full_module_graph(), "must be");
   if (_modules != nullptr) {
     for (int i = 0; i < _modules->length(); i++) {
       _modules->at(i)->clear_archived_oops();

--- a/src/hotspot/share/classfile/moduleEntry.cpp
+++ b/src/hotspot/share/classfile/moduleEntry.cpp
@@ -443,7 +443,7 @@ void ModuleEntry::remove_unshareable_info() {
 }
 
 void ModuleEntry::load_from_archive(ClassLoaderData* loader_data) {
-  assert(CDSConfig::is_using_archive(), "runtime only");
+  assert(CDSConfig::is_using_full_module_graph(), "runtime only");
   set_loader_data(loader_data);
   JFR_ONLY(INIT_ID(this);)
 }
@@ -453,7 +453,7 @@ void ModuleEntry::preload_archived_oops() {
 }
 
 void ModuleEntry::restore_archived_oops(ClassLoaderData* loader_data) {
-  assert(CDSConfig::is_using_archive(), "runtime only");
+  assert(CDSConfig::is_using_full_module_graph(), "runtime only");
   Handle module_handle(Thread::current(), HeapShared::get_root(_archived_module_index, /*clear=*/true));
   assert(module_handle.not_null(), "huh");
   set_module_handle(loader_data->add_handle(module_handle));
@@ -474,7 +474,7 @@ void ModuleEntry::restore_archived_oops(ClassLoaderData* loader_data) {
 }
 
 void ModuleEntry::clear_archived_oops() {
-  assert(CDSConfig::is_using_archive(), "runtime only");
+  assert(CDSConfig::is_using_archive() && !CDSConfig::is_using_full_module_graph(), "runtime only");
   HeapShared::clear_root(_archived_module_index);
 }
 
@@ -509,7 +509,7 @@ Array<ModuleEntry*>* ModuleEntryTable::build_aot_table(ClassLoaderData* loader_d
 
 void ModuleEntryTable::load_archived_entries(ClassLoaderData* loader_data,
                                              Array<ModuleEntry*>* archived_modules) {
-  assert(CDSConfig::is_using_archive(), "runtime only");
+  assert(CDSConfig::is_using_full_module_graph(), "runtime only");
 
   for (int i = 0; i < archived_modules->length(); i++) {
     ModuleEntry* archived_entry = archived_modules->at(i);
@@ -519,7 +519,7 @@ void ModuleEntryTable::load_archived_entries(ClassLoaderData* loader_data,
 }
 
 void ModuleEntryTable::restore_archived_oops(ClassLoaderData* loader_data, Array<ModuleEntry*>* archived_modules) {
-  assert(CDSConfig::is_using_archive(), "runtime only");
+  assert(CDSConfig::is_using_full_module_graph(), "runtime only");
   for (int i = 0; i < archived_modules->length(); i++) {
     ModuleEntry* archived_entry = archived_modules->at(i);
     archived_entry->restore_archived_oops(loader_data);

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -892,7 +892,7 @@ void SystemDictionaryShared::link_all_exclusion_check_candidates(InstanceKlass* 
 // it can be checked by should_be_excluded_impl().
 bool SystemDictionaryShared::should_be_excluded(Klass* k) {
   assert(CDSConfig::is_dumping_archive(), "sanity");
-  assert(CDSConfig::current_thread_is_vm_or_dumper(), "sanity");
+  // This method could be called during AOT compilation from compiler thread.
 
   if (CDSConfig::is_dumping_dynamic_archive() && AOTMetaspace::in_aot_cache(k)) {
     // We have reached a super type that's already in the base archive. Treat it

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -25,38 +25,84 @@
 
 #include "asm/macroAssembler.hpp"
 #include "cds/aotCacheAccess.hpp"
+#include "cds/aotCompressedPointers.hpp"
 #include "cds/aotMetaspace.hpp"
 #include "cds/cds_globals.hpp"
 #include "cds/cdsConfig.hpp"
 #include "cds/heapShared.hpp"
-#include "ci/ciUtilities.hpp"
+#include "ci/ciConstant.hpp"
+#include "ci/ciEnv.hpp"
+#include "ci/ciField.hpp"
+#include "ci/ciMethod.hpp"
+#include "ci/ciMethodData.hpp"
+#include "ci/ciObject.hpp"
+#include "ci/ciUtilities.inline.hpp"
 #include "classfile/javaAssertions.hpp"
+#include "classfile/stringTable.hpp"
+#include "classfile/symbolTable.hpp"
+#include "classfile/systemDictionary.hpp"
+#include "classfile/vmClasses.hpp"
+#include "classfile/vmIntrinsics.hpp"
 #include "code/aotCodeCache.hpp"
+#include "code/codeBlob.hpp"
 #include "code/codeCache.hpp"
+#include "code/oopRecorder.inline.hpp"
+#include "compiler/abstractCompiler.hpp"
+#include "compiler/compilationPolicy.hpp"
+#include "compiler/compileBroker.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
+#include "compiler/compileTask.hpp"
+#include "gc/g1/g1BarrierSetRuntime.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/barrierSetNMethod.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
 #include "gc/shared/gcConfig.hpp"
 #include "logging/logStream.hpp"
 #include "memory/memoryReserver.hpp"
+#include "memory/universe.hpp"
+#include "oops/klass.inline.hpp"
+#include "oops/method.inline.hpp"
+#include "oops/trainingData.hpp"
 #include "prims/jvmtiThreadState.hpp"
 #include "prims/upcallLinker.hpp"
+#include "runtime/atomicAccess.hpp"
 #include "runtime/deoptimization.hpp"
 #include "runtime/flags/flagSetting.hpp"
 #include "runtime/globals_extension.hpp"
+#include "runtime/handles.inline.hpp"
 #include "runtime/icache.hpp"
 #include "runtime/java.hpp"
+#include "runtime/jniHandles.inline.hpp"
+#include "runtime/mountUnmountDisabler.hpp"
 #include "runtime/mutexLocker.hpp"
+#include "runtime/objectMonitorTable.hpp"
 #include "runtime/os.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
-#include "runtime/stubInfo.hpp"
+#include "runtime/stubCodeGenerator.hpp"
 #include "runtime/stubRoutines.hpp"
+#include "runtime/threadIdentifier.hpp"
+#include "runtime/timerTrace.hpp"
 #include "utilities/copy.hpp"
+#include "utilities/formatBuffer.hpp"
+#include "utilities/ostream.hpp"
+#include "utilities/spinYield.hpp"
 #ifdef COMPILER1
+#include "c1/c1_LIRAssembler.hpp"
 #include "c1/c1_Runtime1.hpp"
-#endif
+#include "gc/g1/c1/g1BarrierSetC1.hpp"
+#include "gc/shared/c1/barrierSetC1.hpp"
+#if INCLUDE_SHENANDOAHGC
+#include "gc/shenandoah/c1/shenandoahBarrierSetC1.hpp"
+#endif // INCLUDE_SHENANDOAHGC
+#include "gc/z/c1/zBarrierSetC1.hpp"
+#endif // COMPILER1
 #ifdef COMPILER2
+#include "opto/c2_MacroAssembler.hpp"
+#include "opto/parse.hpp"
 #include "opto/runtime.hpp"
+#endif
+#if INCLUDE_JFR
+#include "jfr/support/jfrIntrinsics.hpp"
 #endif
 #if INCLUDE_G1GC
 #include "gc/g1/g1BarrierSetRuntime.hpp"
@@ -68,6 +114,9 @@
 #endif
 #if INCLUDE_ZGC
 #include "gc/z/zBarrierSetRuntime.hpp"
+#endif
+#if defined(X86) && !defined(ZERO)
+#include "rdtsc_x86.hpp"
 #endif
 
 #include <errno.h>
@@ -91,6 +140,23 @@ static LogStream& load_failure_log() {
   }
 }
 
+// Stream to print AOT code loading info
+static LogStream& load_info_log() {
+  static LogStream  log_aot(LogLevel::Info, LogTagSetMapping<LOG_TAGS(aot)>::tagset());
+  static LogStream log_init(LogLevel::Info, LogTagSetMapping<LOG_TAGS(aot, codecache, init)>::tagset());
+  return log_init.is_enabled() ? log_init : log_aot;
+}
+
+static elapsedTimer _t_totalLoad;
+static elapsedTimer _t_totalPreload;
+static elapsedTimer _t_totalRegister;
+static elapsedTimer _t_totalFind;
+static elapsedTimer _t_totalStore;
+
+static bool enable_timers() {
+  return CITime || log_is_enabled(Info, aot, codecache, stats);
+}
+
 // Report AOT code cache failure and exit VM
 // if (AOTMode is `on` and AbortVMOnAOTCodeFailure is default)
 //     or AbortVMOnAOTCodeFailure is `true`.
@@ -104,16 +170,16 @@ static void report_load_failure() {
   if (abort_vm) {
     vm_exit_during_initialization("Unable to use AOT Code Cache.", nullptr);
   }
-  load_failure_log().print_cr("Unable to use AOT Code Cache.");
+  load_failure_log().print_cr("Unable to use AOT Code Cache");
   AOTCodeCache::disable_caching();
 }
 
 static void report_store_failure() {
   if (AbortVMOnAOTCodeFailure) {
-    tty->print_cr("Unable to create AOT Code Cache.");
+    tty->print_cr("Unable to create AOT Code Cache");
     vm_abort(false);
   }
-  log_error(aot, codecache, exit)("Unable to create AOT Code Cache.");
+  log_error(aot, codecache, exit)("Unable to create AOT Code Cache");
   AOTCodeCache::disable_caching();
 }
 
@@ -126,7 +192,7 @@ static void report_store_failure() {
 // where we set number of compiler threads for AOT assembly phase.
 //
 // 3. We determine presence of AOT code in AOT Cache in
-// AOTMetaspace::open_static_archive() which is calles
+// AOTMetaspace::get_aot_code_region_size() which is called
 // after compilationPolicy_init() but before codeCache_init().
 //
 // 4. AOTCodeCache::initialize() is called during universe_init()
@@ -154,21 +220,37 @@ bool AOTCodeCache::is_using_stub()   {
   return AOTStubCaching && is_on_for_use();
 }
 
-// Next methods could be called regardless AOT code cache status.
-// Initially they are called during flags parsing and finilized
+bool AOTCodeCache::is_dumping_code() {
+  return AOTCodeCaching && is_on_for_dump();
+}
+
+bool AOTCodeCache::is_using_code() {
+  return AOTCodeCaching && is_on_for_use();
+}
+
+// This is used before AOTCodeCahe is initialized
+// but after AOT (CDS) Cache flags consistency is checked.
+bool AOTCodeCache::maybe_dumping_code() {
+  return AOTCodeCaching && CDSConfig::is_dumping_final_static_archive();
+}
+
+// Next methods could be called regardless of AOT code cache status.
+// Initially they are called during AOT flags parsing and finalized
 // in AOTCodeCache::initialize().
 void AOTCodeCache::enable_caching() {
+  FLAG_SET_ERGO_IF_DEFAULT(AOTCodeCaching, true);
   FLAG_SET_ERGO_IF_DEFAULT(AOTStubCaching, true);
   FLAG_SET_ERGO_IF_DEFAULT(AOTAdapterCaching, true);
 }
 
 void AOTCodeCache::disable_caching() {
+  FLAG_SET_ERGO(AOTCodeCaching, false);
   FLAG_SET_ERGO(AOTStubCaching, false);
   FLAG_SET_ERGO(AOTAdapterCaching, false);
 }
 
 bool AOTCodeCache::is_caching_enabled() {
-  return AOTStubCaching || AOTAdapterCaching;
+  return AOTCodeCaching || AOTStubCaching || AOTAdapterCaching;
 }
 
 static uint32_t encode_id(AOTCodeEntry::Kind kind, int id) {
@@ -198,53 +280,51 @@ uint AOTCodeCache::max_aot_code_size() {
   return _max_aot_code_size;
 }
 
+bool AOTCodeCache::is_code_load_thread_on() {
+  return AOTCodeCaching && !CDSConfig::is_dumping_final_static_archive();
+}
+
 // It is called from AOTMetaspace::initialize_shared_spaces()
 // which is called from universe_init().
-// At this point all AOT class linking seetings are finilized
+// At this point all AOT class linking settings are finalized
 // and AOT cache is open so we can map AOT code region.
 void AOTCodeCache::initialize() {
+  if (!is_caching_enabled()) {
+    load_info_log().print_cr("AOT Code Cache is not used: disabled");
+    return;
+  }
 #if defined(ZERO) || !(defined(AMD64) || defined(AARCH64))
-  log_info(aot, codecache, init)("AOT Code Cache is not supported on this platform.");
+  load_info_log().print_cr("AOT Code Cache is not supported on this platform");
   disable_caching();
   return;
 #else
-  if (FLAG_IS_DEFAULT(AOTCache)) {
-    log_info(aot, codecache, init)("AOT Code Cache is not used: AOTCache is not specified.");
-    disable_caching();
-    return; // AOTCache must be specified to dump and use AOT code
-  }
+  assert(!FLAG_IS_DEFAULT(AOTCache), "AOTCache should be specified");
 
   if (VerifyOops) {
     // Disable AOT stubs caching when VerifyOops flag is on.
     // Verify oops code generated a lot of C strings which overflow
     // AOT C string table (which has fixed size).
     // AOT C string table will be reworked later to handle such cases.
-    //
-    // Note: AOT adapters are not affected - they don't have oop operations.
-    log_info(aot, codecache, init)("AOT Stubs Caching is not supported with VerifyOops.");
-    FLAG_SET_ERGO(AOTStubCaching, false);
+    load_info_log().print_cr("AOT Code Caching is not supported with VerifyOops");
+    disable_caching();
+    return;
   }
 
   bool is_dumping = false;
   bool is_using   = false;
   if (CDSConfig::is_dumping_final_static_archive() && CDSConfig::is_dumping_aot_linked_classes()) {
-    is_dumping = true;
-    enable_caching();
     is_dumping = is_caching_enabled();
   } else if (CDSConfig::is_using_archive() && CDSConfig::is_using_aot_linked_classes()) {
-    enable_caching();
     is_using = is_caching_enabled();
-  } else {
-    log_info(aot, codecache, init)("AOT Code Cache is not used: AOT Class Linking is not used.");
-    disable_caching();
-    return; // nothing to do
   }
   if (!(is_dumping || is_using)) {
+    load_info_log().print_cr("AOT Code Cache is not used: AOT Class Linking is not used");
     disable_caching();
     return; // AOT code caching disabled on command line
   }
+  // Reserve AOT Cache region when we dumping AOT code.
   _max_aot_code_size = AOTCodeMaxSize;
-  if (!FLAG_IS_DEFAULT(AOTCodeMaxSize)) {
+  if (is_dumping && !FLAG_IS_DEFAULT(AOTCodeMaxSize)) {
     if (!is_aligned(AOTCodeMaxSize, os::vm_allocation_granularity())) {
       _max_aot_code_size = align_up(AOTCodeMaxSize, os::vm_allocation_granularity());
       log_debug(aot,codecache,init)("Max AOT Code Cache size is aligned up to %uK", (int)(max_aot_code_size()/K));
@@ -252,7 +332,7 @@ void AOTCodeCache::initialize() {
   }
   size_t aot_code_size = is_using ? AOTCacheAccess::get_aot_code_region_size() : 0;
   if (is_using && aot_code_size == 0) {
-    log_info(aot, codecache, init)("AOT Code Cache is empty");
+    load_info_log().print_cr("AOT Code Cache is empty");
     disable_caching();
     return;
   }
@@ -265,6 +345,7 @@ void AOTCodeCache::initialize() {
     return;
   }
   if (is_dumping) {
+    FLAG_SET_DEFAULT(FoldStableValues, false);
     FLAG_SET_DEFAULT(ForceUnreachable, true);
   }
   FLAG_SET_DEFAULT(DelayCompilerStubsGeneration, false);
@@ -281,7 +362,8 @@ void AOTCodeCache::init2() {
   if (opened_cache == nullptr) {
     return;
   }
-  if (!opened_cache->verify_config()) {
+  // After Universe initialized
+  if (!opened_cache->verify_config_on_use()) { // Check on AOT code loading
     delete opened_cache;
     opened_cache = nullptr;
     report_load_failure();
@@ -291,7 +373,7 @@ void AOTCodeCache::init2() {
   // initialize aot runtime constants as appropriate to this runtime
   AOTRuntimeConstants::initialize_from_runtime();
 
-  // initialize the table of external routines so we can save
+  // initialize the table of external routines and initial stubs so we can save
   // generated code blobs that reference them
   AOTCodeAddressTable* table = opened_cache->_table;
   assert(table != nullptr, "should be initialized already");
@@ -299,6 +381,19 @@ void AOTCodeCache::init2() {
 
   // Now cache and address table are ready for AOT code generation
   _cache = opened_cache;
+
+  if (is_using_code()) {
+    FLAG_SET_ERGO_IF_DEFAULT(AOTCompileEagerly, true);
+  }
+  // Set ClassInitBarrierMode after all checks since it affects code generation
+  if (is_dumping_code()) {
+    FLAG_SET_ERGO_IF_DEFAULT(ClassInitBarrierMode, 1);
+  } else {
+    if (ClassInitBarrierMode > 0) {
+      log_info(aot, codecache, init)("Set ClassInitBarrierMode to 0 because AOT Code caching is off");
+    }
+    FLAG_SET_ERGO(ClassInitBarrierMode, 0);
+  }
 }
 
 bool AOTCodeCache::open_cache(bool is_dumping, bool is_using) {
@@ -332,6 +427,49 @@ void AOTCodeCache::dump() {
   }
 }
 
+class CachedCodeDirectory {
+public:
+  uint _aot_code_size;
+  char* _aot_code_data;
+
+  void set_aot_code_data(uint size, char* aot_data) {
+    _aot_code_size = size;
+    AOTCacheAccess::set_pointer(&_aot_code_data, aot_data);
+  }
+
+  static CachedCodeDirectory* create();
+};
+
+// Storing AOT code in the AOT code region (ac) of AOT Cache:
+//
+// [1] Use CachedCodeDirectory to keep track of all of data related to AOT code.
+//     E.g., you can build a hash table to record what methods have been archived.
+//
+// [2] Memory for all data for AOT code, including CachedCodeDirectory, should be
+//     allocated using AOTCacheAccess::allocate_aot_code_region().
+//
+// [3] CachedCodeDirectory must be the very first allocation.
+//
+// [4] Two kinds of pointer can be stored:
+//     - A pointer p that points to metadata. AOTCacheAccess::can_generate_aot_code(p) must return true.
+//     - A pointer to a buffer returned by AOTCacheAccess::allocate_aot_code_region().
+//       (It's OK to point to an interior location within this buffer).
+//     Such pointers must be stored using AOTCacheAccess::set_pointer()
+//
+// The buffers allocated by AOTCacheAccess::allocate_aot_code_region() are in a contiguous region. At runtime, this
+// region is mapped to the process address space. All the pointers in this buffer are relocated as necessary
+// (e.g., to account for the runtime location of the CodeCache).
+//
+// This is always at the very beginning of the mmapped CDS "ac" (AOT code) region
+static CachedCodeDirectory* _aot_code_directory = nullptr;
+
+CachedCodeDirectory* CachedCodeDirectory::create() {
+  assert(AOTCacheAccess::is_aot_code_region_empty(), "must be");
+  CachedCodeDirectory* dir = (CachedCodeDirectory*)AOTCacheAccess::allocate_aot_code_region(sizeof(CachedCodeDirectory));
+  dir->set_aot_code_data(0, nullptr);
+  return dir;
+}
+
 #define DATA_ALIGNMENT HeapWordSize
 
 AOTCodeCache::AOTCodeCache(bool is_dumping, bool is_using) :
@@ -346,12 +484,16 @@ AOTCodeCache::AOTCodeCache(bool is_dumping, bool is_using) :
   _for_dump(is_dumping),
   _failed(false),
   _lookup_failed(false),
+  _for_preload(false),
+  _has_clinit_barriers(false),
   _table(nullptr),
   _load_entries(nullptr),
   _search_entries(nullptr),
   _store_entries(nullptr),
   _C_strings_buf(nullptr),
-  _store_entries_cnt(0)
+  _store_entries_cnt(0),
+  _compile_id(0),
+  _comp_level(0)
 {
   // Read header at the begining of cache
   if (_for_use) {
@@ -359,34 +501,38 @@ AOTCodeCache::AOTCodeCache(bool is_dumping, bool is_using) :
     size_t load_size = AOTCacheAccess::get_aot_code_region_size();
     ReservedSpace rs = MemoryReserver::reserve(load_size, mtCode);
     if (!rs.is_reserved()) {
-      log_warning(aot, codecache, init)("Failed to reserved %u bytes of memory for mapping AOT code region into AOT Code Cache", (uint)load_size);
+      log_warning(aot, codecache, init)("Failed to reserved %u bytes of memory for mapping AOT code region from AOT Cache", (uint)load_size);
       set_failed();
       return;
     }
     if (!AOTCacheAccess::map_aot_code_region(rs)) {
-      log_warning(aot, codecache, init)("Failed to read/mmap cached code region into AOT Code Cache");
+      log_warning(aot, codecache, init)("Failed to read/mmap AOT code region from AOT Cache");
       set_failed();
       return;
     }
+    _aot_code_directory = (CachedCodeDirectory*)rs.base();
 
-    _load_size = (uint)load_size;
-    _load_buffer = (char*)rs.base();
+    _load_size = _aot_code_directory->_aot_code_size;
+    _load_buffer = _aot_code_directory->_aot_code_data;
     assert(is_aligned(_load_buffer, DATA_ALIGNMENT), "load_buffer is not aligned");
-    log_debug(aot, codecache, init)("Mapped %u bytes at address " INTPTR_FORMAT " at AOT Code Cache", _load_size, p2i(_load_buffer));
+    load_info_log().print_cr("Mapped %u bytes at address " INTPTR_FORMAT " from AOT Code Cache", _load_size, p2i(_load_buffer));
 
     _load_header = (Header*)addr(0);
     if (!_load_header->verify(_load_size)) {
       set_failed();
       return;
     }
-    log_info (aot, codecache, init)("Loaded %u AOT code entries from AOT Code Cache", _load_header->entries_count());
-    log_debug(aot, codecache, init)("  Adapters:  total=%u", _load_header->adapters_count());
-    log_debug(aot, codecache, init)("  Shared Blobs: total=%u", _load_header->shared_blobs_count());
-    log_debug(aot, codecache, init)("  StubGen Blobs:  total=%d", _load_header->stubgen_blobs_count());
-    log_debug(aot, codecache, init)("  C1 Blobs: total=%u", _load_header->C1_blobs_count());
-    log_debug(aot, codecache, init)("  C2 Blobs: total=%u", _load_header->C2_blobs_count());
-    log_debug(aot, codecache, init)("  AOT code cache size: %u bytes", _load_header->cache_size());
-
+    load_info_log().print_cr("Loaded %u AOT code entries from AOT Code Cache", _load_header->entries_count());
+    LogStreamHandle(Info, aot, codecache, init) log;
+    if (log.is_enabled()) {
+      log.print_cr("  %s: total=%u", aot_code_entry_kind_name[AOTCodeEntry::Adapter], _load_header->adapters_count());
+      log.print_cr("  %s: total=%u", aot_code_entry_kind_name[AOTCodeEntry::SharedBlob], _load_header->shared_blobs_count());
+      log.print_cr("  %s: total=%u", aot_code_entry_kind_name[AOTCodeEntry::C1Blob], _load_header->C1_blobs_count());
+      log.print_cr("  %s: total=%u", aot_code_entry_kind_name[AOTCodeEntry::C2Blob], _load_header->C2_blobs_count());
+      log.print_cr("  %s: total=%u", aot_code_entry_kind_name[AOTCodeEntry::StubGenBlob], _load_header->stubgen_blobs_count());
+      log.print_cr("  %s: total=%u", aot_code_entry_kind_name[AOTCodeEntry::Nmethod], _load_header->nmethods_count());
+      log.print_cr("  AOT code total size: %u bytes", _load_header->cache_size());
+    }
     // Read strings
     load_strings();
   }
@@ -398,6 +544,14 @@ AOTCodeCache::AOTCodeCache(bool is_dumping, bool is_using) :
     log_debug(aot, codecache, init)("Allocated store buffer at address " INTPTR_FORMAT " of size %u", p2i(_store_buffer), max_aot_code_size());
   }
   _table = new AOTCodeAddressTable();
+}
+
+void AOTCodeCache::invalidate(AOTCodeEntry* entry) {
+  // Invalidate AOT code during production run.
+  // This could be concurrent execution.
+  if (entry != nullptr && is_on_for_use()) {
+    _cache->invalidate_entry(entry);
+  }
 }
 
 void AOTCodeCache::add_stub_entries(StubId stub_id, address start, GrowableArray<address> *entries, int begin_idx) {
@@ -466,6 +620,8 @@ void AOTCodeCache::Config::record(uint cpu_features_offset) {
   // Special configs that cannot be checked with macros
   _compressedOopBase     = CompressedOops::base();
   _compressedOopShift    = CompressedOops::shift();
+  _compressedKlassBase   = CompressedKlassPointers::base();
+  _codeCacheSize         = pointer_delta(CodeCache::high_bound(), CodeCache::low_bound(), 1);
 
 #if defined(X86) && !defined(ZERO)
   _useUnalignedLoadStores = UseUnalignedLoadStores;
@@ -580,6 +736,11 @@ bool AOTCodeCache::Config::verify(AOTCodeCache* cache) const {
   // Special configs that cannot be checked with macros
 #define COMPRESSED_OOPS_HINT "Consider adding -XX:+AOTCompatibleOopCompression when creating the AOT cache"
 
+  size_t codeCacheSize = pointer_delta(CodeCache::high_bound(), CodeCache::low_bound(), 1);
+  if (codeCacheSize > _codeCacheSize) { // Only allow smaller or equal CodeCache size in production run
+    load_failure_log().print_cr("AOT Code Cache disabled: it was created with smaller CodeCache size = %dKb vs current %dKb", (int)(_codeCacheSize/K), (int)(codeCacheSize/K));
+    return false;
+  }
   if ((_compressedOopBase == nullptr || CompressedOops::base() == nullptr) && (_compressedOopBase != CompressedOops::base())) {
     load_failure_log().print_cr("AOT Code Cache disabled: incompatible CompressedOops::base(): %p vs current %p",
                                 _compressedOopBase, CompressedOops::base());
@@ -589,6 +750,10 @@ bool AOTCodeCache::Config::verify(AOTCodeCache* cache) const {
 
   if (!check_config(_compressedOopShift, CompressedOops::shift(), "CompressedOops::shift()")) {
     load_failure_log().print_cr(COMPRESSED_OOPS_HINT);
+    return false;
+  }
+  if ((_compressedKlassBase == nullptr || CompressedKlassPointers::base() == nullptr) && (_compressedKlassBase != CompressedKlassPointers::base())) {
+    load_failure_log().print_cr("AOT Code Cache disabled: incompatible CompressedKlassPointers::base(): %p vs current %p", _compressedKlassBase, CompressedKlassPointers::base());
     return false;
   }
 
@@ -641,25 +806,54 @@ AOTCodeCache* AOTCodeCache::open_for_dump() {
   return nullptr;
 }
 
-void copy_bytes(const char* from, address to, uint size) {
+bool AOTCodeCache::is_address_in_aot_cache(address p) {
+  AOTCodeCache* cache = open_for_use();
+  if (cache == nullptr) {
+    return false;
+  }
+  if ((p >= (address)cache->cache_buffer()) &&
+      (p < (address)(cache->cache_buffer() + cache->load_size()))) {
+    return true;
+  }
+  return false;
+}
+
+static void copy_bytes(const char* from, address to, uint size) {
   assert((int)size > 0, "sanity");
   memcpy(to, from, size);
   log_trace(aot, codecache)("Copied %d bytes from " INTPTR_FORMAT " to " INTPTR_FORMAT, size, p2i(from), p2i(to));
 }
 
-AOTCodeReader::AOTCodeReader(AOTCodeCache* cache, AOTCodeEntry* entry) {
+AOTCodeReader::AOTCodeReader(AOTCodeCache* cache, AOTCodeEntry* entry, CompileTask* task) {
+  precond(cache != nullptr);
   _cache = cache;
   _entry = entry;
   _load_buffer = cache->cache_buffer();
   _read_position = 0;
-  _lookup_failed = false;
-  _name          = nullptr;
-  _reloc_data    = nullptr;
-  _reloc_count   = 0;
-  _oop_maps      = nullptr;
+  _failure = nullptr;
+
+  // Values used by restore(code_blob).
   _entry_kind    = AOTCodeEntry::None;
-  _stub_data     = nullptr;
   _id            = -1;
+  _stub_data     = nullptr;
+  if (task != nullptr) {
+    _compile_id  = task->compile_id();
+    _comp_level  = task->comp_level();
+    _preload     = task->preload();
+  } else {
+    _compile_id  = 0;
+    _comp_level  = 0;
+    _preload     = false;
+  }
+  _name           = nullptr;
+  _reloc_data     = nullptr;
+  _reloc_count    = 0;
+  _oop_maps       = nullptr;
+  _immutable_data = nullptr;
+  _oop_list       = nullptr;
+  _metadata_list  = nullptr;
+  _reloc_imm_oop_list      = nullptr;
+  _reloc_imm_metadata_list = nullptr;
 }
 
 void AOTCodeReader::set_read_position(uint pos) {
@@ -716,8 +910,8 @@ address AOTCodeCache::reserve_bytes(uint nbytes) {
   assert(for_dump(), "Code Cache file is not created");
   uint new_position = _write_position + nbytes;
   if (new_position >= (uint)((char*)_store_entries - _store_buffer)) {
-    log_warning(aot,codecache)("Failed to ensure %d bytes at offset %d in AOT Code Cache. Increase AOTCodeMaxSize.",
-                               nbytes, _write_position);
+    log_error(aot, codecache)("Failed to ensure %d bytes at offset %d in AOT Code Cache. Increase AOTCodeMaxSize.",
+                              nbytes, _write_position);
     set_failed();
     report_store_failure();
     return nullptr;
@@ -738,14 +932,13 @@ uint AOTCodeCache::write_bytes(const void* buffer, uint nbytes) {
   }
   uint new_position = _write_position + nbytes;
   if (new_position >= (uint)((char*)_store_entries - _store_buffer)) {
-    log_warning(aot, codecache)("Failed to write %d bytes at offset %d to AOT Code Cache. Increase AOTCodeMaxSize.",
-                                nbytes, _write_position);
+    log_error(aot, codecache)("Failed to write %d bytes at offset %d to AOT Code Cache. Increase AOTCodeMaxSize.",
+                              nbytes, _write_position);
     set_failed();
     report_store_failure();
     return 0;
   }
   copy_bytes((const char* )buffer, (address)(_store_buffer + _write_position), nbytes);
-  log_trace(aot, codecache)("Wrote %d bytes at offset %d to AOT Code Cache", nbytes, _write_position);
   _write_position += nbytes;
   if (_store_size < _write_position) {
     _store_size = _write_position;
@@ -753,25 +946,111 @@ uint AOTCodeCache::write_bytes(const void* buffer, uint nbytes) {
   return nbytes;
 }
 
+AOTCodeEntry* AOTCodeCache::find_code_entry(const methodHandle& method, uint comp_level) {
+  assert(is_using_code(), "AOT code caching should be enabled");
+  if (!method->in_aot_cache()) {
+    return nullptr;
+  }
+
+  MethodCounters* mc = method->method_counters();
+  // AOT T4 code uses carry bit to indicate recompilation request
+  if (mc != nullptr && mc->invocation_counter()->carry()) {
+    return nullptr; // Already requested JIT compilation
+  }
+
+  // DisableAOTCode uses decimal values as bitmask:
+  // Tier 1 (A1)                  |     1
+  // Tier 2 (A1 + counters)       |    10
+  // Tier 3 (A1 + counters + mdo) |   100
+  // Tier 4 (A4)                  |  1000
+  // Tier 5 (AP4)                 | 10000
+  // All C1 tiers                 |   111
+  // All tiers                    | 11111
+  switch (comp_level) {
+    case CompLevel_simple:
+      if ((DisableAOTCode % 10) == 1) {
+        return nullptr;
+      }
+      break;
+    case CompLevel_limited_profile:
+      if ((DisableAOTCode / 10) % 10 == 1) {
+        return nullptr;
+      }
+      break;
+    case CompLevel_full_optimization:
+      if ((DisableAOTCode / 1000) % 10 == 1) {
+        return nullptr;
+      }
+      break;
+
+    default: return nullptr; // Level 1, 2, and 4 only
+  }
+  TraceTime t1("Total time to find AOT code", &_t_totalFind, enable_timers(), false);
+  if (is_on() && _cache->cache_buffer() != nullptr) {
+    uint id = (uint)cast_to_u4(AOTCacheAccess::method_to_narrow_ptr(method()));
+    AOTCodeEntry* entry = _cache->find_entry(AOTCodeEntry::Nmethod, id, comp_level);
+    if (entry == nullptr) {
+      LogStreamHandle(Info, aot, codecache, nmethod) log;
+      if (log.is_enabled()) {
+        ResourceMark rm;
+        const char* target_name = method->name_and_sig_as_C_string();
+        log.print_cr("Missing entry for '%s' (comp_level %d, id: " UINT32_FORMAT_X_0 ")", target_name, (uint)comp_level, id);
+      }
+#ifdef ASSERT
+    } else {
+      assert(!entry->has_clinit_barriers(), "only preload code should have clinit barriers");
+      ResourceMark rm;
+      assert(method() == entry->method(), "AOTCodeCache: saved nmethod's method %p (name: %s id: " UINT32_FORMAT_X_0
+             ") is different from the method %p (name: %s, id: " UINT32_FORMAT_X_0 " being looked up" ,
+             entry->method(), entry->method()->name_and_sig_as_C_string(), entry->id(), method(), method()->name_and_sig_as_C_string(), id);
+#endif
+    }
+
+    CompilerDirectiveMatcher matcher(method, comp_level);
+    DirectiveSet* directives = matcher.directive_set();
+    if (directives->IgnoreAOTCompiledOption || directives->ExcludeOption) {
+      LogStreamHandle(Info, aot, codecache, compilation) log;
+      if (log.is_enabled()) {
+        log.print_cr("Ignore AOT code entry on level %d for ", comp_level);
+        method->print_value_on(&log);
+      }
+      return nullptr;
+    }
+
+    return entry;
+  }
+  return nullptr;
+}
+
+Method* AOTCodeEntry::method() {
+  assert(_kind == Nmethod, "invalid kind %d", _kind);
+  assert(AOTCodeCache::is_on_for_use(), "must be");
+  return AOTCacheAccess::narrow_ptr_to_method(cast_from_u4(_id));
+}
+
 void* AOTCodeEntry::operator new(size_t x, AOTCodeCache* cache) {
   return (void*)(cache->add_entry());
 }
 
-static bool check_entry(AOTCodeEntry::Kind kind, uint id, AOTCodeEntry* entry) {
+static bool check_entry(AOTCodeEntry::Kind kind, uint id, uint comp_level, AOTCodeEntry* entry) {
   if (entry->kind() == kind) {
     assert(entry->id() == id, "sanity");
-    return true; // Found
+    if (kind != AOTCodeEntry::Nmethod || // adapters and stubs have only one version
+        // Look only for normal AOT code entry, preload code is handled separately
+        (!entry->not_entrant() && (entry->comp_level() == comp_level))) {
+      return true; // Found
+    }
   }
   return false;
 }
 
-AOTCodeEntry* AOTCodeCache::find_entry(AOTCodeEntry::Kind kind, uint id) {
+AOTCodeEntry* AOTCodeCache::find_entry(AOTCodeEntry::Kind kind, uint id, uint comp_level) {
   assert(_for_use, "sanity");
   uint count = _load_header->entries_count();
   if (_load_entries == nullptr) {
     // Read it
-    _search_entries = (uint*)addr(_load_header->entries_offset()); // [id, index]
-    _load_entries = (AOTCodeEntry*)(_search_entries + 2 * count);
+    _search_entries = (uint*)addr(_load_header->search_table_offset()); // [id, index]
+    _load_entries = (AOTCodeEntry*)addr(_load_header->entries_offset());
     log_debug(aot, codecache, init)("Read %d entries table at offset %d from AOT Code Cache", count, _load_header->entries_offset());
   }
   // Binary search
@@ -784,10 +1063,10 @@ AOTCodeEntry* AOTCodeCache::find_entry(AOTCodeEntry::Kind kind, uint id) {
     if (is == id) {
       int index = _search_entries[ix + 1];
       AOTCodeEntry* entry = &(_load_entries[index]);
-      if (check_entry(kind, id, entry)) {
+      if (check_entry(kind, id, comp_level, entry)) {
         return entry; // Found
       }
-      // Linear search around to handle id collission
+      // Leaner search around
       for (int i = mid - 1; i >= l; i--) { // search back
         ix = i * 2;
         is = _search_entries[ix];
@@ -796,7 +1075,7 @@ AOTCodeEntry* AOTCodeCache::find_entry(AOTCodeEntry::Kind kind, uint id) {
         }
         index = _search_entries[ix + 1];
         AOTCodeEntry* entry = &(_load_entries[index]);
-        if (check_entry(kind, id, entry)) {
+        if (check_entry(kind, id, comp_level, entry)) {
           return entry; // Found
         }
       }
@@ -808,11 +1087,11 @@ AOTCodeEntry* AOTCodeCache::find_entry(AOTCodeEntry::Kind kind, uint id) {
         }
         index = _search_entries[ix + 1];
         AOTCodeEntry* entry = &(_load_entries[index]);
-        if (check_entry(kind, id, entry)) {
+        if (check_entry(kind, id, comp_level, entry)) {
           return entry; // Found
         }
       }
-      break; // Not found match
+      break; // No match found
     } else if (is < id) {
       l = mid + 1;
     } else {
@@ -822,12 +1101,107 @@ AOTCodeEntry* AOTCodeCache::find_entry(AOTCodeEntry::Kind kind, uint id) {
   return nullptr;
 }
 
-extern "C" {
-  static int uint_cmp(const void *i, const void *j) {
-    uint a = *(uint *)i;
-    uint b = *(uint *)j;
-    return a > b ? 1 : a < b ? -1 : 0;
+void AOTCodeCache::invalidate_entry(AOTCodeEntry* entry) {
+  assert(entry!= nullptr, "all entries should be read already");
+  if (entry->not_entrant()) {
+    return; // Someone invalidated it already
   }
+#ifdef ASSERT
+  assert(_load_entries != nullptr, "sanity");
+  assert(entry->is_loaded() || entry->for_preload(), "invalidate only AOT code in use or a preload code");
+  bool found = false;
+  uint i = 0;
+  uint count = 0;
+  if (entry->for_preload()) {
+    count = _load_header->preload_entries_count();
+    AOTCodeEntry* preload_entry = (AOTCodeEntry*)addr(_load_header->preload_entries_offset());
+    for (; i < count; i++) {
+      if (entry == &preload_entry[i]) {
+        break;
+      }
+    }
+  } else {
+    count = _load_header->entries_count();
+    for(; i < count; i++) {
+      if (entry == &(_load_entries[i])) {
+        break;
+      }
+    }
+  }
+  found = (i < count);
+  assert(found, "entry should exist");
+#endif
+  entry->set_not_entrant();
+  uint name_offset = entry->offset() + entry->name_offset();
+  const char* name = _load_buffer + name_offset;;
+  uint level       = entry->comp_level();
+  uint comp_id     = entry->comp_id();
+  bool for_preload = entry->for_preload();
+  bool clinit_brs  = entry->has_clinit_barriers();
+  log_info(aot, codecache, nmethod)("Invalidated entry for '%s' (comp_id %d, comp_level %d, hash: " UINT32_FORMAT_X_0 "%s%s)",
+                                    name, comp_id, level, entry->id(), (for_preload ? "P" : "A"), (clinit_brs ? ", has clinit barriers" : ""));
+
+  if (!for_preload && (entry->comp_level() == CompLevel_full_optimization)) {
+    // Invalidate preload code if normal AOT C2 code is invalidated,
+    // most likely because some dependencies changed during run.
+    // We can still use normal AOT code if preload code is
+    // invalidated - normal AOT code has less restrictions.
+    MethodCounters* mc = entry->method()->method_counters();
+    if (mc != nullptr && mc->aot_preload_code_entry() != nullptr) {
+      AOTCodeEntry* preload_entry = mc->aot_preload_code_entry();
+      if (preload_entry != nullptr) {
+        assert(preload_entry->for_preload(), "expecting only such entries here");
+        invalidate_entry(preload_entry);
+      }
+    }
+  }
+}
+
+// +1 for preload code
+const int AOTCompLevel_count = CompLevel_count + 1; // 6 levels indexed from 0 to 5
+
+struct AOTCodeEntryStats {
+private:
+  uint _kind_cnt[AOTCodeEntry::Kind_count];
+  uint _nmethod_cnt[AOTCompLevel_count];
+  uint _clinit_barriers_cnt;
+
+public:
+  static void check_kind(uint kind) {
+    assert(kind > AOTCodeEntry::None && kind < AOTCodeEntry::Kind_count, "Invalid AOTCodeEntry kind %d", kind);
+  }
+  static void check_complevel(uint lvl) {
+    assert(lvl > CompLevel_none && lvl < AOTCompLevel_count, "Invalid compilation level %d", lvl);
+  }
+
+  void inc_entry_cnt(uint kind)  { check_kind(kind); _kind_cnt[kind] += 1; }
+  void inc_nmethod_cnt(uint lvl) { check_complevel(lvl); _nmethod_cnt[lvl] += 1; }
+  void inc_clinit_barriers_cnt() { _clinit_barriers_cnt += 1; }
+
+  AOTCodeEntryStats() {
+    memset(this, 0, sizeof(AOTCodeEntryStats));
+  }
+
+  void collect_entry_stats(AOTCodeEntry* entry) {
+    inc_entry_cnt(entry->kind());
+    if (entry->is_nmethod()) {
+      entry->for_preload() ? inc_nmethod_cnt(AOTCompLevel_count-1)
+                           : inc_nmethod_cnt(entry->comp_level());
+      if (entry->has_clinit_barriers()) {
+        inc_clinit_barriers_cnt();
+      }
+    }
+  }
+
+  uint entry_count(uint kind) { check_kind(kind); return _kind_cnt[kind]; }
+  uint nmethod_count(uint lvl) { check_complevel(lvl); return _nmethod_cnt[lvl]; }
+  uint clinit_barriers_count() { return _clinit_barriers_cnt; }
+};
+
+static int uint_cmp(const void *i, const void *j) {
+  uint a = *(uint *)i;
+  uint b = *(uint *)j;
+  return a > b ? 1 : a < b ? -1 : 0;
 }
 
 void AOTCodeCache::store_cpu_features(char*& buffer, uint buffer_size) {
@@ -845,7 +1219,9 @@ bool AOTCodeCache::finish_write() {
   if (!align_write()) {
     return false;
   }
-  uint strings_offset = _write_position;
+  // End of AOT code
+  uint code_size = _write_position;
+  uint strings_offset = code_size;
   int strings_count = store_strings();
   if (strings_count < 0) {
     return false;
@@ -855,17 +1231,16 @@ bool AOTCodeCache::finish_write() {
   }
   uint strings_size = _write_position - strings_offset;
 
-  uint entries_count = 0; // Number of entrant (useful) code entries
-  uint entries_offset = _write_position;
+  uint code_count = _store_entries_cnt;
+  if (code_count > 0) {
+    _aot_code_directory = CachedCodeDirectory::create();
+    assert(_aot_code_directory != nullptr, "Sanity check");
 
-  uint store_count = _store_entries_cnt;
-  if (store_count > 0) {
     uint header_size = (uint)align_up(sizeof(AOTCodeCache::Header), DATA_ALIGNMENT);
-    uint code_count = store_count;
     uint search_count = code_count * 2;
     uint search_size = search_count * sizeof(uint);
     uint entries_size = (uint)align_up(code_count * sizeof(AOTCodeEntry), DATA_ALIGNMENT); // In bytes
-    // _write_position includes size of code and strings
+    // _write_position should include code and strings
     uint code_alignment = code_count * DATA_ALIGNMENT; // We align_up code size when storing it.
     uint cpu_features_size = VM_Version::cpu_features_size();
     uint total_cpu_features_size = sizeof(uint) + cpu_features_size; // sizeof(uint) to store cpu_features_size
@@ -887,50 +1262,91 @@ bool AOTCodeCache::finish_write() {
     uint* search = NEW_C_HEAP_ARRAY(uint, search_count, mtCode);
 
     AOTCodeEntry* entries_address = _store_entries; // Pointer to latest entry
-    uint adapters_count = 0;
-    uint shared_blobs_count = 0;
-    uint stubgen_blobs_count = 0;
-    uint C1_blobs_count = 0;
-    uint C2_blobs_count = 0;
+    AOTCodeEntryStats stats;
     uint max_size = 0;
     // AOTCodeEntry entries were allocated in reverse in store buffer.
     // Process them in reverse order to cache first code first.
-    for (int i = store_count - 1; i >= 0; i--) {
-      entries_address[i].set_next(nullptr); // clear pointers before storing data
-      uint size = align_up(entries_address[i].size(), DATA_ALIGNMENT);
+
+    // Store AOTCodeEntry for preload code first.
+    current = align_up(current, DATA_ALIGNMENT);
+    uint preload_entries_cnt = 0;
+    uint preload_entries_offset = current - start;
+    AOTCodeEntry* preload_entries = (AOTCodeEntry*)current;
+    for (int i = code_count - 1; i >= 0; i--) {
+      AOTCodeEntry* entry = &entries_address[i];
+      if (entry->load_fail()) {
+        continue;
+      }
+      if (entry->for_preload()) {
+        if (entry->not_entrant()) {
+          // Skip not entrant preload code:
+          // we can't pre-load code which may have failing dependencies.
+          log_info(aot, codecache, exit)("Skip not entrant preload code comp_id: %d, comp_level: %d, hash: " UINT32_FORMAT_X_0 "%s",
+                                         entry->comp_id(), entry->comp_level(), entry->id(), (entry->has_clinit_barriers() ? ", has clinit barriers" : ""));
+        } else {
+          copy_bytes((const char*)entry, (address)current, sizeof(AOTCodeEntry));
+          stats.collect_entry_stats(entry);
+          current += sizeof(AOTCodeEntry);
+          preload_entries_cnt++;
+        }
+      }
+    }
+
+    // Now write the data for preload AOTCodeEntry
+    current = align_up(current, DATA_ALIGNMENT);
+    for (int i = 0; i < (int)preload_entries_cnt; i++) {
+      AOTCodeEntry* entry = &preload_entries[i];
+      uint size = align_up(entry->size(), DATA_ALIGNMENT);
       if (size > max_size) {
         max_size = size;
       }
-      copy_bytes((_store_buffer + entries_address[i].offset()), (address)current, size);
-      entries_address[i].set_offset(current - start); // New offset
+      copy_bytes((_store_buffer + entry->offset()), (address)current, size);
+      entry->set_offset(current - start); // New offset
       current += size;
-      uint n = write_bytes(&(entries_address[i]), sizeof(AOTCodeEntry));
-      if (n != sizeof(AOTCodeEntry)) {
-        FREE_C_HEAP_ARRAY(search);
-        return false;
+    }
+
+    // Store the rest of AOTCodeEntry
+    uint entries_count = 0;
+    uint new_entries_offset = current - start;
+    AOTCodeEntry* code_entries = (AOTCodeEntry*)current;
+    for (int i = code_count - 1; i >= 0; i--) {
+      AOTCodeEntry* entry = &entries_address[i];
+      if (entry->load_fail() || entry->for_preload()) {
+        continue;
       }
-      search[entries_count*2 + 0] = entries_address[i].id();
+      if (entry->not_entrant()) {
+        log_info(aot, codecache, exit)("Not entrant new entry comp_id: %d, comp_level: %d, hash: " UINT32_FORMAT_X_0 "%s",
+                                       entry->comp_id(), entry->comp_level(), entry->id(), (entry->has_clinit_barriers() ? ", has clinit barriers" : ""));
+        entry->set_entrant(); // Reset
+      }
+      copy_bytes((const char*)entry, (address)current, sizeof(AOTCodeEntry));
+      stats.collect_entry_stats(entry);
+      current += sizeof(AOTCodeEntry);
+      search[entries_count*2 + 0] = entry->id();
       search[entries_count*2 + 1] = entries_count;
       entries_count++;
-      AOTCodeEntry::Kind kind = entries_address[i].kind();
-      if (kind == AOTCodeEntry::Adapter) {
-        adapters_count++;
-      } else if (kind == AOTCodeEntry::SharedBlob) {
-        shared_blobs_count++;
-      } else if (kind == AOTCodeEntry::StubGenBlob) {
-        stubgen_blobs_count++;
-      } else if (kind == AOTCodeEntry::C1Blob) {
-        C1_blobs_count++;
-      } else if (kind == AOTCodeEntry::C2Blob) {
-        C2_blobs_count++;
-      }
     }
-    if (entries_count == 0) {
-      log_info(aot, codecache, exit)("AOT Code Cache was not created: no entires");
+
+    // Now write the data for AOTCodeEntry
+    current = align_up(current, DATA_ALIGNMENT);
+    for (int i = 0; i < (int)entries_count; i++) {
+      AOTCodeEntry* entry = &code_entries[i];
+      uint size = align_up(entry->size(), DATA_ALIGNMENT);
+      if (size > max_size) {
+        max_size = size;
+      }
+      copy_bytes((_store_buffer + entry->offset()), (address)current, size);
+      entry->set_offset(current - start); // New offset
+      current += size;
+    }
+
+    if (preload_entries_cnt == 0 && entries_count == 0) {
+      log_info(aot, codecache, exit)("AOT Code Cache was not created: no entries");
       FREE_C_HEAP_ARRAY(search);
       return true; // Nothing to write
     }
-    assert(entries_count <= store_count, "%d > %d", entries_count, store_count);
+    uint total_entries_cnt = preload_entries_cnt + entries_count;
+    assert(total_entries_cnt <= code_count, "%d > %d", total_entries_cnt, code_count);
     // Write strings
     if (strings_count > 0) {
       copy_bytes((_store_buffer + strings_offset), (address)current, strings_size);
@@ -938,7 +1354,8 @@ bool AOTCodeCache::finish_write() {
       current += strings_size;
     }
 
-    uint new_entries_offset = (current - start); // New offset
+    current = align_up(current, DATA_ALIGNMENT);
+    uint search_table_offset = current - start;
     // Sort and store search table
     qsort(search, entries_count, 2*sizeof(uint), uint_cmp);
     search_size = 2 * entries_count * sizeof(uint);
@@ -946,29 +1363,31 @@ bool AOTCodeCache::finish_write() {
     FREE_C_HEAP_ARRAY(search);
     current += search_size;
 
-    // Write entries
-    entries_size = entries_count * sizeof(AOTCodeEntry); // New size
-    copy_bytes((_store_buffer + entries_offset), (address)current, entries_size);
-    current += entries_size;
+    log_stats_on_exit(stats);
+
     uint size = (current - start);
     assert(size <= total_size, "%d > %d", size , total_size);
-
-    log_debug(aot, codecache, exit)("  Adapters:  total=%u", adapters_count);
-    log_debug(aot, codecache, exit)("  Shared Blobs:  total=%d", shared_blobs_count);
-    log_debug(aot, codecache, exit)("  StubGen Blobs:  total=%d", stubgen_blobs_count);
-    log_debug(aot, codecache, exit)("  C1 Blobs:      total=%d", C1_blobs_count);
-    log_debug(aot, codecache, exit)("  C2 Blobs:      total=%d", C2_blobs_count);
-    log_debug(aot, codecache, exit)("  AOT code cache size: %u bytes, max entry's size: %u bytes", size, max_size);
-
+    LogStreamHandle(Info, aot, codecache, exit) log;
+    if (log.is_enabled()) {
+      log.print_cr("  AOT code cache size: %u bytes", size);
+      log.print_cr("    header size:        %u", header_size);
+      log.print_cr("    total code size:    %u (max code's size: %u)", code_size, max_size);
+      log.print_cr("    entries size:       %u", entries_size);
+      log.print_cr("    entry search table: %u", search_size);
+      log.print_cr("    C strings size:     %u", strings_size);
+      log.print_cr("    CPU features data:  %u", total_cpu_features_size);
+    }
     // Finalize header
     AOTCodeCache::Header* header = (AOTCodeCache::Header*)start;
     header->init(size, (uint)strings_count, strings_offset,
-                 entries_count, new_entries_offset,
-                 adapters_count, shared_blobs_count,
-                 stubgen_blobs_count, C1_blobs_count,
-                 C2_blobs_count, cpu_features_offset);
+                 entries_count, new_entries_offset, search_table_offset,
+                 preload_entries_cnt, preload_entries_offset,
+                 stats.entry_count(AOTCodeEntry::Adapter), stats.entry_count(AOTCodeEntry::SharedBlob),
+                 stats.entry_count(AOTCodeEntry::StubGenBlob), stats.entry_count(AOTCodeEntry::C1Blob),
+                 stats.entry_count(AOTCodeEntry::C2Blob), cpu_features_offset);
 
-    log_info(aot, codecache, exit)("Wrote %d AOT code entries to AOT Code Cache", entries_count);
+    log_info(aot, codecache, exit)("Wrote %d AOT code entries to AOT Code Cache", total_entries_cnt);
+    _aot_code_directory->set_aot_code_data(size, start);
   }
   return true;
 }
@@ -1017,7 +1436,8 @@ bool AOTCodeCache::store_code_blob(CodeBlob& blob, AOTCodeEntry::Kind entry_kind
   if (AOTCodeEntry::is_blob(entry_kind) && !is_dumping_stub()) {
     return false;
   }
-  log_debug(aot, codecache, stubs)("Writing blob '%s' (id=%u, kind=%s) to AOT Code Cache", name, id, aot_code_entry_kind_name[entry_kind]);
+  log_debug(aot, codecache, stubs)("Writing blob '%s' (id=%u, kind=%s) to AOT Code Cache",
+                                   name, id, aot_code_entry_kind_name[entry_kind]);
 
 #ifdef ASSERT
   LogStreamHandle(Trace, aot, codecache, stubs) log;
@@ -1129,10 +1549,10 @@ bool AOTCodeCache::store_code_blob(CodeBlob& blob, AOTCodeEntry::Kind entry_kind
 
 #ifndef PRODUCT
   // Write asm remarks after relocation info
-  if (!cache->write_asm_remarks(blob)) {
+  if (!cache->write_asm_remarks(blob.asm_remarks(), /* use_string_table */ true)) {
     return false;
   }
-  if (!cache->write_dbg_strings(blob)) {
+  if (!cache->write_dbg_strings(blob.dbg_strings(), /* use_string_table */ true)) {
     return false;
   }
 #endif /* PRODUCT */
@@ -1149,7 +1569,7 @@ bool AOTCodeCache::store_code_blob(CodeBlob& blob, AOTCodeEntry::Kind entry_kind
 
   AOTCodeEntry* entry = new(cache) AOTCodeEntry(entry_kind, encode_id(entry_kind, id),
                                                 entry_position, entry_size, name_offset, name_size,
-                                                blob_offset, has_oop_maps, blob.content_begin());
+                                                blob_offset, has_oop_maps);
   log_debug(aot, codecache, stubs)("Wrote code blob '%s' (id=%u, kind=%s) to AOT Code Cache", name, id, aot_code_entry_kind_name[entry_kind]);
   return true;
 }
@@ -1287,17 +1707,19 @@ CodeBlob* AOTCodeCache::load_code_blob(AOTCodeEntry::Kind entry_kind, uint id, c
   if (AOTCodeEntry::is_blob(entry_kind) && !is_using_stub()) {
     return nullptr;
   }
-  log_debug(aot, codecache, stubs)("Reading blob '%s' (id=%u, kind=%s) from AOT Code Cache", name, id, aot_code_entry_kind_name[entry_kind]);
+  log_debug(aot, codecache, stubs)("Loading blob '%s' (id=%u, kind=%s) from AOT Code Cache",
+                                   name, id, aot_code_entry_kind_name[entry_kind]);
 
   AOTCodeEntry* entry = cache->find_entry(entry_kind, encode_id(entry_kind, id));
   if (entry == nullptr) {
     return nullptr;
   }
-  AOTCodeReader reader(cache, entry);
+  AOTCodeReader reader(cache, entry, nullptr);
   CodeBlob* blob = reader.compile_code_blob(name, entry_kind, id, stub_data);
 
-  log_debug(aot, codecache, stubs)("%sRead blob '%s' (id=%u, kind=%s) from AOT Code Cache",
-                                   (blob == nullptr? "Failed to " : ""), name, id, aot_code_entry_kind_name[entry_kind]);
+  log_debug(aot, codecache, stubs)("%s blob '%s' (id=%u, kind=%s) from AOT Code Cache",
+                                   (blob == nullptr? "Failed to load" : "Loaded"), name, id,
+                                   aot_code_entry_kind_name[entry_kind]);
   return blob;
 }
 
@@ -1330,13 +1752,13 @@ CodeBlob* AOTCodeReader::compile_code_blob(const char* name, AOTCodeEntry::Kind 
   if (strncmp(stored_name, name, (name_size - 1)) != 0) {
     log_warning(aot, codecache, stubs)("Saved blob's name '%s' is different from the expected name '%s'",
                                        stored_name, name);
-    set_lookup_failed(); // Skip this blob
+    set_lookup_failed("Saved blob's name is different"); // Skip this blob
     return nullptr;
   }
   _name = stored_name;
 
   // Read archived code blob and related info
-  uint offset = entry_position + _entry->blob_offset();
+  uint offset = entry_position + _entry->code_offset();
   CodeBlob* archived_blob = (CodeBlob*)addr(offset);
   offset += archived_blob->size();
 
@@ -1390,6 +1812,7 @@ void AOTCodeReader::restore(CodeBlob* code_blob) {
   // the generator's code buffer. We don't attach them to the blob but
   // they get processed below by fix_relocations.
   if (!AOTCodeEntry::is_multi_stub_blob(_entry_kind)) {
+    // Allocates space for mutable data and copy relocation data
     code_blob->restore_mutable_data(_reloc_data);
   }
   code_blob->set_oop_maps(_oop_maps);
@@ -1403,6 +1826,15 @@ void AOTCodeReader::restore(CodeBlob* code_blob) {
     }
     // publish entries found either in stub_data or as offsets in blob
     AOTCodeCache::publish_stub_addresses(*code_blob, blob_id, _stub_data);
+  } else if (code_blob->is_nmethod()) {
+    nmethod* nm = code_blob->as_nmethod();
+    nm->set_compile_id(_compile_id);
+    nm->set_aot_code_entry(_entry);
+    nm->set_immutable_data(_immutable_data);
+    // Restore metadata and oops sections which are used
+    // by fix_relocations().
+    nm->copy_values(_oop_list);
+    nm->copy_values(_metadata_list);
   }
 
   // Now that all the entry points are in the address table we can
@@ -1431,21 +1863,22 @@ void AOTCodeReader::restore(CodeBlob* code_blob) {
       relocInfo* locs = (relocInfo*)_reloc_data;
       code_buffer.insts()->initialize_shared_locs(locs, _reloc_count);
       code_buffer.insts()->set_locs_end(locs + _reloc_count);
-      CodeSection *cs = code_buffer.code_section(CodeBuffer::SECT_INSTS);
+      CodeSection* cs = code_buffer.code_section(CodeBuffer::SECT_INSTS);
       RelocIterator reloc_iter(cs);
       fix_relocations(code_blob, reloc_iter);
     }
   } else {
     // the AOT-load time relocs will be in the blob's restored relocs
     RelocIterator reloc_iter(code_blob);
-    fix_relocations(code_blob, reloc_iter);
+    fix_relocations(code_blob, reloc_iter, _reloc_imm_oop_list, _reloc_imm_metadata_list);
   }
 
 #ifndef PRODUCT
+  bool use_string_table = !code_blob->is_nmethod(); // not for nmethods
   code_blob->asm_remarks().init();
-  read_asm_remarks(code_blob->asm_remarks());
+  read_asm_remarks(code_blob->asm_remarks(), use_string_table);
   code_blob->dbg_strings().init();
-  read_dbg_strings(code_blob->dbg_strings());
+  read_dbg_strings(code_blob->dbg_strings(), use_string_table);
 #endif // PRODUCT
 }
 
@@ -1467,7 +1900,7 @@ void AOTCodeReader::read_stub_data(CodeBlob* code_blob, AOTStubData* stub_data) 
   uint offset = align_read_int();
   LogStreamHandle(Trace, aot, codecache, stubs) log;
   if (log.is_enabled()) {
-    log.print_cr("======== Stub data starts at offset %d", offset);
+    log.print_cr("======== Stub data starts at offset %d", (offset - _entry->offset()));
   }
   // read stub and entries until we see NO_STUBID
   StubId stub_id = *(StubId*)addr(offset); offset += sizeof(StubId);
@@ -1581,13 +2014,414 @@ void AOTCodeCache::publish_stub_addresses(CodeBlob &code_blob, BlobId blob_id, A
   }
 }
 
+AOTCodeEntry* AOTCodeCache::store_nmethod(nmethod* nm, AbstractCompiler* compiler, bool for_preload) {
+  if (!is_dumping_code()) {
+    return nullptr;
+  }
+  assert(CDSConfig::is_dumping_aot_code(), "should be called only when allowed");
+  AOTCodeCache* cache = open_for_dump();
+  precond(cache != nullptr);
+  precond(!nm->is_osr_method()); // AOT compilation is requested only during AOT cache assembly phase
+  if (!compiler->is_c1() && !compiler->is_c2()) {
+    // Only c1 and c2 compilers
+    return nullptr;
+  }
+  int comp_level = nm->comp_level();
+  if (comp_level == CompLevel_full_profile) {
+    // Do not cache C1 compiles with full profile i.e. tier3
+    return nullptr;
+  }
+  assert(comp_level == CompLevel_simple || comp_level == CompLevel_limited_profile || comp_level == CompLevel_full_optimization, "must be");
+
+  TraceTime t1("Total time to store AOT code", &_t_totalStore, enable_timers(), false);
+  AOTCodeEntry* entry = cache->write_nmethod(nm, for_preload);
+  {
+    ResourceMark rm;
+    const char* name = nm->method()->name_and_sig_as_C_string();
+    const char* msg = (entry != nullptr) ? ": wrote to AOT Code Cache" :
+                                           "is skipped: store to AOT Code Cache failed";
+    log_info(aot, codecache, nmethod)("%d (A%s%d) '%s' AOT%s %s",
+             nm->compile_id(), (for_preload ? "P" : ""), comp_level, name,
+             (nm->has_clinit_barriers() ? ", has clinit barriers" : ""), msg);
+  }
+  // Clean up fields which could be set here
+  cache->_for_preload = false;
+  cache->_has_clinit_barriers = false;
+  return entry;
+}
+
+AOTCodeEntry* AOTCodeCache::write_nmethod(nmethod* nm, bool for_preload) {
+  AOTCodeCache* cache = open_for_dump();
+  assert(cache != nullptr, "sanity check");
+  assert(!nm->has_clinit_barriers() || (ClassInitBarrierMode > 0), "sanity");
+  _compile_id = nm->compile_id();
+  _comp_level = nm->comp_level();
+  Method* method = nm->method();
+  if (!AOTCacheAccess::can_generate_aot_code(method)) {
+    ResourceMark rm;
+    log_info(aot, codecache, nmethod)("%d (A%s%d) '%s' AOT is skipped: method is not in AOT cache",
+             compile_id(), (for_preload ? "P" : ""), comp_level(), method->name_and_sig_as_C_string());
+    assert(AOTCacheAccess::can_generate_aot_code(method), "sanity");
+    return nullptr;
+  }
+  InstanceKlass* holder = method->method_holder();
+  bool builtin_loader = holder->class_loader_data()->is_builtin_class_loader_data();
+  if (!builtin_loader) {
+    ResourceMark rm;
+    log_info(aot, codecache, nmethod)("%d (A%s%d) '%s' AOT is skipped: loaded by custom class loader %s",
+             compile_id(), (for_preload ? "P" : ""), comp_level(), method->name_and_sig_as_C_string(),
+             holder->class_loader_data()->loader_name());
+    assert(builtin_loader, "sanity");
+    return nullptr;
+  }
+
+  _for_preload = for_preload;
+  _has_clinit_barriers = nm->has_clinit_barriers();
+  assert(!_has_clinit_barriers || _for_preload, "only preload code has clinit barriers");
+
+  if (!align_write()) {
+    return nullptr;
+  }
+
+  uint entry_position = _write_position;
+
+  // Write name
+  uint name_offset = 0;
+  uint name_size   = 0;
+  uint id = 0;
+  uint n;
+  {
+    ResourceMark rm;
+    const char* name = method->name_and_sig_as_C_string();
+    log_info(aot, codecache, nmethod)("%d (A%s%d) '%s' AOT%s: writing to AOT Code Cache",
+             compile_id(), (for_preload ? "P" : ""), comp_level(), name,
+             (nm->has_clinit_barriers() ? ", has clinit barriers" : ""));
+
+    LogStreamHandle(Info, aot, codecache, loader) log;
+    if (log.is_enabled()) {
+      oop loader = holder->class_loader();
+      oop domain = holder->protection_domain();
+      stringStream ss;
+      ss.print("Holder: ");
+      holder->print_value_on(&ss);
+      ss.print(" loader: ");
+      if (loader == nullptr) {
+        ss.print("nullptr");
+      } else {
+        loader->print_value_on(&ss);
+       }
+      ss.print(" domain: ");
+      if (domain == nullptr) {
+        log.print("nullptr");
+      } else {
+        domain->print_value_on(&ss);
+       }
+      log.print_cr("%s", ss.freeze());
+    }
+    name_offset = _write_position  - entry_position;
+    name_size   = (uint)strlen(name) + 1; // Includes '/0'
+    n = write_bytes(name, name_size);
+    if (n != name_size) {
+      return nullptr;
+    }
+  }
+  id = (uint)cast_to_u4(AOTCacheAccess::to_narrow_ptr(nm->method()));
+
+  // Write nmethod's code blob
+  if (!cache->align_write()) {
+    return nullptr;
+  }
+  uint blob_offset = cache->_write_position - entry_position;
+  address archive_buffer = cache->reserve_bytes(nm->size());
+  if (archive_buffer == nullptr) {
+    return nullptr;
+  }
+  CodeBlob::archive_blob(nm, archive_buffer);
+
+  uint reloc_data_size = nm->relocation_size();
+  n = write_bytes((address)nm->relocation_begin(), reloc_data_size);
+  if (n != reloc_data_size) {
+    return nullptr;
+  }
+
+  // Write oops and metadata present in the nmethod's data region
+  if (!write_oops(nm)) {
+    if (lookup_failed() && !failed()) {
+      // Skip this method and reposition file
+      set_write_position(entry_position);
+    }
+    return nullptr;
+  }
+  if (!write_metadata(nm)) {
+    if (lookup_failed() && !failed()) {
+      // Skip this method and reposition file
+      set_write_position(entry_position);
+    }
+    return nullptr;
+  }
+
+  bool has_oop_maps = false;
+  if (nm->oop_maps() != nullptr) {
+    if (!cache->write_oop_map_set(*nm)) {
+      return nullptr;
+    }
+    has_oop_maps = true;
+  }
+
+  uint immutable_data_size = nm->immutable_data_size();
+  n = write_bytes(nm->immutable_data_begin(), immutable_data_size);
+  if (n != immutable_data_size) {
+    return nullptr;
+  }
+
+  JavaThread* thread = JavaThread::current();
+  HandleMark hm(thread);
+  GrowableArray<Handle> oop_list;
+  GrowableArray<Metadata*> metadata_list;
+
+  nm->create_reloc_immediates_list(thread, oop_list, metadata_list);
+  if (!write_nmethod_reloc_immediates(oop_list, metadata_list)) {
+    if (lookup_failed() && !failed()) {
+      // Skip this method and reposition file
+      set_write_position(entry_position);
+    }
+    return nullptr;
+  }
+
+  RelocIterator iter(nm);
+  if (!write_relocations(*nm, iter, &oop_list, &metadata_list)) {
+    return nullptr;
+  }
+
+#ifndef PRODUCT
+  if (!cache->write_asm_remarks(nm->asm_remarks(), /* use_string_table */ false)) {
+    return nullptr;
+  }
+  if (!cache->write_dbg_strings(nm->dbg_strings(), /* use_string_table */ false)) {
+    return nullptr;
+  }
+#endif /* PRODUCT */
+
+  uint entry_size = _write_position - entry_position;
+  AOTCodeEntry* entry = new (this) AOTCodeEntry(AOTCodeEntry::Nmethod, id,
+                                                entry_position, entry_size,
+                                                name_offset, name_size,
+                                                blob_offset, has_oop_maps,
+                                                comp_level(), compile_id(),
+                                                nm->has_clinit_barriers(), for_preload);
+  return entry;
+}
+
+bool AOTCodeCache::load_nmethod(ciEnv* env, ciMethod* target, int entry_bci, AbstractCompiler* compiler, CompLevel comp_level) {
+  precond(is_using_code());
+  assert(entry_bci == InvocationEntryBci, "unexpected entry_bci=%d", entry_bci);
+  CompileTask* task = env->task();
+  AOTCodeEntry* entry = task->aot_code_entry();
+  precond(entry != nullptr);
+  if (entry->not_entrant()) {
+    // AOT entry could be invalidated while task was in queue
+    task->set_failure_reason("AOT code entry was marked not-entrant while waiting in compilation queue");
+    return false;
+  }
+  TraceTime t1("Total time to load AOT code", &_t_totalLoad, enable_timers(), false);
+  task->mark_aot_load_start(os::elapsed_counter());
+  bool preload = task->preload();
+  assert(entry != nullptr, "sanity");
+  if (log_is_enabled(Info, aot, codecache, nmethod)) {
+    VM_ENTRY_MARK;
+    ResourceMark rm;
+    methodHandle method(THREAD, target->get_Method());
+    const char* target_name = method->name_and_sig_as_C_string();
+    uint id = (uint)cast_to_u4(AOTCacheAccess::method_to_narrow_ptr(method()));
+    bool clinit_brs = entry->has_clinit_barriers();
+    log_info(aot, codecache, nmethod)("%d (A%s%d) '%s' AOT nmethod id: " UINT32_FORMAT_X_0 "%s: %sloading from AOT Code Cache",
+             task->compile_id(), (preload ? "P" : ""), task->comp_level(), target_name, id,
+             (clinit_brs ? ", has clinit barriers" : ""), (preload ? "pre" : ""));
+  }
+
+  AOTCodeCache* cache = open_for_use();
+  AOTCodeReader reader(cache, entry, task);
+  bool success = reader.compile_nmethod(env, target, compiler);
+  if (success) {
+    assert(task->is_success(), "sanity");
+    task->set_num_inlined_bytecodes(entry->num_inlined_bytecodes());
+  } else if (!env->failing() || !env->codecache_full()) {
+    // Invalidate AOT entry if there were issues in restoring AOT code or in dependencies
+    entry->set_load_fail();
+    entry->set_not_entrant();
+  }
+  task->mark_aot_load_finish(os::elapsed_counter());
+  return success;
+}
+
+bool AOTCodeReader::compile_nmethod(ciEnv* env, ciMethod* target, AbstractCompiler* compiler) {
+  CompileTask* task = env->task();
+  AOTCodeEntry* aot_code_entry = _entry;
+  nmethod* nm = nullptr;
+
+  uint entry_position = aot_code_entry->offset();
+  uint archived_nm_offset = entry_position + aot_code_entry->code_offset();
+  nmethod* archived_nm = (nmethod*)addr(archived_nm_offset);
+  set_read_position(archived_nm_offset + archived_nm->size());
+
+  OopRecorder* oop_recorder = new OopRecorder(env->arena());
+  env->set_oop_recorder(oop_recorder);
+
+  // Set fields for AOTCodeReader::restore()
+  _name = "nmethod";
+
+  uint offset = read_position();
+  _reloc_data = (address)addr(offset);
+  offset += archived_nm->relocation_size();
+  set_read_position(offset);
+
+  // Read oops and metadata
+  VM_ENTRY_MARK
+  GrowableArray<Handle> oop_list;
+  GrowableArray<Metadata*> metadata_list;
+
+  if (!read_oop_metadata_list(THREAD, oop_list, metadata_list, oop_recorder)) {
+   task->set_failure_reason(lookup_failure());
+   return false;
+  }
+  _oop_list      = &oop_list;
+  _metadata_list = &metadata_list;
+
+  _oop_maps = read_oop_map_set();
+
+  offset = read_position();
+  _immutable_data = (address)addr(offset);
+  offset += archived_nm->immutable_data_size();
+  set_read_position(offset);
+
+  GrowableArray<Handle> reloc_immediate_oop_list;
+  GrowableArray<Metadata*> reloc_immediate_metadata_list;
+  if (!read_oop_metadata_list(THREAD, reloc_immediate_oop_list, reloc_immediate_metadata_list, nullptr)) {
+   task->set_failure_reason(lookup_failure());
+   return false;
+  }
+  _reloc_imm_oop_list      = &reloc_immediate_oop_list;
+  _reloc_imm_metadata_list = &reloc_immediate_metadata_list;
+
+  // Read Dependencies (compressed already)
+  Dependencies* dependencies = new Dependencies(env);
+  dependencies->set_content(_immutable_data, archived_nm->dependencies_size());
+  env->set_dependencies(dependencies);
+
+  const char* name = addr(entry_position + aot_code_entry->name_offset());
+
+  TraceTime t1("Total time to register AOT nmethod", &_t_totalRegister, enable_timers(), false);
+  bool install_code = !VerifyAOTCode;
+  nm = env->register_aot_method(THREAD, target, compiler, archived_nm, this, install_code);
+
+  bool preload = task->preload();
+  if (VerifyAOTCode && !env->failing()) {
+    // Emulate success
+    task->mark_success();
+    task->set_nm_content_size(archived_nm->content_size());
+    task->set_nm_insts_size(archived_nm->insts_size());
+    task->set_nm_total_size(archived_nm->total_size());
+    log_info(aot, codecache, nmethod)("%d (A%s%d) '%s': Verified nmethod from AOT Code Cache",
+                                      compile_id(), (preload ? "P" : ""), comp_level(), name);
+    return true;
+  }
+  bool success = task->is_success();
+  if (success) {
+    log_info(aot, codecache, nmethod)("%d (A%s%d) '%s': Loaded nmethod from AOT Code Cache",
+                                      compile_id(), (preload ? "P" : ""), comp_level(), name);
+#ifdef ASSERT
+    LogStreamHandle(Debug, aot, codecache, nmethod) log;
+    if (log.is_enabled()) {
+      FlagSetting fs(PrintRelocations, true);
+      nm->print_on(&log);
+      nm->decode2(&log);
+    }
+#endif
+  }
+
+  return success;
+}
+
+bool skip_preload(methodHandle mh) {
+  if (!mh->method_holder()->is_loaded()) {
+    return true;
+  }
+  CompilerDirectiveMatcher matcher(mh, CompLevel_full_optimization);
+  DirectiveSet* directives = matcher.directive_set();
+  if (directives->DontPreloadOption || directives->ExcludeOption) {
+    LogStreamHandle(Info, aot, codecache, init) log;
+    if (log.is_enabled()) {
+      ResourceMark rm;
+      stringStream ss;
+      ss.print("Exclude preloading code for ");
+      mh->print_value_on(&ss);
+      log.print_cr("%s", ss.freeze());
+    }
+    return true;
+  }
+  return false;
+}
+
+void AOTCodeCache::preload_code(JavaThread* thread) {
+  if (!is_using_code()) {
+    return;
+  }
+  if (!CompilerConfig::is_c2_enabled()) {
+    log_debug(aot, codecache, init)("AOT preload code skipped: C2 compiler disabled");
+    return;
+  }
+
+  if ((DisableAOTCode / 10000) % 10 == 1) {
+    return; // no preloaded code (level 5);
+  }
+  _cache->preload_aot_code(thread);
+}
+
+void AOTCodeCache::preload_aot_code(TRAPS) {
+  if (CompilationPolicy::compiler_count(CompLevel_full_optimization) == 0) {
+    // Since we reuse the CompilerBroker API to install AOT code, we're required to have a JIT compiler for the
+    // level we want (that is CompLevel_full_optimization).
+    return;
+  }
+  TraceTime t1("Total time to preload AOT code", &_t_totalPreload, enable_timers(), false);
+  assert(_for_use, "sanity");
+  uint count = _load_header->entries_count();
+  uint preload_entries_count = _load_header->preload_entries_count();
+  if (preload_entries_count > 0) {
+    load_info_log().print_cr("Read %d preload entries from AOT Code Cache", preload_entries_count);
+    AOTCodeEntry* preload_entry = (AOTCodeEntry*)addr(_load_header->preload_entries_offset());
+    uint count = MIN2(preload_entries_count, AOTCodePreloadStop);
+    for (uint i = AOTCodePreloadStart; i < count; i++) {
+      AOTCodeEntry* entry = &preload_entry[i];
+      if (entry->not_entrant()) {
+        continue;
+      }
+      methodHandle mh(THREAD, entry->method());
+      assert((mh.not_null() && AOTMetaspace::in_aot_cache((address)mh())), "sanity");
+      if (skip_preload(mh)) {
+        continue; // Exclude preloading for this method
+      }
+      assert(mh->method_holder()->is_loaded(), "");
+      if (!mh->method_holder()->is_linked()) {
+        ResourceMark rm;
+        log_debug(aot, codecache, init)("Preload AOT code for %s skipped: method holder is not linked",
+                                        mh->name_and_sig_as_C_string());
+        continue; // skip
+      }
+      CompileBroker::preload_aot_method(mh, entry, CHECK);
+    }
+  }
+}
+
 // ------------ process code and data --------------
 
 // Can't use -1. It is valid value for jump to iteself destination
 // used by static call stub: see NativeJump::jump_destination().
 #define BAD_ADDRESS_ID -2
 
-bool AOTCodeCache::write_relocations(CodeBlob& code_blob, RelocIterator& iter) {
+bool AOTCodeCache::write_relocations(CodeBlob& code_blob, RelocIterator& iter,
+                                     GrowableArray<Handle>* oop_list,
+                                     GrowableArray<Metadata*>* metadata_list) {
   if (!align_write_int()) {
     return false;
   }
@@ -1597,6 +2431,55 @@ bool AOTCodeCache::write_relocations(CodeBlob& code_blob, RelocIterator& iter) {
     int idx = reloc_data.append(0); // default value
     switch (iter.type()) {
       case relocInfo::none:
+      break;
+      case relocInfo::oop_type: {
+        oop_Relocation* r = (oop_Relocation*)iter.reloc();
+        if (r->oop_is_immediate()) {
+          assert(oop_list != nullptr, "sanity check");
+          // store index of oop in the reloc immediate oop list
+          Handle h(JavaThread::current(), r->oop_value());
+          int oop_idx = oop_list->find(h);
+          assert(oop_idx != -1, "sanity check");
+          reloc_data.at_put(idx, (uint)oop_idx);
+        }
+        break;
+      }
+      case relocInfo::metadata_type: {
+        metadata_Relocation* r = (metadata_Relocation*)iter.reloc();
+        if (r->metadata_is_immediate()) {
+          assert(metadata_list != nullptr, "sanity check");
+          // store index of metadata in the reloc immediate metadata list
+          int metadata_idx = metadata_list->find(r->metadata_value());
+          assert(metadata_idx != -1, "sanity check");
+          reloc_data.at_put(idx, (uint)metadata_idx);
+        }
+        break;
+      }
+      case relocInfo::virtual_call_type:  // Fall through. They all call resolve_*_call blobs.
+      case relocInfo::opt_virtual_call_type:
+      case relocInfo::static_call_type: {
+        CallRelocation* r = (CallRelocation*)iter.reloc();
+        address dest = r->destination();
+        if (dest == r->addr()) { // possible call via trampoline on Aarch64
+          dest = (address)-1;    // do nothing in this case when loading this relocation
+        }
+        int id = _table->id_for_address(dest, iter, &code_blob);
+        if (id == BAD_ADDRESS_ID) {
+          return false;
+        }
+        reloc_data.at_put(idx, id);
+        break;
+      }
+      case relocInfo::trampoline_stub_type: {
+        address dest = ((trampoline_stub_Relocation*)iter.reloc())->destination();
+        int id = _table->id_for_address(dest, iter, &code_blob);
+        if (id == BAD_ADDRESS_ID) {
+          return false;
+        }
+        reloc_data.at_put(idx, id);
+        break;
+      }
+      case relocInfo::static_stub_type:
         break;
       case relocInfo::runtime_call_type: {
         // Record offset of runtime destination
@@ -1625,11 +2508,28 @@ bool AOTCodeCache::write_relocations(CodeBlob& code_blob, RelocIterator& iter) {
         reloc_data.at_put(idx, id);
         break;
       }
-      case relocInfo::internal_word_type:
+      case relocInfo::internal_word_type: {
+        address target = ((internal_word_Relocation*)iter.reloc())->target();
+        // assert to make sure that delta fits into 32 bits
+        assert(CodeCache::contains((void *)target), "Wrong internal_word_type relocation");
+        uint delta = (uint)(target - code_blob.content_begin());
+        reloc_data.at_put(idx, delta);
         break;
-      case relocInfo::section_word_type:
+      }
+      case relocInfo::section_word_type: {
+        address target = ((section_word_Relocation*)iter.reloc())->target();
+        assert(CodeCache::contains((void *)target), "Wrong section_word_type relocation");
+        uint delta = (uint)(target - code_blob.content_begin());
+        reloc_data.at_put(idx, delta);
+        break;
+      }
+      case relocInfo::poll_type:
+        break;
+      case relocInfo::poll_return_type:
         break;
       case relocInfo::post_call_nop_type:
+        break;
+      case relocInfo::entry_guard_type:
         break;
       default:
         log_debug(aot, codecache, reloc)("relocation %d unimplemented", (int)iter.type());
@@ -1672,7 +2572,9 @@ bool AOTCodeCache::write_relocations(CodeBlob& code_blob, RelocIterator& iter) {
   return true;
 }
 
-void AOTCodeReader::fix_relocations(CodeBlob *code_blob, RelocIterator& iter) {
+void AOTCodeReader::fix_relocations(CodeBlob *code_blob, RelocIterator& iter,
+                                    GrowableArray<Handle>* oop_list,
+                                    GrowableArray<Metadata*>* metadata_list) {
   uint offset = align_read_int();
   int reloc_count = *(int*)addr(offset);
   offset += sizeof(int);
@@ -1699,6 +2601,51 @@ void AOTCodeReader::fix_relocations(CodeBlob *code_blob, RelocIterator& iter) {
     switch (iter.type()) {
       case relocInfo::none:
         break;
+      case relocInfo::oop_type: {
+        assert(code_blob->is_nmethod(), "sanity check");
+        oop_Relocation* r = (oop_Relocation*)iter.reloc();
+        if (r->oop_is_immediate()) {
+          assert(oop_list != nullptr, "sanity check");
+          Handle h = oop_list->at(reloc_data[j]);
+          r->set_value(cast_from_oop<address>(h()));
+        } else {
+          r->fix_oop_relocation();
+        }
+        break;
+      }
+      case relocInfo::metadata_type: {
+        assert(code_blob->is_nmethod(), "sanity check");
+        metadata_Relocation* r = (metadata_Relocation*)iter.reloc();
+        Metadata* m;
+        if (r->metadata_is_immediate()) {
+          assert(metadata_list != nullptr, "sanity check");
+          m = metadata_list->at(reloc_data[j]);
+        } else {
+          // Get already updated value from nmethod.
+          int index = r->metadata_index();
+          m = code_blob->as_nmethod()->metadata_at(index);
+        }
+        r->set_value((address)m);
+        break;
+      }
+      case relocInfo::virtual_call_type:   // Fall through. They all call resolve_*_call blobs.
+      case relocInfo::opt_virtual_call_type:
+      case relocInfo::static_call_type: {
+        address dest = _cache->address_for_id(reloc_data[j]);
+        if (dest != (address)-1) {
+          ((CallRelocation*)iter.reloc())->set_destination(dest);
+        }
+        break;
+      }
+      case relocInfo::trampoline_stub_type: {
+        address dest = _cache->address_for_id(reloc_data[j]);
+        if (dest != (address)-1) {
+          ((trampoline_stub_Relocation*)iter.reloc())->set_destination(dest);
+        }
+        break;
+      }
+      case relocInfo::static_stub_type:
+        break;
       case relocInfo::runtime_call_type: {
         address dest = _cache->address_for_id(reloc_data[j]);
         if (dest != (address)-1) {
@@ -1722,16 +2669,24 @@ void AOTCodeReader::fix_relocations(CodeBlob *code_blob, RelocIterator& iter) {
         break;
       }
       case relocInfo::internal_word_type: {
+        uint delta = reloc_data[j];
         internal_word_Relocation* r = (internal_word_Relocation*)iter.reloc();
-        r->fix_relocation_after_aot_load(aot_code_entry()->dumptime_content_start_addr(), code_blob->content_begin());
+        r->fix_relocation_after_aot_load(code_blob->content_begin(), delta);
         break;
       }
       case relocInfo::section_word_type: {
+        uint delta = reloc_data[j];
         section_word_Relocation* r = (section_word_Relocation*)iter.reloc();
-        r->fix_relocation_after_aot_load(aot_code_entry()->dumptime_content_start_addr(), code_blob->content_begin());
+        r->fix_relocation_after_aot_load(code_blob->content_begin(), delta);
         break;
       }
+      case relocInfo::poll_type:
+        break;
+      case relocInfo::poll_return_type:
+        break;
       case relocInfo::post_call_nop_type:
+        break;
+      case relocInfo::entry_guard_type:
         break;
       default:
         assert(false,"relocation %d unimplemented", (int)iter.type());
@@ -1743,6 +2698,542 @@ void AOTCodeReader::fix_relocations(CodeBlob *code_blob, RelocIterator& iter) {
     j++;
   }
   assert(j == reloc_count, "sanity");
+}
+
+bool AOTCodeCache::write_nmethod_reloc_immediates(GrowableArray<Handle>& oop_list, GrowableArray<Metadata*>& metadata_list) {
+  int count = oop_list.length();
+  if (!write_bytes(&count, sizeof(int))) {
+    return false;
+  }
+  for (GrowableArrayIterator<Handle> iter = oop_list.begin();
+       iter != oop_list.end(); ++iter) {
+    Handle h = *iter;
+    if (!write_oop(h())) {
+      return false;
+    }
+  }
+
+  count = metadata_list.length();
+  if (!write_bytes(&count, sizeof(int))) {
+    return false;
+  }
+  for (GrowableArrayIterator<Metadata*> iter = metadata_list.begin();
+       iter != metadata_list.end(); ++iter) {
+    Metadata* m = *iter;
+    if (!write_metadata(m)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool AOTCodeCache::write_metadata(nmethod* nm) {
+  int count = nm->metadata_count()-1;
+  if (!write_bytes(&count, sizeof(int))) {
+    return false;
+  }
+  for (Metadata** p = nm->metadata_begin(); p < nm->metadata_end(); p++) {
+    if (!write_metadata(*p)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool AOTCodeCache::write_metadata(Metadata* m) {
+  uint n = 0;
+  if (m == nullptr) {
+    DataKind kind = DataKind::Null;
+    n = write_bytes(&kind, sizeof(int));
+    if (n != sizeof(int)) {
+      return false;
+    }
+  } else if (m == (Metadata*)Universe::non_oop_word()) {
+    DataKind kind = DataKind::No_Data;
+    n = write_bytes(&kind, sizeof(int));
+    if (n != sizeof(int)) {
+      return false;
+    }
+  } else if (m->is_klass()) {
+    if (!write_klass((Klass*)m)) {
+      return false;
+    }
+  } else if (m->is_method()) {
+    if (!write_method((Method*)m)) {
+      return false;
+    }
+  } else if (m->is_methodCounters()) {
+    DataKind kind = DataKind::MethodCnts;
+    n = write_bytes(&kind, sizeof(int));
+    if (n != sizeof(int)) {
+      return false;
+    }
+    if (!write_method(((MethodCounters*)m)->method())) {
+      return false;
+    }
+    log_debug(aot, codecache, metadata)("%d (A%d): Wrote MethodCounters : " INTPTR_FORMAT, compile_id(), comp_level(), p2i(m));
+  } else { // Not supported
+    fatal("metadata : " INTPTR_FORMAT " unimplemented", p2i(m));
+    return false;
+  }
+  return true;
+}
+
+Metadata* AOTCodeReader::read_metadata() {
+  uint code_offset = read_position();
+  Metadata* m = nullptr;
+  DataKind kind = *(DataKind*)addr(code_offset);
+  code_offset += sizeof(DataKind);
+  set_read_position(code_offset);
+  if (kind == DataKind::Null) {
+    m = (Metadata*)nullptr;
+  } else if (kind == DataKind::No_Data) {
+    m = (Metadata*)Universe::non_oop_word();
+  } else if (kind == DataKind::Klass) {
+    m = (Metadata*)read_klass();
+  } else if (kind == DataKind::Method) {
+    m = (Metadata*)read_method();
+  } else if (kind == DataKind::MethodCnts) {
+    kind = *(DataKind*)addr(code_offset);
+    code_offset += sizeof(DataKind);
+    set_read_position(code_offset);
+    m = (Metadata*)read_method();
+    if (m != nullptr) {
+      Method* method = (Method*)m;
+      m = method->get_method_counters(Thread::current());
+      if (m == nullptr) {
+        set_lookup_failed("Failed to read MethodCounters");
+        log_debug(aot, codecache, metadata)("%d (A%d): Failed to read MethodCounters", compile_id(), comp_level());
+      } else {
+        log_debug(aot, codecache, metadata)("%d (A%d): Read MethodCounters : " INTPTR_FORMAT, compile_id(), comp_level(), p2i(m));
+      }
+    }
+  } else {
+    set_lookup_failed("Unknown metadata kind");
+    log_debug(aot, codecache, metadata)("%d (A%d): Unknown metadata's kind: %d", compile_id(), comp_level(), (int)kind);
+  }
+  return m;
+}
+
+bool AOTCodeCache::write_method(Method* method) {
+  ResourceMark rm; // To method's name printing
+  if (AOTCacheAccess::can_generate_aot_code(method)) {
+    DataKind kind = DataKind::Method;
+    uint n = write_bytes(&kind, sizeof(int));
+    if (n != sizeof(int)) {
+      return false;
+    }
+    narrowPtr method_narrow_ptr = AOTCacheAccess::to_narrow_ptr(method);
+    n = write_bytes(&method_narrow_ptr, sizeof(narrowPtr));
+    if (n != sizeof(narrowPtr)) {
+      return false;
+    }
+    log_debug(aot, codecache, metadata)("%d (A%d): Registered method: %s @ 0x%08x",
+              compile_id(), comp_level(), method->name_and_sig_as_C_string(), cast_to_u4(method_narrow_ptr));
+    return true;
+  }
+  log_debug(aot, codecache, metadata)("%d (A%d): Method can not be registered: %s",
+            compile_id(), comp_level(), method->name_and_sig_as_C_string());
+  set_lookup_failed();
+  return false;
+}
+
+Method* AOTCodeReader::read_method() {
+  uint code_offset = read_position();
+  narrowPtr method_narrow_ptr = *(narrowPtr*)addr(code_offset);
+  code_offset += sizeof(uint);
+  set_read_position(code_offset);
+  Method* m = AOTCacheAccess::narrow_ptr_to_method(method_narrow_ptr);
+  if (!AOTMetaspace::in_aot_cache((address)m)) {
+    // Something changed in CDS
+    set_lookup_failed("Method is not in AOT cache");
+    log_debug(aot, codecache, metadata)("%d (A%d): Lookup failed for method: " INTPTR_FORMAT " is not in AOT cache",
+              compile_id(), comp_level(), p2i((address)m));
+    return nullptr;
+  }
+  assert(m->is_method(), "sanity");
+  ResourceMark rm;
+  Klass* k = m->method_holder();
+  if (!k->is_instance_klass()) {
+    set_lookup_failed("Method holder is not instance klass");
+    log_debug(aot, codecache, metadata)("%d (A%d): Lookup failed for '%s': holder %s is not instance klass",
+              compile_id(), comp_level(), m->name_and_sig_as_C_string(), k->external_name());
+    return nullptr;
+  } else if (!AOTMetaspace::in_aot_cache((address)k)) {
+    set_lookup_failed("Method holder is not in AOT cache");
+    log_debug(aot, codecache, metadata)("%d (A%d): Lookup failed for '%s': holder %s is not in AOT cache",
+              compile_id(), comp_level(), m->name_and_sig_as_C_string(), k->external_name());
+    return nullptr;
+  } else if (!InstanceKlass::cast(k)->is_loaded() || !InstanceKlass::cast(k)->is_linked()) {
+    set_lookup_failed("Method holder is not loaded or not linked");
+    log_debug(aot, codecache, metadata)("%d (A%d): Lookup failed for '%s': holder %s is not %s",
+              compile_id(), comp_level(), m->name_and_sig_as_C_string(), k->external_name(),
+              (!InstanceKlass::cast(k)->is_loaded() ? "loaded" : "linked"));
+    return nullptr;
+  }
+  log_debug(aot, codecache, metadata)("%d (A%d): Found method '%s' in AOT cache",
+            compile_id(), comp_level(), m->name_and_sig_as_C_string());
+  return m;
+}
+
+bool AOTCodeCache::write_klass(Klass* klass) {
+  uint array_dim = 0;
+  bool can_write = true;
+  if (klass->is_objArray_klass()) {
+    // We must check klass and its bottom_klass.
+    can_write = AOTCacheAccess::can_generate_aot_code(klass);
+    array_dim = ObjArrayKlass::cast(klass)->dimension();
+    klass     = ObjArrayKlass::cast(klass)->bottom_klass(); // overwrites klass
+  }
+  uint init_state = 0;
+  if (klass->is_instance_klass()) {
+    InstanceKlass* ik = InstanceKlass::cast(klass);
+    init_state = (ik->is_initialized() ? 1 : 0);
+    can_write &= AOTCacheAccess::can_generate_aot_code_for(ik);
+  } else {
+    assert(klass->is_typeArray_klass(), "must be");
+    can_write &= AOTCacheAccess::can_generate_aot_code(klass);
+  }
+  ResourceMark rm;
+  uint state = (array_dim << 1) | (init_state & 1);
+  if (can_write) {
+    DataKind kind = DataKind::Klass;
+    uint n = write_bytes(&kind, sizeof(int));
+    if (n != sizeof(int)) {
+      return false;
+    }
+    // Record state of instance klass initialization and array dimentions.
+    n = write_bytes(&state, sizeof(int));
+    if (n != sizeof(int)) {
+      return false;
+    }
+    narrowPtr klass_narrow_ptr = AOTCacheAccess::to_narrow_ptr(klass);
+    n = write_bytes(&klass_narrow_ptr, sizeof(narrowPtr));
+    if (n != sizeof(narrowPtr)) {
+      return false;
+    }
+    log_debug(aot, codecache, metadata)("%d (A%d): Registered klass: %s%s%s @ 0x%08x",
+              compile_id(), comp_level(), klass->external_name(),
+              (!klass->is_instance_klass() ? "" : (init_state == 1 ? " (initialized)" : " (not-initialized)")),
+              (array_dim > 0 ? " (object array)" : ""), cast_to_u4(klass_narrow_ptr));
+    return true;
+  }
+  log_debug(aot, codecache, metadata)("%d (A%d): Klass is not registered: %s%s%s",
+            compile_id(), comp_level(), klass->external_name(),
+            (!klass->is_instance_klass() ? "" : (init_state == 1 ? " (initialized)" : " (not-initialized)")),
+            (array_dim > 0 ? " (object array)" : ""));
+  set_lookup_failed();
+  return false;
+}
+
+Klass* AOTCodeReader::read_klass() {
+  uint code_offset = read_position();
+  uint state = *(uint*)addr(code_offset);
+  uint init_state = (state  & 1);
+  uint array_dim  = (state >> 1);
+  code_offset += sizeof(int);
+  narrowPtr klass_narrow_ptr = *(narrowPtr*)addr(code_offset);
+  code_offset += sizeof(uint);
+  set_read_position(code_offset);
+  Klass* k = AOTCacheAccess::narrow_ptr_to_klass(klass_narrow_ptr);
+  if (!AOTMetaspace::in_aot_cache((address)k)) {
+    // Something changed in CDS
+    set_lookup_failed("Klass is not in AOT cache");
+    log_debug(aot, codecache, metadata)("%d (A%d): Lookup failed klass: " INTPTR_FORMAT " is not in AOT cache",
+              compile_id(), comp_level(), p2i((address)k));
+    return nullptr;
+  }
+  assert(k->is_klass(), "sanity");
+  ResourceMark rm;
+  if (k->is_instance_klass() && !InstanceKlass::cast(k)->is_loaded()) {
+    set_lookup_failed("Klass is not loaded");
+    log_debug(aot, codecache, metadata)("%d (A%d): Lookup failed for klass %s: not loaded",
+              compile_id(), comp_level(), k->external_name());
+    return nullptr;
+  } else
+  // Allow not initialized klass which was uninitialized during code caching or for preload
+  if (k->is_instance_klass() && !InstanceKlass::cast(k)->is_initialized() && (init_state == 1) && !_preload) {
+    set_lookup_failed("Klass is not initialized");
+    log_debug(aot, codecache, metadata)("%d (A%d): Lookup failed for klass %s: not initialized",
+              compile_id(), comp_level(), k->external_name());
+    return nullptr;
+  }
+  if (array_dim > 0) {
+    assert(k->is_instance_klass() || k->is_typeArray_klass(), "sanity check");
+    Klass* ak = k->array_klass_or_null(array_dim);
+    if (ak == nullptr) {
+      set_lookup_failed("Lookup failed for array klass");
+      log_debug(aot, codecache, metadata)("%d (A%d): Lookup failed for %d-dimensions array klass %s",
+                compile_id(), comp_level(), array_dim, k->external_name());
+      return nullptr;
+    }
+    log_debug(aot, codecache, metadata)("%d (A%d): Found %d-dimensions array klass %s",
+              compile_id(), comp_level(), array_dim, k->external_name());
+    return ak;
+  } else {
+    log_debug(aot, codecache, metadata)("%d (A%d): Found klass %s",
+              compile_id(), comp_level(), k->external_name());
+    return k;
+  }
+}
+
+bool AOTCodeCache::write_oop(jobject& jo) {
+  oop obj = JNIHandles::resolve(jo);
+  return write_oop(obj);
+}
+
+bool AOTCodeCache::write_oop(oop obj) {
+  DataKind kind;
+  uint n = 0;
+  if (obj == nullptr) {
+    kind = DataKind::Null;
+    n = write_bytes(&kind, sizeof(int));
+    if (n != sizeof(int)) {
+      return false;
+    }
+  } else if (cast_from_oop<void *>(obj) == Universe::non_oop_word()) {
+    kind = DataKind::No_Data;
+    n = write_bytes(&kind, sizeof(int));
+    if (n != sizeof(int)) {
+      return false;
+    }
+  } else if (java_lang_Class::is_instance(obj)) {
+    if (java_lang_Class::is_primitive(obj)) {
+      int bt = (int)java_lang_Class::primitive_type(obj);
+      kind = DataKind::Primitive;
+      n = write_bytes(&kind, sizeof(int));
+      if (n != sizeof(int)) {
+        return false;
+      }
+      n = write_bytes(&bt, sizeof(int));
+      if (n != sizeof(int)) {
+        return false;
+      }
+      log_debug(aot, codecache, oops)("%d (A%d): Wrote primitive type klass: %s",
+                compile_id(), comp_level(), type2name((BasicType)bt));
+      return true;
+    } else {
+      Klass* klass = java_lang_Class::as_Klass(obj);
+      if (!write_klass(klass)) {
+        return false;
+      }
+    }
+  } else if (java_lang_String::is_instance(obj)) {
+    int k = AOTCacheAccess::get_archived_object_permanent_index(obj);  // k >= 0 means obj is a "permanent heap object"
+    ResourceMark rm;
+    size_t length_sz = 0;
+    const char* string = java_lang_String::as_utf8_string(obj, length_sz);
+    if (k >= 0) {
+      kind = DataKind::String;
+      n = write_bytes(&kind, sizeof(int));
+      if (n != sizeof(int)) {
+        return false;
+      }
+      n = write_bytes(&k, sizeof(int));
+      if (n != sizeof(int)) {
+        return false;
+      }
+      log_debug(aot, codecache, oops)("%d (A%d): Wrote String object: " PTR_FORMAT " : %s",
+                compile_id(), comp_level(), p2i(obj), string);
+      return true;
+    }
+    // Not archived String object - bailout
+    set_lookup_failed();
+    log_debug(aot, codecache, oops)("%d (A%d): Failed to write String object: " PTR_FORMAT " : %s",
+              compile_id(), comp_level(), p2i(obj), string);
+    return false;
+  } else if (java_lang_Module::is_instance(obj)) {
+    fatal("Module object unimplemented");
+  } else if (java_lang_ClassLoader::is_instance(obj)) {
+    if (obj == SystemDictionary::java_system_loader()) {
+      kind = DataKind::SysLoader;
+    } else if (obj == SystemDictionary::java_platform_loader()) {
+      kind = DataKind::PlaLoader;
+    } else {
+      ResourceMark rm;
+      set_lookup_failed();
+      log_debug(aot, codecache, oops)("%d (A%d): Not supported Class Loader: " PTR_FORMAT " : %s",
+                compile_id(), comp_level(), p2i(obj), obj->klass()->external_name());
+      return false;
+    }
+    n = write_bytes(&kind, sizeof(int));
+    if (n != sizeof(int)) {
+      return false;
+    }
+    log_debug(aot, codecache, oops)("%d (A%d): Wrote ClassLoader: java_%s_loader",
+              compile_id(), comp_level(), (kind == DataKind::SysLoader ? "system" : "platform"));
+    return true;
+  } else {
+    ResourceMark rm;
+    int k = AOTCacheAccess::get_archived_object_permanent_index(obj);  // k >= 0 means obj is a "permanent heap object"
+    if (k >= 0) {
+      kind = DataKind::MH_Oop;
+      n = write_bytes(&kind, sizeof(int));
+      if (n != sizeof(int)) {
+        return false;
+      }
+      n = write_bytes(&k, sizeof(int));
+      if (n != sizeof(int)) {
+        return false;
+      }
+      log_debug(aot, codecache, oops)("%d (A%d): Wrote MH object: " PTR_FORMAT " : %s",
+                compile_id(), comp_level(), p2i(obj), obj->klass()->external_name());
+      return true;
+    }
+    // Not archived Java object - bailout
+    set_lookup_failed();
+    log_debug(aot, codecache, oops)("%d (A%d): Failed to write Java object: " PTR_FORMAT " : %s",
+              compile_id(), comp_level(), p2i(obj), obj->klass()->external_name());
+    return false;
+  }
+  return true;
+}
+
+oop AOTCodeReader::read_oop(JavaThread* thread) {
+  uint code_offset = read_position();
+  oop obj = nullptr;
+  DataKind kind = *(DataKind*)addr(code_offset);
+  code_offset += sizeof(DataKind);
+  set_read_position(code_offset);
+  if (kind == DataKind::Null) {
+    return nullptr;
+  } else if (kind == DataKind::No_Data) {
+    return cast_to_oop(Universe::non_oop_word());
+  } else if (kind == DataKind::Klass) {
+    Klass* k = read_klass();
+    if (k == nullptr) {
+      return nullptr;
+    }
+    obj = k->java_mirror();
+    if (obj == nullptr) {
+      set_lookup_failed("Lookup failed for java_mirror");
+      log_debug(aot, codecache, oops)("%d (A%d): Lookup failed for java_mirror of klass %s",
+                compile_id(), comp_level(), k->external_name());
+      return nullptr;
+    }
+  } else if (kind == DataKind::Primitive) {
+    code_offset = read_position();
+    int t = *(int*)addr(code_offset);
+    code_offset += sizeof(int);
+    set_read_position(code_offset);
+    BasicType bt = (BasicType)t;
+    obj = java_lang_Class::primitive_mirror(bt);
+    log_debug(aot, codecache, oops)("%d (A%d): Read primitive type klass: %s", compile_id(), comp_level(), type2name(bt));
+  } else if (kind == DataKind::String) {
+    code_offset = read_position();
+    int k = *(int*)addr(code_offset);
+    code_offset += sizeof(int);
+    set_read_position(code_offset);
+    obj = AOTCacheAccess::get_archived_object(k);
+    if (obj == nullptr) {
+      set_lookup_failed("Lookup failed for String object");
+      log_debug(aot, codecache, oops)("%d (A%d): Lookup failed for String object", compile_id(), comp_level());
+      return nullptr;
+    }
+    assert(java_lang_String::is_instance(obj), "must be string");
+
+    ResourceMark rm;
+    size_t length_sz = 0;
+    const char* string = java_lang_String::as_utf8_string(obj, length_sz);
+    log_debug(aot, codecache, oops)("%d (A%d): Read String object: %s", compile_id(), comp_level(), string);
+  } else if (kind == DataKind::SysLoader) {
+    obj = SystemDictionary::java_system_loader();
+    log_debug(aot, codecache, oops)("%d (A%d): Read java_system_loader", compile_id(), comp_level());
+  } else if (kind == DataKind::PlaLoader) {
+    obj = SystemDictionary::java_platform_loader();
+    log_debug(aot, codecache, oops)("%d (A%d): Read java_platform_loader", compile_id(), comp_level());
+  } else if (kind == DataKind::MH_Oop) {
+    code_offset = read_position();
+    int k = *(int*)addr(code_offset);
+    code_offset += sizeof(int);
+    set_read_position(code_offset);
+    obj = AOTCacheAccess::get_archived_object(k);
+    if (obj == nullptr) {
+      set_lookup_failed("Lookup failed for MH object");
+      log_debug(aot, codecache, oops)("%d (A%d): Lookup failed for MH object", compile_id(), comp_level());
+      return nullptr;
+    }
+    ResourceMark rm;
+    log_debug(aot, codecache, oops)("%d (A%d): Read MH object: " PTR_FORMAT " : %s",
+              compile_id(), comp_level(), p2i(obj), obj->klass()->external_name());
+  } else {
+    set_lookup_failed("Unknown oop's kind");
+    log_debug(aot, codecache, oops)("%d (A%d): Unknown oop's kind: %d",
+              compile_id(), comp_level(), (int)kind);
+    return nullptr;
+  }
+  return obj;
+}
+
+bool AOTCodeReader::read_oop_metadata_list(JavaThread* current, GrowableArray<Handle> &oop_list, GrowableArray<Metadata*> &metadata_list, OopRecorder* oop_recorder) {
+  uint offset = read_position();
+  int count = *(int *)addr(offset);
+  offset += sizeof(int);
+  set_read_position(offset);
+  for (int i = 0; i < count; i++) {
+    oop obj = read_oop(current);
+    if (lookup_failed()) {
+      return false;
+    }
+    Handle h(current, obj);
+    oop_list.append(h);
+    if (oop_recorder != nullptr) {
+      jobject jo = JNIHandles::make_local(current, obj);
+      if (oop_recorder->is_real(jo)) {
+        oop_recorder->find_index(jo);
+      } else {
+        oop_recorder->allocate_oop_index(jo);
+      }
+    }
+    LogStreamHandle(Trace, aot, codecache, oops) log;
+    if (log.is_enabled()) {
+      ResourceMark rm;
+      stringStream ss;
+      ss.print("%d (A%d): %d: " INTPTR_FORMAT " ", compile_id(), comp_level(), i, p2i(obj));
+      if (obj == Universe::non_oop_word()) {
+        ss.print("non-oop word");
+      } else if (obj == nullptr) {
+        ss.print("nullptr-oop");
+      } else {
+        obj->print_value_on(&ss);
+      }
+      log.print_cr("%s", ss.freeze());
+    }
+  }
+
+  offset = read_position();
+  count = *(int *)addr(offset);
+  offset += sizeof(int);
+  set_read_position(offset);
+  for (int i = 0; i < count; i++) {
+    Metadata* m = read_metadata();
+    if (lookup_failed()) {
+      return false;
+    }
+    metadata_list.append(m);
+    if (oop_recorder != nullptr) {
+      if (oop_recorder->is_real(m)) {
+        oop_recorder->find_index(m);
+      } else {
+        oop_recorder->allocate_metadata_index(m);
+      }
+    }
+    LogStreamHandle(Trace, aot, codecache, metadata) log;
+    if (log.is_enabled()) {
+      ResourceMark rm;
+      stringStream ss;
+      ss.print("%d (A%d): %d: " INTPTR_FORMAT " ", compile_id(), comp_level(), i, p2i(m));
+      if (m == (Metadata*)Universe::non_oop_word()) {
+        ss.print("non-metadata word");
+      } else if (m == nullptr) {
+        ss.print("nullptr-oop");
+      } else {
+        Metadata::print_value_on_maybe_null(&ss, m);
+      }
+      log.print_cr("%s", ss.freeze());
+    }
+  }
+  return true;
 }
 
 bool AOTCodeCache::write_oop_map_set(CodeBlob& cb) {
@@ -1771,8 +3262,21 @@ ImmutableOopMapSet* AOTCodeReader::read_oop_map_set() {
   return oopmaps;
 }
 
+bool AOTCodeCache::write_oops(nmethod* nm) {
+  int count = nm->oops_count()-1;
+  if (!write_bytes(&count, sizeof(int))) {
+    return false;
+  }
+  for (oop* p = nm->oops_begin(); p < nm->oops_end(); p++) {
+    if (!write_oop(*p)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 #ifndef PRODUCT
-bool AOTCodeCache::write_asm_remarks(CodeBlob& cb) {
+bool AOTCodeCache::write_asm_remarks(AsmRemarks& asm_remarks, bool use_string_table) {
   if (!align_write_int()) {
     return false;
   }
@@ -1782,18 +3286,26 @@ bool AOTCodeCache::write_asm_remarks(CodeBlob& cb) {
     return false;
   }
   uint count = 0;
-  bool result = cb.asm_remarks().iterate([&] (uint offset, const char* str) -> bool {
-    log_trace(aot, codecache, stubs)("asm remark offset=%d, str='%s'", offset, str);
+  bool result = asm_remarks.iterate([&] (uint offset, const char* str) -> bool {
+    log_trace(aot, codecache, stubs)("%d (A%d): asm remark offset=%d, str='%s'",
+              compile_id(), comp_level(), offset, str);
     uint n = write_bytes(&offset, sizeof(uint));
     if (n != sizeof(uint)) {
       return false;
     }
-    const char* cstr = add_C_string(str);
-    int id = _table->id_for_C_string((address)cstr);
-    assert(id != BAD_ADDRESS_ID, "asm remark string '%s' not found in AOTCodeAddressTable", str);
-    n = write_bytes(&id, sizeof(int));
-    if (n != sizeof(int)) {
-      return false;
+    if (use_string_table) {
+      const char* cstr = add_C_string(str);
+      int id = _table->id_for_C_string((address)cstr);
+      assert(id != BAD_ADDRESS_ID, "asm remark string '%s' not found in AOTCodeAddressTable", str);
+      n = write_bytes(&id, sizeof(int));
+      if (n != sizeof(int)) {
+        return false;
+      }
+    } else {
+      n = write_bytes(str, (uint)strlen(str) + 1);
+      if (n != strlen(str) + 1) {
+        return false;
+      }
     }
     count += 1;
     return true;
@@ -1802,7 +3314,7 @@ bool AOTCodeCache::write_asm_remarks(CodeBlob& cb) {
   return result;
 }
 
-void AOTCodeReader::read_asm_remarks(AsmRemarks& asm_remarks) {
+void AOTCodeReader::read_asm_remarks(AsmRemarks& asm_remarks, bool use_string_table) {
   // Read asm remarks
   uint offset = align_read_int();
   uint count = *(uint *)addr(offset);
@@ -1810,15 +3322,21 @@ void AOTCodeReader::read_asm_remarks(AsmRemarks& asm_remarks) {
   for (uint i = 0; i < count; i++) {
     uint remark_offset = *(uint *)addr(offset);
     offset += sizeof(uint);
-    int remark_string_id = *(uint *)addr(offset);
-    offset += sizeof(int);
-    const char* remark = (const char*)_cache->address_for_C_string(remark_string_id);
+    const char* remark = nullptr;
+    if (use_string_table) {
+      int remark_string_id = *(uint *)addr(offset);
+      offset += sizeof(int);
+      remark = (const char*)_cache->address_for_C_string(remark_string_id);
+    } else {
+      remark = (const char*)addr(offset);
+      offset += (uint)strlen(remark)+1;
+    }
     asm_remarks.insert(remark_offset, remark);
   }
   set_read_position(offset);
 }
 
-bool AOTCodeCache::write_dbg_strings(CodeBlob& cb) {
+bool AOTCodeCache::write_dbg_strings(DbgStrings& dbg_strings, bool use_string_table) {
   if (!align_write_int()) {
     return false;
   }
@@ -1828,14 +3346,22 @@ bool AOTCodeCache::write_dbg_strings(CodeBlob& cb) {
     return false;
   }
   uint count = 0;
-  bool result = cb.dbg_strings().iterate([&] (const char* str) -> bool {
-    log_trace(aot, codecache, stubs)("dbg string=%s", str);
-    const char* cstr = add_C_string(str);
-    int id = _table->id_for_C_string((address)cstr);
-    assert(id != BAD_ADDRESS_ID, "db string '%s' not found in AOTCodeAddressTable", str);
-    uint n = write_bytes(&id, sizeof(int));
-    if (n != sizeof(int)) {
-      return false;
+  bool result = dbg_strings.iterate([&] (const char* str) -> bool {
+    log_trace(aot, codecache, stubs)("%d (A%d): dbg string='%s'",
+              compile_id(), comp_level(), str);
+    if (use_string_table) {
+      const char* cstr = add_C_string(str);
+      int id = _table->id_for_C_string((address)cstr);
+      assert(id != BAD_ADDRESS_ID, "db string '%s' not found in AOTCodeAddressTable", str);
+      uint n = write_bytes(&id, sizeof(int));
+      if (n != sizeof(int)) {
+        return false;
+      }
+    } else {
+      uint n = write_bytes(str, (uint)strlen(str) + 1);
+      if (n != strlen(str) + 1) {
+        return false;
+      }
     }
     count += 1;
     return true;
@@ -1844,15 +3370,21 @@ bool AOTCodeCache::write_dbg_strings(CodeBlob& cb) {
   return result;
 }
 
-void AOTCodeReader::read_dbg_strings(DbgStrings& dbg_strings) {
+void AOTCodeReader::read_dbg_strings(DbgStrings& dbg_strings, bool use_string_table) {
   // Read dbg strings
   uint offset = align_read_int();
   uint count = *(uint *)addr(offset);
   offset += sizeof(uint);
   for (uint i = 0; i < count; i++) {
-    int string_id = *(uint *)addr(offset);
-    offset += sizeof(int);
-    const char* str = (const char*)_cache->address_for_C_string(string_id);
+    const char* str = nullptr;
+    if (use_string_table) {
+      int string_id = *(uint *)addr(offset);
+      offset += sizeof(int);
+      str = (const char*)_cache->address_for_C_string(string_id);
+    } else {
+      str = (const char*)addr(offset);
+      offset += (uint)strlen(str)+1;
+    }
     dbg_strings.insert(str);
   }
   set_read_position(offset);
@@ -1864,11 +3396,12 @@ void AOTCodeReader::read_dbg_strings(DbgStrings& dbg_strings) {
 // address table ids for generated routine entry adresses, external
 // addresses and C string addresses are partitioned into positive
 // integer ranges defined by the following positive base and max
-// values i.e. [_extrs_base, _extrs_base + _extrs_max -1],
-// [_stubs_base, _stubs_base + _stubs_max -1], [_c_str_base,
-// _c_str_base + _c_str_max -1],
+// values i.e.
+//   [_extrs_base, _extrs_base + _extrs_max -1],
+//   [_stubs_base, _stubs_base + _stubs_max -1],
+//   [_c_str_base, _c_str_base + _c_str_max -1],
 
-#define _extrs_max 380
+#define _extrs_max 500
 #define _stubs_max static_cast<int>(EntryId::NUM_ENTRYIDS)
 
 #define _extrs_base 0
@@ -1917,15 +3450,16 @@ void AOTCodeAddressTable::init_extrs() {
   initializing_extrs = true;
   _extrs_addr = NEW_C_HEAP_ARRAY(address, _extrs_max, mtCode);
 
-  _extrs_length = 0;
-
   {
     // Required by initial stubs
     ADD_EXTERNAL_ADDRESS(SharedRuntime::exception_handler_for_return_address); // used by forward_exception
+    ADD_EXTERNAL_ADDRESS(CompressedKlassPointers::base_addr());
     ADD_EXTERNAL_ADDRESS(CompressedOops::base_addr()); // used by call_stub
     ADD_EXTERNAL_ADDRESS(Thread::current); // used by call_stub
     ADD_EXTERNAL_ADDRESS(SharedRuntime::throw_StackOverflowError);
     ADD_EXTERNAL_ADDRESS(SharedRuntime::throw_delayed_StackOverflowError);
+    ADD_EXTERNAL_ADDRESS(StubRoutines::crc_table_addr());
+    ADD_EXTERNAL_ADDRESS(StubRoutines::verify_oop_count_addr()); // used by generate_verify_oop()
   }
 
   // Record addresses of VM runtime methods
@@ -1951,6 +3485,12 @@ void AOTCodeAddressTable::init_extrs() {
 #endif /* PRODUCT */
 
   ADD_EXTERNAL_ADDRESS(SharedRuntime::enable_stack_reserved_zone);
+  ADD_EXTERNAL_ADDRESS(SharedRuntime::rc_trace_method_entry);
+  ADD_EXTERNAL_ADDRESS(SharedRuntime::reguard_yellow_pages);
+  ADD_EXTERNAL_ADDRESS(SharedRuntime::dtrace_method_entry);
+  ADD_EXTERNAL_ADDRESS(SharedRuntime::dtrace_method_exit);
+  ADD_EXTERNAL_ADDRESS(SharedRuntime::complete_monitor_unlocking_C);
+  ADD_EXTERNAL_ADDRESS(SharedRuntime::OSR_migration_end);
 
 #if defined(AMD64) && !defined(ZERO)
   ADD_EXTERNAL_ADDRESS(SharedRuntime::montgomery_multiply);
@@ -1965,14 +3505,12 @@ void AOTCodeAddressTable::init_extrs() {
   ADD_EXTERNAL_ADDRESS(SharedRuntime::dlog);
   ADD_EXTERNAL_ADDRESS(SharedRuntime::dlog10);
   ADD_EXTERNAL_ADDRESS(SharedRuntime::dpow);
-#ifndef ZERO
-  ADD_EXTERNAL_ADDRESS(SharedRuntime::drem);
-#endif
   ADD_EXTERNAL_ADDRESS(SharedRuntime::dsin);
   ADD_EXTERNAL_ADDRESS(SharedRuntime::dtan);
   ADD_EXTERNAL_ADDRESS(SharedRuntime::f2i);
   ADD_EXTERNAL_ADDRESS(SharedRuntime::f2l);
 #ifndef ZERO
+  ADD_EXTERNAL_ADDRESS(SharedRuntime::drem);
   ADD_EXTERNAL_ADDRESS(SharedRuntime::frem);
 #endif
   ADD_EXTERNAL_ADDRESS(SharedRuntime::l2d);
@@ -1981,28 +3519,37 @@ void AOTCodeAddressTable::init_extrs() {
   ADD_EXTERNAL_ADDRESS(SharedRuntime::lmul);
   ADD_EXTERNAL_ADDRESS(SharedRuntime::lrem);
 
-#if INCLUDE_JVMTI
-  ADD_EXTERNAL_ADDRESS(&JvmtiExport::_should_notify_object_alloc);
-#endif /* INCLUDE_JVMTI */
-
   ADD_EXTERNAL_ADDRESS(ThreadIdentifier::unsafe_offset());
-  // already added
-  // ADD_EXTERNAL_ADDRESS(Thread::current);
+  ADD_EXTERNAL_ADDRESS(ObjectMonitorTable::current_table_address());
 
   ADD_EXTERNAL_ADDRESS(os::javaTimeMillis);
   ADD_EXTERNAL_ADDRESS(os::javaTimeNanos);
 #ifndef PRODUCT
   ADD_EXTERNAL_ADDRESS(os::breakpoint);
+  ADD_EXTERNAL_ADDRESS(&SharedRuntime::_partial_subtype_ctr);
+  ADD_EXTERNAL_ADDRESS(JavaThread::verify_cross_modify_fence_failure);
 #endif
 
-  ADD_EXTERNAL_ADDRESS(StubRoutines::crc_table_addr());
-#ifndef PRODUCT
-  ADD_EXTERNAL_ADDRESS(&SharedRuntime::_partial_subtype_ctr);
-#endif
+#if INCLUDE_JVMTI
+  ADD_EXTERNAL_ADDRESS(&JvmtiExport::_should_notify_object_alloc);
+#endif /* INCLUDE_JVMTI */
+  // For JVMTI
+  ADD_EXTERNAL_ADDRESS(MountUnmountDisabler::notify_jvmti_events_address());
+  ADD_EXTERNAL_ADDRESS(MountUnmountDisabler::global_vthread_transition_disable_count_address());
 
 #if INCLUDE_JFR
   ADD_EXTERNAL_ADDRESS(JfrIntrinsicSupport::write_checkpoint);
   ADD_EXTERNAL_ADDRESS(JfrIntrinsicSupport::return_lease);
+  ADD_EXTERNAL_ADDRESS(JfrIntrinsicSupport::load_barrier);
+  ADD_EXTERNAL_ADDRESS(JfrIntrinsicSupport::epoch_address());
+  ADD_EXTERNAL_ADDRESS(JfrIntrinsicSupport::epoch_generation_address());
+  ADD_EXTERNAL_ADDRESS(JfrIntrinsicSupport::signal_address());
+  ADD_EXTERNAL_ADDRESS(&VMContinuations)
+#endif
+  // For JFR
+  ADD_EXTERNAL_ADDRESS(os::elapsed_counter);
+#if defined(X86) && !defined(ZERO)
+  ADD_EXTERNAL_ADDRESS(Rdtsc::elapsed_counter);
 #endif
 
   ADD_EXTERNAL_ADDRESS(UpcallLinker::handle_uncaught_exception); // used by upcall_stub_exception_handler
@@ -2015,8 +3562,6 @@ void AOTCodeAddressTable::init_extrs() {
     ADD_EXTERNAL_ADDRESS(SharedRuntime::resolve_opt_virtual_call_C);
     ADD_EXTERNAL_ADDRESS(SharedRuntime::resolve_virtual_call_C);
     ADD_EXTERNAL_ADDRESS(SharedRuntime::resolve_static_call_C);
-    // already added
-    // ADD_EXTERNAL_ADDRESS(SharedRuntime::throw_delayed_StackOverflowError);
     ADD_EXTERNAL_ADDRESS(SharedRuntime::throw_AbstractMethodError);
     ADD_EXTERNAL_ADDRESS(SharedRuntime::throw_IncompatibleClassChangeError);
     ADD_EXTERNAL_ADDRESS(SharedRuntime::throw_NullPointerException_at_call);
@@ -2051,11 +3596,9 @@ void AOTCodeAddressTable::init_extrs() {
     ADD_EXTERNAL_ADDRESS(Runtime1::move_appendix_patching);
     ADD_EXTERNAL_ADDRESS(Runtime1::predicate_failed_trap);
     ADD_EXTERNAL_ADDRESS(Runtime1::unimplemented_entry);
-    // already added
-    // ADD_EXTERNAL_ADDRESS(Thread::current);
-    ADD_EXTERNAL_ADDRESS(CompressedKlassPointers::base_addr());
+    ADD_EXTERNAL_ADDRESS(Runtime1::trace_block_entry);
   }
-#endif
+#endif // COMPILER1
 
 #ifdef COMPILER2
   {
@@ -2076,62 +3619,72 @@ void AOTCodeAddressTable::init_extrs() {
     ADD_EXTERNAL_ADDRESS(OptoRuntime::rethrow_C);
     ADD_EXTERNAL_ADDRESS(OptoRuntime::slow_arraycopy_C);
     ADD_EXTERNAL_ADDRESS(OptoRuntime::register_finalizer_C);
+    ADD_EXTERNAL_ADDRESS(OptoRuntime::compile_method_C);
     ADD_EXTERNAL_ADDRESS(OptoRuntime::vthread_end_first_transition_C);
     ADD_EXTERNAL_ADDRESS(OptoRuntime::vthread_start_final_transition_C);
     ADD_EXTERNAL_ADDRESS(OptoRuntime::vthread_start_transition_C);
     ADD_EXTERNAL_ADDRESS(OptoRuntime::vthread_end_transition_C);
-    // already added for
-#if defined(AARCH64) && ! defined(PRODUCT)
-    ADD_EXTERNAL_ADDRESS(JavaThread::verify_cross_modify_fence_failure);
-#endif // AARCH64 && !PRODUCT
+    ADD_EXTERNAL_ADDRESS(Parse::trap_stress_counter_address());
   }
+#if defined(AMD64) || defined(AARCH64)
+  ADD_EXTERNAL_ADDRESS(C2_MacroAssembler::abort_verify_int_in_range);
+  ADD_EXTERNAL_ADDRESS(C2_MacroAssembler::abort_verify_long_in_range);
+#endif // defined(AMD64) || defined(AARCH64)
 #endif // COMPILER2
 
-#if INCLUDE_G1GC
-  ADD_EXTERNAL_ADDRESS(G1BarrierSetRuntime::write_ref_field_pre_entry);
-  ADD_EXTERNAL_ADDRESS(G1BarrierSetRuntime::write_ref_array_pre_narrow_oop_entry); // used by arraycopy stubs
-  ADD_EXTERNAL_ADDRESS(G1BarrierSetRuntime::write_ref_array_pre_oop_entry); // used by arraycopy stubs
-  ADD_EXTERNAL_ADDRESS(G1BarrierSetRuntime::write_ref_array_post_entry); // used by arraycopy stubs
   ADD_EXTERNAL_ADDRESS(BarrierSetNMethod::nmethod_stub_entry_barrier); // used by method_entry_barrier
-
+#if INCLUDE_G1GC
+  if (UseG1GC) {
+    ADD_EXTERNAL_ADDRESS(G1BarrierSetRuntime::write_ref_field_pre_entry);
+    ADD_EXTERNAL_ADDRESS(G1BarrierSetRuntime::write_ref_array_pre_narrow_oop_entry); // used by arraycopy stubs
+    ADD_EXTERNAL_ADDRESS(G1BarrierSetRuntime::write_ref_array_pre_oop_entry); // used by arraycopy stubs
+    ADD_EXTERNAL_ADDRESS(G1BarrierSetRuntime::write_ref_array_post_entry); // used by arraycopy stubs
+    ADD_EXTERNAL_ADDRESS(G1BarrierSetRuntime::clone_addr());
+  }
 #endif
 #if INCLUDE_SHENANDOAHGC
-  ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::write_barrier_pre);
-  ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::write_barrier_pre_narrow);
-  ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_strong);
-  ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_strong_narrow);
-  ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_strong_narrow_narrow);
-  ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_weak);
-  ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_weak_narrow);
-  ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_weak_narrow_narrow);
-  ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_phantom);
-  ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_phantom_narrow);
-  ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_phantom_narrow_narrow);
-  ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::arraycopy_barrier_oop);
-  ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::arraycopy_barrier_narrow_oop);
-  ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::clone);
+  if (UseShenandoahGC) {
+    ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::write_barrier_pre);
+    ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::write_barrier_pre_narrow);
+    ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_strong);
+    ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_strong_narrow);
+    ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_strong_narrow_narrow);
+    ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_weak);
+    ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_weak_narrow);
+    ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_weak_narrow_narrow);
+    ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_phantom);
+    ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_phantom_narrow);
+    ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::load_reference_barrier_phantom_narrow_narrow);
+    ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::arraycopy_barrier_oop);
+    ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::arraycopy_barrier_narrow_oop);
+    ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::clone);
+  }
 #endif
 #if INCLUDE_ZGC
-  ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_addr());
-  ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_store_good_addr());
-  ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::load_barrier_on_weak_oop_field_preloaded_addr());
-  ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::load_barrier_on_phantom_oop_field_preloaded_addr());
-  ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::no_keepalive_load_barrier_on_weak_oop_field_preloaded_addr());
-  ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::no_keepalive_load_barrier_on_phantom_oop_field_preloaded_addr());
-  ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::store_barrier_on_oop_field_with_healing_addr());
-  ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::store_barrier_on_oop_field_without_healing_addr());
-  ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::no_keepalive_store_barrier_on_oop_field_without_healing_addr());
-  ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::store_barrier_on_native_oop_field_without_healing_addr());
-  ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::load_barrier_on_oop_array_addr());
+  if (UseZGC) {
+    ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_addr());
+    ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_store_good_addr());
+    ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::load_barrier_on_weak_oop_field_preloaded_addr());
+    ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::load_barrier_on_phantom_oop_field_preloaded_addr());
+    ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::no_keepalive_load_barrier_on_weak_oop_field_preloaded_addr());
+    ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::no_keepalive_load_barrier_on_phantom_oop_field_preloaded_addr());
+    ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::store_barrier_on_oop_field_with_healing_addr());
+    ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::store_barrier_on_oop_field_without_healing_addr());
+    ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::no_keepalive_store_barrier_on_oop_field_without_healing_addr());
+    ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::store_barrier_on_native_oop_field_without_healing_addr());
+    ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::load_barrier_on_oop_array_addr());
+    ADD_EXTERNAL_ADDRESS(ZBarrierSetRuntime::clone_addr());
 
-  ADD_EXTERNAL_ADDRESS(ZPointerVectorLoadBadMask);
-  ADD_EXTERNAL_ADDRESS(ZPointerVectorStoreBadMask);
-  ADD_EXTERNAL_ADDRESS(ZPointerVectorStoreGoodMask);
+    ADD_EXTERNAL_ADDRESS(ZPointerVectorLoadBadMask);
+    ADD_EXTERNAL_ADDRESS(ZPointerVectorStoreBadMask);
+    ADD_EXTERNAL_ADDRESS(ZPointerVectorStoreGoodMask);
 #if defined(AMD64)
-  ADD_EXTERNAL_ADDRESS(&ZPointerLoadShift);
-  ADD_EXTERNAL_ADDRESS(&ZPointerLoadShiftTable);
+    ADD_EXTERNAL_ADDRESS(&ZPointerLoadShift);
+    ADD_EXTERNAL_ADDRESS(&ZPointerLoadShiftTable);
 #endif
-#endif
+  } // UseZGC
+#endif // INCLUDE_ZGC
+
 #ifndef ZERO
 #if defined(AMD64) || defined(AARCH64) || defined(RISCV64)
   ADD_EXTERNAL_ADDRESS(MacroAssembler::debug64);
@@ -2157,15 +3710,15 @@ void AOTCodeAddressTable::init_extrs() {
 void AOTCodeAddressTable::init_extrs2() {
   assert(initializing_extrs && !_extrs_complete,
          "invalid sequence for init_extrs2");
-
   {
-  ADD_EXTERNAL_ADDRESS(Continuation::prepare_thaw); // used by cont_thaw
-  ADD_EXTERNAL_ADDRESS(Continuation::thaw_entry()); // used by cont_thaw
-  ADD_EXTERNAL_ADDRESS(ContinuationEntry::thaw_call_pc_address()); // used by cont_preempt_stub
+    ADD_EXTERNAL_ADDRESS(Continuation::prepare_thaw); // used by cont_thaw
+    ADD_EXTERNAL_ADDRESS(Continuation::thaw_entry()); // used by cont_thaw
+    ADD_EXTERNAL_ADDRESS(ContinuationEntry::thaw_call_pc_address()); // used by cont_preempt_stub
+    ADD_EXTERNAL_ADDRESS(Continuation::freeze_entry()); // used by gen_continuation_yield
   }
   _extrs_complete = true;
   initializing_extrs = false;
-  log_debug(aot, codecache, init)("External addresses recorded and closed");
+  log_info(aot, codecache, init)("External addresses %d recorded and closed", _extrs_length);
 }
 
 void AOTCodeAddressTable::add_external_addresses(GrowableArray<address>& addresses) {
@@ -2194,25 +3747,54 @@ void AOTCodeAddressTable::add_stub_entry(EntryId entry_id, address a) {
 void AOTCodeAddressTable::set_shared_stubs_complete() {
   assert(!_shared_stubs_complete, "repeated close for shared stubs!");
   _shared_stubs_complete = true;
-  log_debug(aot, codecache, init)("Shared stubs closed");
+  log_info(aot, codecache, init)("Shared stubs recorded and closed");
 }
 
 void AOTCodeAddressTable::set_c1_stubs_complete() {
   assert(!_c1_stubs_complete, "repeated close for c1 stubs!");
+  uint old_extrs_length = _extrs_length;
+#ifdef COMPILER1
+#if INCLUDE_G1GC
+  if (UseG1GC) {
+    G1BarrierSetC1* bs = (G1BarrierSetC1*)BarrierSet::barrier_set()->barrier_set_c1();
+    ADD_EXTERNAL_ADDRESS(bs->pre_barrier_c1_runtime_code_blob()->code_begin());
+  }
+#endif // INCLUDE_G1GC
+#if INCLUDE_ZGC
+  if (UseZGC) {
+    ZBarrierSetC1* bs = (ZBarrierSetC1*)BarrierSet::barrier_set()->barrier_set_c1();
+    ADD_EXTERNAL_ADDRESS(bs->_load_barrier_on_oop_field_preloaded_runtime_stub);
+    ADD_EXTERNAL_ADDRESS(bs->_load_barrier_on_weak_oop_field_preloaded_runtime_stub);
+    ADD_EXTERNAL_ADDRESS(bs->_store_barrier_on_oop_field_with_healing);
+    ADD_EXTERNAL_ADDRESS(bs->_store_barrier_on_oop_field_without_healing);
+  }
+#endif // INCLUDE_ZGC
+#if INCLUDE_SHENANDOAHGC
+  if (UseShenandoahGC) {
+    ShenandoahBarrierSetC1* bs = (ShenandoahBarrierSetC1*)BarrierSet::barrier_set()->barrier_set_c1();
+    ADD_EXTERNAL_ADDRESS(bs->pre_barrier_c1_runtime_code_blob()->code_begin());
+    ADD_EXTERNAL_ADDRESS(bs->load_reference_barrier_strong_rt_code_blob()->code_begin());
+    ADD_EXTERNAL_ADDRESS(bs->load_reference_barrier_strong_native_rt_code_blob()->code_begin());
+    ADD_EXTERNAL_ADDRESS(bs->load_reference_barrier_weak_rt_code_blob()->code_begin());
+    ADD_EXTERNAL_ADDRESS(bs->load_reference_barrier_phantom_rt_code_blob()->code_begin());
+  }
+#endif // INCLUDE_SHENANDOAHGC
+#endif // COMPILER1
   _c1_stubs_complete = true;
-  log_debug(aot, codecache, init)("C1 stubs closed");
+  log_info(aot, codecache, init)("C1 stubs recorded and closed");
+  log_info(aot, codecache, init)("External C1 addresses %d recorded", (_extrs_length - old_extrs_length));
 }
 
 void AOTCodeAddressTable::set_c2_stubs_complete() {
   assert(!_c2_stubs_complete, "repeated close for c2 stubs!");
   _c2_stubs_complete = true;
-  log_debug(aot, codecache, init)("C2 stubs closed");
+  log_info(aot, codecache, init)("C2 stubs recorded and closed");
 }
 
 void AOTCodeAddressTable::set_stubgen_stubs_complete() {
   assert(!_stubgen_stubs_complete, "repeated close for stubgen stubs!");
   _stubgen_stubs_complete = true;
-  log_debug(aot, codecache, init)("StubGen stubs closed");
+  log_info(aot, codecache, init)("StubGen stubs recorded and closed");
 }
 
 #ifdef PRODUCT
@@ -2242,7 +3824,7 @@ void AOTCodeCache::load_strings() {
   uint strings_offset = _load_header->strings_offset();
   uint* string_lengths = (uint*)addr(strings_offset);
   strings_offset += (strings_count * sizeof(uint));
-  uint strings_size = _load_header->entries_offset() - strings_offset;
+  uint strings_size = _load_header->search_table_offset() - strings_offset;
   // We have to keep cached strings longer than _cache buffer
   // because they are refernced from compiled code which may
   // still be executed on VM exit after _cache is freed.
@@ -2260,7 +3842,7 @@ void AOTCodeCache::load_strings() {
   assert((uint)(p - _C_strings_buf) <= strings_size, "(" INTPTR_FORMAT " - " INTPTR_FORMAT ") = %d > %d ", p2i(p), p2i(_C_strings_buf), (uint)(p - _C_strings_buf), strings_size);
   _C_strings_count = strings_count;
   _C_strings_used  = strings_count;
-  log_debug(aot, codecache, init)("  Loaded %d C strings of total length %d at offset %d from AOT Code Cache", _C_strings_count, strings_size, strings_offset);
+  log_info(aot, codecache, init)("  Loaded %d C strings of total length %d at offset %d from AOT Code Cache", _C_strings_count, strings_size, strings_offset);
 }
 
 int AOTCodeCache::store_strings() {
@@ -2401,7 +3983,7 @@ int AOTCodeAddressTable::id_for_address(address addr, RelocIterator reloc, CodeB
   }
   // fast path for stubs and external addresses
   if (_hash_table != nullptr) {
-    int *result = _hash_table->get(addr);
+    int* result = _hash_table->get(addr);
     if (result != nullptr) {
       id = *result;
       log_trace(aot, codecache)("Address " INTPTR_FORMAT " retrieved from AOT Code Cache address hash table with index '%d'",
@@ -2422,6 +4004,9 @@ int AOTCodeAddressTable::id_for_address(address addr, RelocIterator reloc, CodeB
       if (desc == nullptr) {
         desc = StubCodeDesc::desc_for(addr + frame::pc_return_offset);
       }
+      reloc.print_current_on(tty);
+      code_blob->print_on(tty);
+      code_blob->print_code_on(tty);
       const char* sub_name = (desc != nullptr) ? desc->name() : "<unknown>";
       assert(false, "Address " INTPTR_FORMAT " for Stub:%s is missing in AOT Code Cache addresses table", p2i(addr), sub_name);
     } else {
@@ -2444,20 +4029,16 @@ int AOTCodeAddressTable::id_for_address(address addr, RelocIterator reloc, CodeB
           assert(dist > (uint)(_all_max + MAX_STR_COUNT), "change encoding of distance");
           return dist;
         }
-#ifdef ASSERT
         reloc.print_current_on(tty);
         code_blob->print_on(tty);
         code_blob->print_code_on(tty);
         assert(false, "Address " INTPTR_FORMAT " for runtime target '%s+%d' is missing in AOT Code Cache addresses table", p2i(addr), func_name, offset);
-#endif
       } else {
-#ifdef ASSERT
         reloc.print_current_on(tty);
         code_blob->print_on(tty);
         code_blob->print_code_on(tty);
         os::find(addr, tty);
         assert(false, "Address " INTPTR_FORMAT " for <unknown>/('%s') is missing in AOT Code Cache addresses table", p2i(addr), (const char*)addr);
-#endif
       }
     } else {
       return _extrs_base + id;
@@ -2465,6 +4046,12 @@ int AOTCodeAddressTable::id_for_address(address addr, RelocIterator reloc, CodeB
   }
   return id;
 }
+
+#undef _extrs_max
+#undef _stubs_max
+#undef _extrs_base
+#undef _stubs_base
+#undef _all_max
 
 AOTRuntimeConstants AOTRuntimeConstants::_aot_runtime_constants;
 
@@ -2508,17 +4095,45 @@ address AOTRuntimeConstants::card_table_base_address() {
   return (address)&_aot_runtime_constants._card_table_base;
 }
 
+void AOTCodeEntry::print(outputStream* st) const {
+  st->print_cr(" AOT Code Cache entry " INTPTR_FORMAT " [kind: %d, id: " UINT32_FORMAT_X_0 ", offset: %d, size: %d, comp_level: %d, comp_id: %d, %s%s%s%s]",
+               p2i(this), (int)_kind, _id, _offset, _size, _comp_level, _comp_id,
+               (_not_entrant? "not_entrant" : "entrant"),
+               (_loaded ? ", loaded" : ""),
+               (_has_clinit_barriers ? ", has_clinit_barriers" : ""),
+               (_for_preload ? ", for_preload" : ""));
+}
+
 // This is called after initialize() but before init2()
-// and _cache is not set yet.
+// and _cache is not set yet - use `opened_cache`.
 void AOTCodeCache::print_on(outputStream* st) {
   if (opened_cache != nullptr && opened_cache->for_use()) {
-    st->print_cr("\nAOT Code Cache");
+    st->print_cr("\nAOT Code Cache Preload entries");
+
+    uint preload_count = opened_cache->_load_header->preload_entries_count();
+    AOTCodeEntry* preload_entries = (AOTCodeEntry*)opened_cache->addr(opened_cache->_load_header->preload_entries_offset());
+    for (uint i = 0; i < preload_count; i++) {
+      AOTCodeEntry* entry = &preload_entries[i];
+
+      uint entry_position = entry->offset();
+      uint name_offset = entry->name_offset() + entry_position;
+      const char* saved_name = opened_cache->addr(name_offset);
+
+      st->print_cr("%4u: %10s Id:%u AP%u size=%u '%s' %s%s%s",
+                   i, aot_code_entry_kind_name[entry->kind()], entry->id(), entry->comp_level(),
+                   entry->size(),  saved_name,
+                   entry->has_clinit_barriers() ? " has_clinit_barriers" : "",
+                   entry->is_loaded()           ? " loaded"              : "",
+                   entry->not_entrant()         ? " not_entrant"         : "");
+    }
+
+    st->print_cr("\nAOT Code Cache entries");
+
     uint count = opened_cache->_load_header->entries_count();
-    uint* search_entries = (uint*)opened_cache->addr(opened_cache->_load_header->entries_offset()); // [id, index]
-    AOTCodeEntry* load_entries = (AOTCodeEntry*)(search_entries + 2 * count);
+    uint* search_entries = (uint*)opened_cache->addr(opened_cache->_load_header->search_table_offset()); // [id, index]
+    AOTCodeEntry* load_entries = (AOTCodeEntry*)opened_cache->addr(opened_cache->_load_header->entries_offset());
 
     for (uint i = 0; i < count; i++) {
-      // Use search_entries[] to order ouput
       int index = search_entries[2*i + 1];
       AOTCodeEntry* entry = &(load_entries[index]);
 
@@ -2526,14 +4141,16 @@ void AOTCodeCache::print_on(outputStream* st) {
       uint name_offset = entry->name_offset() + entry_position;
       const char* saved_name = opened_cache->addr(name_offset);
 
-      st->print_cr("%4u: %10s idx:%4u Id:%u size=%u '%s'",
-                   i, aot_code_entry_kind_name[entry->kind()], index, entry->id(), entry->size(), saved_name);
+      st->print_cr("%4u: %10s idx:%4u Id:%u A%u size=%u '%s' %s%s",
+                   i, aot_code_entry_kind_name[entry->kind()], index, entry->id(), entry->comp_level(),
+                   entry->size(),  saved_name,
+                   entry->is_loaded()           ? " loaded"              : "",
+                   entry->not_entrant()         ? " not_entrant"         : "");
     }
   }
 }
 
 // methods for managing entries in multi-stub blobs
-
 
 AOTStubData::AOTStubData(BlobId blob_id) :
   _blob_id(blob_id),
@@ -2706,3 +4323,170 @@ void AOTStubData::check_stored(StubId stub_id) {
   }
 }
 #endif
+
+//============ Statistic ============
+
+void AOTCodeCache::print_timers_on(outputStream* st) {
+  if (is_using_code()) {
+    st->print_cr ("    AOT Code Preload Time:  %7.3f s", _t_totalPreload.seconds());
+    st->print_cr ("    AOT Code Load Time:     %7.3f s", _t_totalLoad.seconds());
+    st->print_cr ("      nmethod register:     %7.3f s", _t_totalRegister.seconds());
+    st->print_cr ("      find AOT code entry:  %7.3f s", _t_totalFind.seconds());
+  }
+  if (is_dumping_code()) {
+    st->print_cr ("    AOT Code Store Time:  %7.3f s", _t_totalStore.seconds());
+  }
+}
+
+void AOTCodeCache::log_stats_on_exit(AOTCodeEntryStats& stats) {
+  LogStream log_aot(LogLevel::Info, LogTagSetMapping<LOG_TAGS(aot)>::tagset());
+  LogStream log_exit(LogLevel::Info, LogTagSetMapping<LOG_TAGS(aot, codecache, exit)>::tagset());
+  LogStream& log = log_aot.is_enabled() ? log_aot : log_exit;
+  if (log.is_enabled()) {
+    for (uint kind = AOTCodeEntry::Adapter; kind < AOTCodeEntry::Kind_count; kind++) {
+      log.print_cr("  %s: total=%u", aot_code_entry_kind_name[kind], stats.entry_count(kind));
+      if (kind == AOTCodeEntry::Nmethod) {
+        for (uint lvl = CompLevel_simple; lvl < AOTCompLevel_count; lvl++) {
+          log.print("    Tier %d: total=%u", lvl, stats.nmethod_count(lvl));
+          if (lvl == AOTCompLevel_count-1) { // AOT Preload
+            log.print(", has_clinit_barriers=%u", stats.clinit_barriers_count());
+          }
+          log.cr();
+        }
+      }
+    }
+  }
+}
+
+struct AOTCodeStats {
+private:
+  struct {
+    uint _loaded_cnt;
+    uint _invalidated_cnt;
+    uint _load_failed_cnt;
+  } _entry_kinds[AOTCodeEntry::Kind_count],
+    _nmethods[AOTCompLevel_count];
+
+  static void check_kind(uint kind) {
+    AOTCodeEntryStats::check_kind(kind);
+  }
+  static void check_complevel(uint lvl) {
+    AOTCodeEntryStats::check_complevel(lvl);
+  }
+  void inc_entry_loaded_cnt(uint kind)      { check_kind(kind); _entry_kinds[kind]._loaded_cnt += 1; }
+  void inc_entry_invalidated_cnt(uint kind) { check_kind(kind); _entry_kinds[kind]._invalidated_cnt += 1; }
+  void inc_entry_load_failed_cnt(uint kind) { check_kind(kind); _entry_kinds[kind]._load_failed_cnt += 1; }
+
+  void inc_nmethod_loaded_cnt(uint lvl)      { check_complevel(lvl); _nmethods[lvl]._loaded_cnt += 1; }
+  void inc_nmethod_invalidated_cnt(uint lvl) { check_complevel(lvl); _nmethods[lvl]._invalidated_cnt += 1; }
+  void inc_nmethod_load_failed_cnt(uint lvl) { check_complevel(lvl); _nmethods[lvl]._load_failed_cnt += 1; }
+
+  void inc_loaded_cnt(AOTCodeEntry* entry) {
+    inc_entry_loaded_cnt(entry->kind());
+    if (entry->is_nmethod()) {
+      entry->for_preload() ? inc_nmethod_loaded_cnt(AOTCompLevel_count-1)
+                           : inc_nmethod_loaded_cnt(entry->comp_level());
+    }
+  }
+
+  void inc_invalidated_cnt(AOTCodeEntry* entry) {
+    inc_entry_invalidated_cnt(entry->kind());
+    if (entry->is_nmethod()) {
+      entry->for_preload() ? inc_nmethod_invalidated_cnt(AOTCompLevel_count-1)
+                           : inc_nmethod_invalidated_cnt(entry->comp_level());
+    }
+  }
+
+  void inc_load_failed_cnt(AOTCodeEntry* entry) {
+    inc_entry_load_failed_cnt(entry->kind());
+    if (entry->is_nmethod()) {
+      entry->for_preload() ? inc_nmethod_load_failed_cnt(AOTCompLevel_count-1)
+                           : inc_nmethod_load_failed_cnt(entry->comp_level());
+    }
+  }
+public:
+  AOTCodeStats() {
+    memset(this, 0, sizeof(AOTCodeStats));
+  }
+  void collect_entry_runtime_stats(AOTCodeEntry* entry) {
+    if (entry->is_loaded()) {
+      inc_loaded_cnt(entry);
+    }
+    if (entry->not_entrant()) {
+      inc_invalidated_cnt(entry);
+    }
+    if (entry->load_fail()) {
+      inc_load_failed_cnt(entry);
+    }
+  }
+
+  uint entry_loaded_count(uint kind)      { check_kind(kind); return _entry_kinds[kind]._loaded_cnt; }
+  uint entry_invalidated_count(uint kind) { check_kind(kind); return _entry_kinds[kind]._invalidated_cnt; }
+  uint entry_load_failed_count(uint kind) { check_kind(kind); return _entry_kinds[kind]._load_failed_cnt; }
+
+  uint nmethod_loaded_count(uint lvl)      { check_complevel(lvl); return _nmethods[lvl]._loaded_cnt; }
+  uint nmethod_invalidated_count(uint lvl) { check_complevel(lvl); return _nmethods[lvl]._invalidated_cnt; }
+  uint nmethod_load_failed_count(uint lvl) { check_complevel(lvl); return _nmethods[lvl]._load_failed_cnt; }
+};
+
+static void print_helper(outputStream* st, const char* name, int count) {
+  if (count > 0) {
+    st->print(" %s=%d", name, count);
+  }
+}
+
+void AOTCodeCache::print_statistics_on(outputStream* st) {
+  AOTCodeCache* cache = open_for_use();
+  if (cache != nullptr) {
+    AOTCodeEntryStats estats;
+    AOTCodeStats      cstats;
+
+    uint preload_count = cache->_load_header->preload_entries_count();
+    uint count = cache->_load_header->entries_count();
+    if ((preload_count + count) == 0) {
+      return;
+    }
+    AOTCodeEntry* preload_entries = (AOTCodeEntry*)cache->addr(cache->_load_header->preload_entries_offset());
+    for (uint i = 0; i < preload_count; i++) {
+      AOTCodeEntry* entry = &preload_entries[i];
+      estats.collect_entry_stats(entry);
+      cstats.collect_entry_runtime_stats(entry);
+
+    }
+
+    AOTCodeEntry* load_entries = (AOTCodeEntry*)cache->addr(cache->_load_header->entries_offset());
+    for (uint i = 0; i < count; i++) {
+      AOTCodeEntry* entry = &load_entries[i];
+      estats.collect_entry_stats(entry);
+      cstats.collect_entry_runtime_stats(entry);
+    }
+
+    st->print_cr("AOT Code Cache: ");
+
+    for (uint kind = AOTCodeEntry::Adapter; kind < AOTCodeEntry::Kind_count; kind++) {
+      if (estats.entry_count(kind) > 0) {
+        st->print("  %s:", aot_code_entry_kind_name[kind]);
+        print_helper(st, "total", estats.entry_count(kind));
+        print_helper(st, "loaded", cstats.entry_loaded_count(kind));
+        print_helper(st, "invalidated", cstats.entry_invalidated_count(kind));
+        print_helper(st, "failed", cstats.entry_load_failed_count(kind));
+        st->cr();
+      }
+      if (kind == AOTCodeEntry::Nmethod) {
+        for (uint lvl = CompLevel_simple; lvl < AOTCompLevel_count; lvl++) {
+          if (estats.nmethod_count(lvl) > 0) {
+            st->print("    AOT Code T%d", lvl);
+            print_helper(st, "total", estats.nmethod_count(lvl));
+            print_helper(st, "loaded", cstats.nmethod_loaded_count(lvl));
+            print_helper(st, "invalidated", cstats.nmethod_invalidated_count(lvl));
+            print_helper(st, "failed", cstats.nmethod_load_failed_count(lvl));
+            if (lvl == AOTCompLevel_count-1) {
+              print_helper(st, "has_clinit_barriers", estats.clinit_barriers_count());
+            }
+            st->cr();
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -25,30 +25,50 @@
 #ifndef SHARE_CODE_AOTCODECACHE_HPP
 #define SHARE_CODE_AOTCODECACHE_HPP
 
+#include "compiler/compilerDefinitions.hpp"
 #include "gc/shared/collectedHeap.hpp"
-#include "gc/shared/gc_globals.hpp"
+#include "memory/allocation.hpp"
+#include "nmt/memTag.hpp"
+#include "oops/oopsHierarchy.hpp"
 #include "runtime/stubInfo.hpp"
+#include "runtime/vm_version.hpp"
+#include "utilities/exceptions.hpp"
 #include "utilities/hashTable.hpp"
+#include "utilities/sizes.hpp"
 
 /*
  * AOT Code Cache collects code from Code Cache and corresponding metadata
  * during application training run.
  * In following "production" runs this code and data can be loaded into
  * Code Cache skipping its generation.
+ * Additionaly special compiled code "preload" is generated with class initialization
+ * barriers which can be called on first Java method invocation.
  */
 
-class CodeBuffer;
-class RelocIterator;
+class AbstractCompiler;
 class AOTCodeCache;
-class AOTCodeReader;
-class AdapterBlob;
-class ExceptionBlob;
-class ImmutableOopMapSet;
 class AsmRemarks;
+class ciConstant;
+class ciEnv;
+class ciMethod;
+class CodeBlob;
+class CompileTask;
 class DbgStrings;
+template<typename E>
+class GrowableArray;
+class ImmutableOopMapSet;
+class JavaThread;
+class Klass;
+class methodHandle;
+class Metadata;
+class Method;
+class nmethod;
+class OopRecorder;
+class outputStream;
+class RelocIterator;
+class StubCodeGenerator;
 
 enum class vmIntrinsicID : int;
-enum CompLevel : signed char;
 
 #define DO_AOTCODEENTRY_KIND(Fn) \
   Fn(None) \
@@ -57,9 +77,11 @@ enum CompLevel : signed char;
   Fn(C1Blob) \
   Fn(C2Blob) \
   Fn(StubGenBlob) \
+  Fn(Nmethod) \
 
 // Descriptor of AOT Code Cache's entry
 class AOTCodeEntry {
+  friend class VMStructs;
 public:
   enum Kind : s1 {
 #define DECL_KIND_ENUM(kind) kind,
@@ -69,40 +91,63 @@ public:
   };
 
 private:
-  AOTCodeEntry* _next;
-  Kind   _kind;
-  uint   _id;          // Adapter's id, vmIntrinsic::ID for stub or name's hash for nmethod
+  Kind    _kind;
+  // Next field is exposed to external profilers - keep it as boolean.
+  bool    _for_preload;           // Code can be used for preload (before classes initialized)
+  bool    _not_entrant;           // Deoptimized
+
+  uint8_t _has_clinit_barriers:1, // Generated code has class init checks (only in for_preload code)
+          _has_oop_maps:1,
+          _loaded:1,              // Code was loaded for use
+          _load_fail:1;           // Failed to load due to some klass state
+
+  uint   _id;          // Adapter's id, vmIntrinsic::ID for stub or Method's offset in AOTCache for nmethod
   uint   _offset;      // Offset to entry
   uint   _size;        // Entry size
-  uint   _name_offset; // Code blob name
+  uint   _name_offset; // Method's or intrinsic name
   uint   _name_size;
-  uint   _blob_offset; // Start of code in cache
-  bool   _has_oop_maps;
-  address _dumptime_content_start_addr; // CodeBlob::content_begin() at dump time; used for applying relocations
+  uint   _code_offset; // Start of code in cache
 
+  uint   _comp_level;  // compilation level
+  uint   _comp_id;     // compilation id
+  uint   _num_inlined_bytecodes;
+  uint   _inline_instructions_size; // size from training run
 public:
   AOTCodeEntry(Kind kind,         uint id,
                uint offset,       uint size,
                uint name_offset,  uint name_size,
-               uint blob_offset,  bool has_oop_maps,
-               address dumptime_content_start_addr) {
-    _next         = nullptr;
+               uint code_offset,  bool has_oop_maps,
+               uint comp_level = 0,
+               uint comp_id = 0,
+               bool has_clinit_barriers = false,
+               bool for_preload = false) {
     _kind         = kind;
+
+    _for_preload  = for_preload;
+    _has_clinit_barriers = has_clinit_barriers;
+    _has_oop_maps = has_oop_maps;
+    _loaded       = false;
+    _load_fail    = false;
+    _not_entrant  = false;
+
     _id           = id;
     _offset       = offset;
     _size         = size;
     _name_offset  = name_offset;
     _name_size    = name_size;
-    _blob_offset  = blob_offset;
-    _has_oop_maps = has_oop_maps;
-    _dumptime_content_start_addr = dumptime_content_start_addr;
+    _code_offset  = code_offset;
+
+    _comp_level   = comp_level;
+    _comp_id      = comp_id;
+    _num_inlined_bytecodes = 0;
+    _inline_instructions_size = 0;
   }
+
   void* operator new(size_t x, AOTCodeCache* cache);
   // Delete is a NOP
   void operator delete( void *ptr ) {}
 
-  AOTCodeEntry* next()        const { return _next; }
-  void set_next(AOTCodeEntry* next) { _next = next; }
+  Method* method();
 
   Kind kind()         const { return _kind; }
   uint id()           const { return _id; }
@@ -113,15 +158,38 @@ public:
   uint size()         const { return _size; }
   uint name_offset()  const { return _name_offset; }
   uint name_size()    const { return _name_size; }
-  uint blob_offset()  const { return _blob_offset; }
+  uint code_offset()  const { return _code_offset; }
+
   bool has_oop_maps() const { return _has_oop_maps; }
-  address dumptime_content_start_addr() const { return _dumptime_content_start_addr; }
+  uint num_inlined_bytecodes() const { return _num_inlined_bytecodes; }
+  void set_inlined_bytecodes(int bytes) { _num_inlined_bytecodes = bytes; }
+
+  uint inline_instructions_size() const { return _inline_instructions_size; }
+  void set_inline_instructions_size(int size) { _inline_instructions_size = size; }
+
+  uint comp_level()   const { return _comp_level; }
+  uint comp_id()      const { return _comp_id; }
+
+  bool has_clinit_barriers() const { return _has_clinit_barriers; }
+  bool for_preload()  const { return _for_preload; }
+  bool is_loaded()    const { return _loaded; }
+  void set_loaded()         { _loaded = true; }
+
+  bool not_entrant()  const { return _not_entrant; }
+  void set_not_entrant()    { _not_entrant = true; }
+  void set_entrant()        { _not_entrant = false; }
+
+  bool load_fail()  const { return _load_fail; }
+  void set_load_fail()    { _load_fail = true; }
+
+  void print(outputStream* st) const NOT_CDS_RETURN;
 
   static bool is_valid_entry_kind(Kind kind) { return kind > None && kind < Kind_count; }
   static bool is_blob(Kind kind) { return kind == SharedBlob || kind == C1Blob || kind == C2Blob || kind == StubGenBlob; }
   static bool is_single_stub_blob(Kind kind) { return kind == SharedBlob || kind == C1Blob || kind == C2Blob; }
   static bool is_multi_stub_blob(Kind kind) { return kind == StubGenBlob; }
   static bool is_adapter(Kind kind) { return kind == Adapter; }
+  bool is_nmethod() const { return _kind == Nmethod; }
 };
 
 // we use a hash table to speed up translation of external addresses
@@ -137,6 +205,8 @@ class AOTCodeAddressHashTable : public HashTable<
 // Addresses of stubs, blobs and runtime finctions called from compiled code.
 class AOTCodeAddressTable : public CHeapObj<mtCode> {
 private:
+  AOTCodeAddressHashTable* _hash_table;
+
   address* _extrs_addr;
   address* _stubs_addr;
   uint     _extrs_length;
@@ -146,11 +216,11 @@ private:
   bool _c1_stubs_complete;
   bool _c2_stubs_complete;
   bool _stubgen_stubs_complete;
-  AOTCodeAddressHashTable* _hash_table;
 
   void hash_address(address addr, int idx);
 public:
   AOTCodeAddressTable() :
+    _hash_table(nullptr),
     _extrs_addr(nullptr),
     _stubs_addr(nullptr),
     _extrs_length(0),
@@ -158,8 +228,7 @@ public:
     _shared_stubs_complete(false),
     _c1_stubs_complete(false),
     _c2_stubs_complete(false),
-    _stubgen_stubs_complete(false),
-    _hash_table(nullptr)
+    _stubgen_stubs_complete(false)
   { }
   void init_extrs();
   void init_extrs2();
@@ -283,6 +352,11 @@ public:
   do_var(bool,  EnableContended)                        /* nmethods */ \
   do_var(intx,  OptoLoopAlignment)                      /* array copy stubs and nmethods */ \
   do_var(bool,  RestrictContended)                      /* nmethods */ \
+  do_var(int,   ContendedPaddingWidth) \
+  do_var(int,   ObjectAlignmentInBytes) \
+  do_var(uint,  GCCardSizeInBytes) \
+  do_var(bool,  PreserveFramePointer) \
+  do_var(bool,  UseTLAB) \
   do_var(bool,  UseAESCTRIntrinsics) \
   do_var(bool,  UseAESIntrinsics) \
   do_var(bool,  UseBASE64Intrinsics) \
@@ -358,6 +432,21 @@ public:
 #define AOTCODECACHE_DECLARE_VAR(type, name) type _saved_ ## name;
 #define AOTCODECACHE_DECLARE_FUN(type, name, func) type _saved_ ## name;
 
+enum class DataKind: int {
+  No_Data   = -1,
+  Null      = 0,
+  Klass     = 1,
+  Method    = 2,
+  String    = 3,
+  MH_Oop    = 4,
+  Primitive = 5, // primitive Class object
+  SysLoader = 6, // java_system_loader
+  PlaLoader = 7, // java_platform_loader
+  MethodCnts= 8
+};
+
+struct AOTCodeEntryStats;
+
 class AOTCodeCache : public CHeapObj<mtCode> {
 
 // Classes used to describe AOT code cache.
@@ -367,7 +456,9 @@ protected:
 
     // Special configs that cannot be checked with macros
     address _compressedOopBase;
-    int _compressedOopShift;
+    int     _compressedOopShift;
+    address _compressedKlassBase;
+    size_t  _codeCacheSize;
 
 #if defined(X86) && !defined(ZERO)
     bool _useUnalignedLoadStores;
@@ -386,8 +477,9 @@ protected:
 
   class Header : public CHeapObj<mtCode> {
   private:
+    // Here should be version and other verification fields
     enum {
-      AOT_CODE_VERSION = 1
+      AOT_CODE_VERSION = 2
     };
     uint   _version;         // AOT code version (should match when reading code cache)
     uint   _cache_size;      // cache size in bytes
@@ -395,6 +487,9 @@ protected:
     uint   _strings_offset;  // offset to recorded C strings
     uint   _entries_count;   // number of recorded entries
     uint   _entries_offset;  // offset of AOTCodeEntry array describing entries
+    uint   _search_table_offset; // offset of table for looking up an AOTCodeEntry
+    uint   _preload_entries_count; // entries for pre-loading code
+    uint   _preload_entries_offset;
     uint   _adapters_count;
     uint   _shared_blobs_count;
     uint   _stubgen_blobs_count;
@@ -405,7 +500,8 @@ protected:
   public:
     void init(uint cache_size,
               uint strings_count,       uint strings_offset,
-              uint entries_count,       uint entries_offset,
+              uint entries_count,       uint entries_offset, uint search_table_offset,
+              uint preload_entries_count, uint preload_entries_offset,
               uint adapters_count,      uint shared_blobs_count,
               uint stubgen_blobs_count, uint C1_blobs_count,
               uint C2_blobs_count,      uint cpu_features_offset) {
@@ -415,6 +511,9 @@ protected:
       _strings_offset = strings_offset;
       _entries_count  = entries_count;
       _entries_offset = entries_offset;
+      _search_table_offset = search_table_offset;
+      _preload_entries_count  = preload_entries_count;
+      _preload_entries_offset = preload_entries_offset;
       _adapters_count = adapters_count;
       _shared_blobs_count = shared_blobs_count;
       _stubgen_blobs_count = stubgen_blobs_count;
@@ -423,18 +522,26 @@ protected:
       _config.record(cpu_features_offset);
     }
 
-
     uint cache_size()     const { return _cache_size; }
     uint strings_count()  const { return _strings_count; }
     uint strings_offset() const { return _strings_offset; }
     uint entries_count()  const { return _entries_count; }
     uint entries_offset() const { return _entries_offset; }
+    uint search_table_offset() const { return _search_table_offset; }
+    uint preload_entries_count()  const { return _preload_entries_count; }
+    uint preload_entries_offset() const { return _preload_entries_offset; }
     uint adapters_count() const { return _adapters_count; }
     uint stubgen_blobs_count()   const { return _stubgen_blobs_count; }
     uint shared_blobs_count()    const { return _shared_blobs_count; }
     uint C1_blobs_count() const { return _C1_blobs_count; }
     uint C2_blobs_count() const { return _C2_blobs_count; }
-
+    uint nmethods_count() const { return _preload_entries_count
+                                         + _entries_count
+                                         - _stubgen_blobs_count
+                                         - _shared_blobs_count
+                                         - _C1_blobs_count
+                                         - _C2_blobs_count
+                                         - _adapters_count; }
     bool verify(uint load_size)  const;
     bool verify_config(AOTCodeCache* cache) const { // Called after Universe initialized
       return _config.verify(cache);
@@ -444,8 +551,8 @@ protected:
 // Continue with AOTCodeCache class definition.
 private:
   Header* _load_header;
-  char*   _load_buffer;    // Aligned buffer for loading cached code
-  char*   _store_buffer;   // Aligned buffer for storing cached code
+  char*   _load_buffer;    // Aligned buffer for loading AOT code
+  char*   _store_buffer;   // Aligned buffer for storing AOT code
   char*   _C_store_buffer; // Original unaligned buffer
 
   uint   _write_position;  // Position in _store_buffer
@@ -456,13 +563,21 @@ private:
   bool   _failed;          // Failed read/write to/from cache (cache is broken?)
   bool   _lookup_failed;   // Failed to lookup for info (skip only this code load)
 
+  bool   _for_preload;         // Code for preload
+  bool   _has_clinit_barriers; // Code with clinit barriers
+
   AOTCodeAddressTable* _table;
 
   AOTCodeEntry* _load_entries;   // Used when reading cache
   uint*         _search_entries; // sorted by ID table [id, index]
   AOTCodeEntry* _store_entries;  // Used when writing cache
   const char*   _C_strings_buf;  // Loaded buffer for _C_strings[] table
-  uint          _store_entries_cnt;
+  uint          _store_entries_cnt; // total entries count
+
+  uint _compile_id;
+  uint _comp_level;
+  uint compile_id() const { return _compile_id; }
+  uint comp_level() const { return _comp_level; }
 
   static AOTCodeCache* open_for_use();
   static AOTCodeCache* open_for_dump();
@@ -490,6 +605,7 @@ public:
   bool failed() const { return _failed; }
   void set_failed()   { _failed = true; }
 
+  static bool is_address_in_aot_cache(address p) NOT_CDS_RETURN_(false);
   static uint max_aot_code_size();
 
   uint load_size() const { return _load_size; }
@@ -516,19 +632,40 @@ public:
     _store_entries -= 1;
     return _store_entries;
   }
+  void preload_aot_code(TRAPS);
 
-  AOTCodeEntry* find_entry(AOTCodeEntry::Kind kind, uint id);
+  AOTCodeEntry* find_entry(AOTCodeEntry::Kind kind, uint id, uint comp_level = 0);
+  void invalidate_entry(AOTCodeEntry* entry);
 
   void store_cpu_features(char*& buffer, uint buffer_size);
 
   bool finish_write();
 
-  bool write_relocations(CodeBlob& code_blob, RelocIterator& iter);
+  void log_stats_on_exit(AOTCodeEntryStats& stats);
+
+  bool write_klass(Klass* klass);
+  bool write_method(Method* method);
+
+  bool write_relocations(CodeBlob& code_blob, RelocIterator& iter,
+                         GrowableArray<Handle>* oop_list = nullptr,
+                         GrowableArray<Metadata*>* metadata_list = nullptr);
+
   bool write_oop_map_set(CodeBlob& cb);
+  bool write_nmethod_reloc_immediates(GrowableArray<Handle>& oop_list, GrowableArray<Metadata*>& metadata_list);
+
+  jobject read_oop(JavaThread* thread);
+  Metadata* read_metadata();
+
+  bool write_oop(jobject& jo);
+  bool write_oop(oop obj);
+  bool write_metadata(Metadata* m);
+  bool write_oops(nmethod* nm);
+  bool write_metadata(nmethod* nm);
   bool write_stub_data(CodeBlob& blob, AOTStubData *stub_data);
+
 #ifndef PRODUCT
-  bool write_asm_remarks(CodeBlob& cb);
-  bool write_dbg_strings(CodeBlob& cb);
+  bool write_asm_remarks(AsmRemarks& asm_remarks, bool use_string_table);
+  bool write_dbg_strings(DbgStrings& dbg_strings, bool use_string_table);
 #endif // PRODUCT
 
 private:
@@ -545,6 +682,8 @@ private:
                                   const char* name,
                                   AOTStubData* stub_data) NOT_CDS_RETURN_(nullptr);
 
+  AOTCodeEntry* write_nmethod(nmethod* nm, bool for_preload);
+
 public:
   // save and restore API for non-enumerable code blobs
   static bool store_code_blob(CodeBlob& blob,
@@ -554,6 +693,9 @@ public:
 
   static CodeBlob* load_code_blob(AOTCodeEntry::Kind kind,
                                   uint id, const char* name) NOT_CDS_RETURN_(nullptr);
+
+  static bool load_nmethod(ciEnv* env, ciMethod* target, int entry_bci, AbstractCompiler* compiler, CompLevel comp_level) NOT_CDS_RETURN_(false);
+  static AOTCodeEntry* store_nmethod(nmethod* nm, AbstractCompiler* compiler, bool for_preload) NOT_CDS_RETURN_(nullptr);
 
   // save and restore API for enumerable code blobs
 
@@ -595,7 +737,8 @@ private:
   DEBUG_ONLY( static bool _passed_init2; )
 
   static bool open_cache(bool is_dumping, bool is_using);
-  bool verify_config() {
+
+  bool verify_config_on_use() {
     if (for_use()) {
       return _load_header->verify_config(this);
     }
@@ -611,62 +754,101 @@ public:
   static void init2() NOT_CDS_RETURN;
   static void init3() NOT_CDS_RETURN;
   static void dump() NOT_CDS_RETURN;
+  static bool is_code_load_thread_on() NOT_CDS_RETURN_(false);
   static bool is_on() CDS_ONLY({ return cache() != nullptr; }) NOT_CDS_RETURN_(false);
   static bool is_on_for_use()  CDS_ONLY({ return is_on() && _cache->for_use(); }) NOT_CDS_RETURN_(false);
   static bool is_on_for_dump() CDS_ONLY({ return is_on() && _cache->for_dump(); }) NOT_CDS_RETURN_(false);
+  static bool is_dumping_code() NOT_CDS_RETURN_(false);
   static bool is_dumping_stub() NOT_CDS_RETURN_(false);
   static bool is_dumping_adapter() NOT_CDS_RETURN_(false);
+  static bool is_using_code() NOT_CDS_RETURN_(false);
   static bool is_using_stub() NOT_CDS_RETURN_(false);
   static bool is_using_adapter() NOT_CDS_RETURN_(false);
   static void enable_caching() NOT_CDS_RETURN;
   static void disable_caching() NOT_CDS_RETURN;
   static bool is_caching_enabled() NOT_CDS_RETURN_(false);
 
+  // It is used before AOTCodeCache is initialized.
+  static bool maybe_dumping_code() NOT_CDS_RETURN_(false);
+
+  static void invalidate(AOTCodeEntry* entry) NOT_CDS_RETURN;
+  static AOTCodeEntry* find_code_entry(const methodHandle& method, uint comp_level) NOT_CDS_RETURN_(nullptr);
+  static void preload_code(JavaThread* thread) NOT_CDS_RETURN;
+
   static const char* add_C_string(const char* str) NOT_CDS_RETURN_(str);
 
   static void print_on(outputStream* st) NOT_CDS_RETURN;
+  static void print_statistics_on(outputStream* st) NOT_CDS_RETURN;
+  static void print_timers_on(outputStream* st) NOT_CDS_RETURN;
 };
 
 // Concurent AOT code reader
 class AOTCodeReader {
 private:
   AOTCodeCache*  _cache;
-  const AOTCodeEntry*  _entry;
-  const char*          _load_buffer; // Loaded cached code buffer
-  uint  _read_position;              // Position in _load_buffer
+  AOTCodeEntry*  _entry;
+  const char*    _load_buffer; // Loaded cached code buffer
+  uint  _read_position;        // Position in _load_buffer
   uint  read_position() const { return _read_position; }
   void  set_read_position(uint pos);
   uint  align_read_int();
+
+  // convenience method to convert offset in AOTCodeEntry data to its address
   const char* addr(uint offset) const { return _load_buffer + offset; }
 
-  bool _lookup_failed;       // Failed to lookup for info (skip only this code load)
-  void set_lookup_failed()     { _lookup_failed = true; }
-  void clear_lookup_failed()   { _lookup_failed = false; }
-  bool lookup_failed()   const { return _lookup_failed; }
+  uint _compile_id;
+  uint _comp_level;
+  uint compile_id() const { return _compile_id; }
+  uint comp_level() const { return _comp_level; }
+
+  bool _preload;             // Preloading code before method execution
 
   // Values used by restore(code_blob).
   // They should be set before calling it.
-  const char*         _name;
-  address             _reloc_data;
-  int                 _reloc_count;
-  ImmutableOopMapSet* _oop_maps;
   AOTCodeEntry::Kind  _entry_kind;
   int                 _id;
   AOTStubData*        _stub_data;
 
-  AOTCodeEntry* aot_code_entry() { return (AOTCodeEntry*)_entry; }
+  const char*         _name;
+  address             _reloc_data;
+  int                 _reloc_count;
+  ImmutableOopMapSet* _oop_maps;
+  address             _immutable_data;
+  GrowableArray<Handle>*    _oop_list;
+  GrowableArray<Metadata*>* _metadata_list;
+  GrowableArray<Handle>*    _reloc_imm_oop_list;
+  GrowableArray<Metadata*>* _reloc_imm_metadata_list;
+
+  const char* _failure;  // Failed to lookup for info (skip only this code load)
+  void set_lookup_failed(const char* failure) { _failure = failure; }
+  bool lookup_failed() const { return _failure != nullptr; }
+  const char* lookup_failure() const { return _failure; }
+
+  Klass* read_klass();
+  Method* read_method();
+
+  oop read_oop(JavaThread* thread);
+  Metadata* read_metadata();
+  bool read_metadata(OopRecorder* oop_recorder);
+
+  bool read_oop_metadata_list(JavaThread* thread, GrowableArray<Handle> &oop_list, GrowableArray<Metadata*> &metadata_list, OopRecorder* oop_recorder);
 
   ImmutableOopMapSet* read_oop_map_set();
   void read_stub_data(CodeBlob* code_blob, AOTStubData *stub_data);
 
-  void fix_relocations(CodeBlob* code_blob, RelocIterator& iter);
+  void fix_relocations(CodeBlob* code_blob, RelocIterator& iter,
+                       GrowableArray<Handle>* oop_list = nullptr,
+                       GrowableArray<Metadata*>* metadata_list = nullptr) NOT_CDS_RETURN;
+
 #ifndef PRODUCT
-  void read_asm_remarks(AsmRemarks& asm_remarks);
-  void read_dbg_strings(DbgStrings& dbg_strings);
+  void read_asm_remarks(AsmRemarks& asm_remarks, bool use_string_table) NOT_CDS_RETURN;
+  void read_dbg_strings(DbgStrings& dbg_strings, bool use_string_table) NOT_CDS_RETURN;
 #endif // PRODUCT
 
 public:
-  AOTCodeReader(AOTCodeCache* cache, AOTCodeEntry* entry);
+  AOTCodeReader(AOTCodeCache* cache, AOTCodeEntry* entry, CompileTask* task);
+
+  bool compile_nmethod(ciEnv* env, ciMethod* target, AbstractCompiler* compiler);
 
   CodeBlob* compile_code_blob(const char* name, AOTCodeEntry::Kind entry_kind, int id, AOTStubData* stub_data = nullptr);
 

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -192,6 +192,12 @@ CodeBlob::CodeBlob(const char* name, CodeBlobKind kind, int size, uint16_t heade
   assert(_mutable_data == blob_end(), "sanity");
 }
 
+#ifdef ASSERT
+CodeBlob::~CodeBlob() {
+  assert(_oop_maps == nullptr || AOTCodeCache::is_address_in_aot_cache((address)_oop_maps), "Not flushed");
+}
+#endif
+
 void CodeBlob::purge() {
   assert(_mutable_data != nullptr, "should never be null");
   if (_mutable_data != blob_end()) {
@@ -200,7 +206,7 @@ void CodeBlob::purge() {
     _mutable_data_size = 0;
     _relocation_size = 0;
   }
-  if (_oop_maps != nullptr) {
+  if (_oop_maps != nullptr && !AOTCodeCache::is_address_in_aot_cache((address)_oop_maps)) {
     delete _oop_maps;
     _oop_maps = nullptr;
   }
@@ -250,8 +256,8 @@ void CodeBlob::prepare_for_archiving_impl() {
   _oop_maps = nullptr;
   _mutable_data = nullptr;
 #ifndef PRODUCT
-  asm_remarks().clear();
-  dbg_strings().clear();
+  asm_remarks().clear_ref();
+  dbg_strings().clear_ref();
 #endif /* PRODUCT */
 }
 

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -174,9 +174,7 @@ protected:
 
 public:
 
-  ~CodeBlob() {
-    assert(_oop_maps == nullptr, "Not flushed");
-  }
+  ~CodeBlob() NOT_DEBUG_RETURN;
 
   // Returns the space needed for CodeBlob
   static unsigned int allocation_size(CodeBuffer* cb, int header_size);

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include "code/aotCodeCache.hpp"
 #include "code/codeBlob.hpp"
 #include "code/codeCache.hpp"
 #include "code/codeHeapState.hpp"
@@ -238,6 +239,19 @@ void CodeCache::initialize_heaps() {
     vm_exit_during_initialization(msg);
   }
   size_t compiler_buffer_size = integer_cast_permit_tautology<size_t>(compiler_buffer_size_uint64);
+
+  // During AOT assembly phase more compiler threads are used
+  // and C2 temp buffer is bigger.
+  // But due to rounding issue the total code cache size could be smaller
+  // than during production run. We can not use AOT code in such case
+  // because branch and call instructions will be incorrect.
+  //
+  // Increase code cache size to guarantee that total size
+  // will be bigger during assembly phase.
+  if (AOTCodeCache::maybe_dumping_code()) {
+    cache_size += align_up(compiler_buffer_size, min_size);
+    cache_size = MIN2(cache_size, CODE_CACHE_SIZE_LIMIT);
+  }
 
   if (!non_nmethod.set) {
     non_nmethod.size += compiler_buffer_size;
@@ -1162,8 +1176,8 @@ size_t CodeCache::max_distance_to_non_nmethod() {
     CodeHeap* blob = get_code_heap(CodeBlobType::NonNMethod);
     // the max distance is minimized by placing the NonNMethod segment
     // in between MethodProfiled and MethodNonProfiled segments
-    size_t dist1 = (size_t)blob->high() - (size_t)_low_bound;
-    size_t dist2 = (size_t)_high_bound - (size_t)blob->low();
+    size_t dist1 = (size_t)blob->high_boundary() - (size_t)_low_bound;
+    size_t dist2 = (size_t)_high_bound - (size_t)blob->low_boundary();
     return dist1 > dist2 ? dist1 : dist2;
   }
 }
@@ -1308,11 +1322,12 @@ static void check_live_nmethods_dependencies(DepChange& changes) {
         // Determine if dependency is already checked. table->put(...) returns
         // 'true' if the dependency is added (i.e., was not in the hashtable).
         if (table->put(*current_sig, 1)) {
-          if (deps.check_dependency() != nullptr) {
+          Klass* witness = deps.check_dependency();
+          if (witness != nullptr) {
             // Dependency checking failed. Print out information about the failed
             // dependency and finally fail with an assert. We can fail here, since
             // dependency checking is never done in a product build.
-            tty->print_cr("Failed dependency:");
+            deps.print_dependency(tty, witness, true);
             changes.print();
             nm->print();
             nm->print_dependencies_on(tty);
@@ -1338,6 +1353,13 @@ void CodeCache::mark_for_deoptimization(DeoptimizationScope* deopt_scope, KlassD
   NoSafepointVerifier nsv;
   for (DepChange::ContextStream str(changes, nsv); str.next(); ) {
     InstanceKlass* d = str.klass();
+    {
+      LogStreamHandle(Trace, dependencies) log;
+      if (log.is_enabled()) {
+        log.print("Processing context ");
+        d->name()->print_value_on(&log);
+      }
+    }
     d->mark_dependent_nmethods(deopt_scope, changes);
   }
 
@@ -1634,20 +1656,16 @@ void CodeCache::print_internals() {
 
   int i = 0;
   FOR_ALL_ALLOCABLE_HEAPS(heap) {
-    if ((_nmethod_heaps->length() >= 1) && Verbose) {
-      tty->print_cr("-- %s --", (*heap)->name());
-    }
+    int heap_total = 0;
+    tty->print_cr("-- %s --", (*heap)->name());
     FOR_ALL_BLOBS(cb, *heap) {
       total++;
+      heap_total++;
       if (cb->is_nmethod()) {
         nmethod* nm = (nmethod*)cb;
 
-        if (Verbose && nm->method() != nullptr) {
-          ResourceMark rm;
-          char *method_name = nm->method()->name_and_sig_as_C_string();
-          tty->print("%s", method_name);
-          if(nm->is_not_entrant()) { tty->print_cr(" not-entrant"); }
-        }
+        tty->print("%4d: ", heap_total);
+        CompileTask::print(tty, nm, (nm->is_not_entrant() ? "non-entrant" : ""), true, true);
 
         nmethodCount++;
 

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -598,9 +598,13 @@ void Dependencies::print_dependency(DepType dept, GrowableArray<DepArgument>* ar
   }
   if (witness != nullptr) {
     bool put_star = !Dependencies::is_concrete_klass(witness);
-    st->print_cr("  witness = %s%s",
-                  (put_star? "*": ""),
-                  witness->external_name());
+    st->print("  witness = %s%s",
+              (put_star ? "*": ""),
+              witness->external_name());
+    if (witness->is_instance_klass()) {
+      st->print(" (%s)", InstanceKlass::cast(witness)->init_state_name());
+    }
+    st->cr();
   }
 }
 

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -346,6 +346,12 @@ class Dependencies: public ResourceObj {
     return _size_in_bytes;
   }
 
+  void set_content(address content_bytes, int size_in_bytes) {
+    assert(_content_bytes == nullptr, "not intialized expected");
+    _content_bytes = content_bytes;
+    _size_in_bytes = size_in_bytes;
+  }
+
   OopRecorder* oop_recorder() { return _oop_recorder; }
   CompileLog*  log()          { return _log; }
 

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -24,6 +24,7 @@
 
 #include "asm/assembler.inline.hpp"
 #include "cds/cdsConfig.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/codeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "code/dependencies.hpp"
@@ -56,6 +57,7 @@
 #include "oops/method.inline.hpp"
 #include "oops/methodData.hpp"
 #include "oops/oop.inline.hpp"
+#include "oops/trainingData.hpp"
 #include "oops/weakHandle.inline.hpp"
 #include "prims/jvmtiImpl.hpp"
 #include "prims/jvmtiThreadState.hpp"
@@ -972,14 +974,17 @@ int nmethod::total_size() const {
 }
 
 const char* nmethod::compile_kind() const {
-  if (is_osr_method())     return "osr";
+  if (is_osr_method()) return "osr";
+  if (preloaded())     return "AP";
+  if (is_aot())        return "A";
+
   if (method() != nullptr && is_native_method()) {
     if (method()->is_continuation_native_intrinsic()) {
       return "cnt";
     }
     return "c2n";
   }
-  return nullptr;
+  return "";
 }
 
 const char* nmethod::compiler_name() const {
@@ -1076,6 +1081,31 @@ nmethod* nmethod::new_native_nmethod(const methodHandle& method,
   return nm;
 }
 
+void nmethod::record_nmethod_dependency() {
+  // To make dependency checking during class loading fast, record
+  // the nmethod dependencies in the classes it is dependent on.
+  // This allows the dependency checking code to simply walk the
+  // class hierarchy above the loaded class, checking only nmethods
+  // which are dependent on those classes.  The slow way is to
+  // check every nmethod for dependencies which makes it linear in
+  // the number of methods compiled.  For applications with a lot
+  // classes the slow way is too slow.
+  for (Dependencies::DepStream deps(this); deps.next(); ) {
+    if (deps.type() == Dependencies::call_site_target_value) {
+      // CallSite dependencies are managed on per-CallSite instance basis.
+      oop call_site = deps.argument_oop(0);
+      MethodHandles::add_dependent_nmethod(call_site, this);
+    } else {
+      InstanceKlass* ik = deps.context_type();
+      if (ik == nullptr) {
+        continue;  // ignore things like evol_method
+      }
+      // record this nmethod as dependent on this klass
+      ik->add_dependent_nmethod(this);
+    }
+  }
+}
+
 nmethod* nmethod::new_nmethod(const methodHandle& method,
   int compile_id,
   int entry_bci,
@@ -1127,29 +1157,8 @@ nmethod* nmethod::new_nmethod(const methodHandle& method,
             handler_table, nul_chk_table, compiler, comp_level, flags);
 
     if (nm != nullptr) {
-      // To make dependency checking during class loading fast, record
-      // the nmethod dependencies in the classes it is dependent on.
-      // This allows the dependency checking code to simply walk the
-      // class hierarchy above the loaded class, checking only nmethods
-      // which are dependent on those classes.  The slow way is to
-      // check every nmethod for dependencies which makes it linear in
-      // the number of methods compiled.  For applications with a lot
-      // classes the slow way is too slow.
-      for (Dependencies::DepStream deps(nm); deps.next(); ) {
-        if (deps.type() == Dependencies::call_site_target_value) {
-          // CallSite dependencies are managed on per-CallSite instance basis.
-          oop call_site = deps.argument_oop(0);
-          MethodHandles::add_dependent_nmethod(call_site, nm);
-        } else {
-          InstanceKlass* ik = deps.context_type();
-          if (ik == nullptr) {
-            continue;  // ignore things like evol_method
-          }
-          // record this nmethod as dependent on this klass
-          ik->add_dependent_nmethod(nm);
-        }
-      }
-      NOT_PRODUCT(if (nm != nullptr)  note_java_nmethod(nm));
+      nm->record_nmethod_dependency();
+      NOT_PRODUCT(note_java_nmethod(nm));
     }
   }
   // Do verification and logging outside CodeCache_lock.
@@ -1161,6 +1170,52 @@ nmethod* nmethod::new_nmethod(const methodHandle& method,
   return nm;
 }
 
+#if INCLUDE_CDS
+nmethod* nmethod::restore(address code_cache_buffer,
+                          const methodHandle& method,
+                          AOTCodeReader* aot_code_reader)
+{
+  // This will call AOTCodeReader::restore() which restores some nmethods data
+  CodeBlob::restore(code_cache_buffer, aot_code_reader);
+  nmethod* nm = (nmethod*)code_cache_buffer;
+  nm->set_method(method());
+  nm->_gc_epoch = CodeCache::gc_epoch();
+
+  // Create cache after PcDesc data is copied - it will be used to initialize cache
+  nm->_pc_desc_container = new PcDescContainer(nm->scopes_pcs_begin());
+
+  nm->post_init();
+  return nm;
+}
+
+nmethod* nmethod::new_nmethod(nmethod* archived_nm,
+                              const methodHandle& method,
+                              AbstractCompiler* compiler,
+                              AOTCodeReader* aot_code_reader)
+{
+  nmethod* nm = nullptr;
+  int nmethod_size = archived_nm->size();
+  int comp_level   = archived_nm->comp_level();
+  // create nmethod
+  {
+    MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
+    address code_cache_buffer = (address)CodeCache::allocate(nmethod_size, CodeCache::get_code_blob_type(comp_level));
+    if (code_cache_buffer != nullptr) {
+      nm = archived_nm->restore(code_cache_buffer, method, aot_code_reader);
+      nm->record_nmethod_dependency();
+      NOT_PRODUCT(note_java_nmethod(nm));
+    }
+  }
+  // Do verification and logging outside CodeCache_lock.
+  if (nm != nullptr) {
+    // Safepoints in nmethod::verify aren't allowed because nm hasn't been installed yet.
+    DEBUG_ONLY(nm->verify();)
+    nm->log_new_nmethod();
+  }
+  return nm;
+}
+#endif // INCLUDE_CDS
+
 // Fill in default values for various fields
 void nmethod::init_defaults(CodeBuffer *code_buffer, CodeOffsets* offsets) {
   // avoid uninitialized fields, even for short time periods
@@ -1168,6 +1223,7 @@ void nmethod::init_defaults(CodeBuffer *code_buffer, CodeOffsets* offsets) {
   _gc_data                    = nullptr;
   _oops_do_mark_link          = nullptr;
   _compiled_ic_data           = nullptr;
+  _aot_code_entry             = nullptr;
 
   _is_unloading_state         = 0;
   _state                      = not_installed;
@@ -1175,6 +1231,7 @@ void nmethod::init_defaults(CodeBuffer *code_buffer, CodeOffsets* offsets) {
   _has_flushed_dependencies   = false;
   _is_unlinked                = false;
   _load_reported              = false; // jvmti state
+  _preloaded                  = false;
 
   _deoptimization_status      = not_marked;
 
@@ -1199,6 +1256,7 @@ void nmethod::post_init() {
   // Flush generated code
   ICache::invalidate_range(code_begin(), code_size());
 
+  // This will disarm entry barrier.
   Universe::heap()->register_nmethod(this);
 
 #ifdef COMPILER2
@@ -1309,7 +1367,7 @@ nmethod::nmethod(
 #if defined(SUPPORT_DATA_STRUCTS)
     if (AbstractDisassembler::show_structs()) {
       if (PrintRelocations) {
-        print_relocations();
+        print_relocations_on(tty);
         tty->print_cr("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
       }
     }
@@ -1374,6 +1432,7 @@ nmethod::nmethod(const nmethod &nm) : CodeBlob(nm._name, nm._kind, nm._size, nm.
   _oops_do_mark_nmethods        = nullptr;
   _oops_do_mark_link            = nullptr;
   _compiled_ic_data             = nullptr;
+  _aot_code_entry               = nm._aot_code_entry;
 
   if (nm._osr_entry_point != nullptr) {
     _osr_entry_point            = (nm._osr_entry_point - (address) &nm) + (address) this;
@@ -1416,6 +1475,7 @@ nmethod::nmethod(const nmethod &nm) : CodeBlob(nm._name, nm._kind, nm._size, nm.
   _has_flushed_dependencies     = nm._has_flushed_dependencies;
   _is_unlinked                  = nm._is_unlinked;
   _load_reported                = nm._load_reported;
+  _preloaded                    = nm._preloaded;
 
   _deoptimization_status        = nm._deoptimization_status;
 
@@ -1550,6 +1610,10 @@ bool nmethod::is_relocatable() {
   }
 
   if (is_osr_method()) {
+    return false;
+  }
+
+  if (is_aot()) {
     return false;
   }
 
@@ -1713,7 +1777,7 @@ nmethod::nmethod(
 void nmethod::log_identity(xmlStream* log) const {
   log->print(" compile_id='%d'", compile_id());
   const char* nm_kind = compile_kind();
-  if (nm_kind != nullptr)  log->print(" compile_kind='%s'", nm_kind);
+  log->print(" compile_kind='%s'", nm_kind);
   log->print(" compiler='%s'", compiler_name());
   if (TieredCompilation) {
     log->print(" level='%d'", comp_level());
@@ -1857,7 +1921,7 @@ void nmethod::print_nmethod(bool printmethod) {
       tty->print_cr("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
     }
     if (printmethod || PrintRelocations || CompilerOracle::has_option(mh, CompileCommandEnum::PrintRelocations)) {
-      print_relocations();
+      print_relocations_on(tty);
       tty->print_cr("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
     }
     if (printmethod || PrintDependencies || CompilerOracle::has_option(mh, CompileCommandEnum::PrintDependencies)) {
@@ -1897,6 +1961,14 @@ inline void nmethod::initialize_immediate_oop(oop* dest, jobject handle) {
   }
 }
 
+void nmethod::copy_values(GrowableArray<Handle>* array) {
+  int length = array->length();
+  assert((address)(oops_begin() + length) <= (address)oops_end(), "oops big enough");
+  oop* dest = oops_begin();
+  for (int index = 0 ; index < length; index++) {
+    dest[index] = array->at(index)();
+  }
+}
 
 // Have to have the same name because it's called by a template
 void nmethod::copy_values(GrowableArray<jobject>* array) {
@@ -1959,6 +2031,26 @@ void nmethod::fix_oop_relocations(ICacheInvalidationContext* icic) {
   bool modified_code = fix_oop_relocations(/*initialize_immediates=*/ false);
   if (modified_code) {
     icic->set_has_modified_code();
+  }
+}
+
+void nmethod::create_reloc_immediates_list(JavaThread* thread, GrowableArray<Handle>& oop_list, GrowableArray<Metadata*>& metadata_list) {
+  RelocIterator iter(this);
+  while (iter.next()) {
+    if (iter.type() == relocInfo::oop_type) {
+      oop_Relocation* reloc = iter.oop_reloc();
+      if (reloc->oop_is_immediate()) {
+        oop dest = reloc->oop_value();
+        Handle h(thread, dest);
+        oop_list.append(h);
+      }
+    } else if (iter.type() == relocInfo::metadata_type) {
+      metadata_Relocation* reloc = iter.metadata_reloc();
+      if (reloc->metadata_is_immediate()) {
+        Metadata* m = reloc->metadata_value();
+        metadata_list.append(m);
+      }
+    }
   }
 }
 
@@ -2178,7 +2270,7 @@ void nmethod::unlink_from_method() {
 }
 
 // Invalidate code
-bool nmethod::make_not_entrant(InvalidationReason invalidation_reason) {
+bool nmethod::make_not_entrant(InvalidationReason invalidation_reason, bool keep_aot_entry) {
   // This can be called while the system is already at a safepoint which is ok
   NoSafepointVerifier nsv;
 
@@ -2242,6 +2334,13 @@ bool nmethod::make_not_entrant(InvalidationReason invalidation_reason) {
     // Remove nmethod from method.
     unlink_from_method();
 
+    if (!keep_aot_entry) {
+      // Keep AOT code if it was simply replaced
+      // otherwise make it not entrant too.
+      AOTCodeCache::invalidate(_aot_code_entry);
+    }
+
+    CompileBroker::log_not_entrant(this);
   } // leave critical region under NMethodState_lock
 
 #ifdef ASSERT
@@ -2288,7 +2387,7 @@ void nmethod::purge(bool unregister_nmethod) {
   MutexLocker ml(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
   // completely deallocate this method
-  Events::log_nmethod_flush(Thread::current(), "flushing %s nmethod " INTPTR_FORMAT, is_osr_method() ? "osr" : "", p2i(this));
+  Events::log_nmethod_flush(Thread::current(), "flushing %s nmethod " INTPTR_FORMAT, compile_kind(), p2i(this));
 
   LogTarget(Debug, codecache) lt;
   if (lt.is_enabled()) {
@@ -2297,9 +2396,9 @@ void nmethod::purge(bool unregister_nmethod) {
     const char* method_name = method()->name()->as_C_string();
     const size_t codecache_capacity = CodeCache::capacity()/1024;
     const size_t codecache_free_space = CodeCache::unallocated_capacity(CodeCache::get_code_blob_type(this))/1024;
-    ls.print("Flushing nmethod %6d/" INTPTR_FORMAT ", level=%d, osr=%d, cold=%d, epoch=" UINT64_FORMAT ", cold_count=" UINT64_FORMAT ". "
+    ls.print("Flushing %s nmethod %6d/" INTPTR_FORMAT ", level=%d, cold=%d, epoch=" UINT64_FORMAT ", cold_count=" UINT64_FORMAT ". "
               "Cache capacity: %zuKb, free space: %zuKb. method %s (%s)",
-              _compile_id, p2i(this), _comp_level, is_osr_method(), is_cold(), _gc_epoch, CodeCache::cold_gc_count(),
+              compile_kind(), _compile_id, p2i(this), _comp_level, is_cold(), _gc_epoch, CodeCache::cold_gc_count(),
               codecache_capacity, codecache_free_space, method_name, compiler_name());
   }
 
@@ -2315,9 +2414,11 @@ void nmethod::purge(bool unregister_nmethod) {
   if (_pc_desc_container != nullptr) {
     delete _pc_desc_container;
   }
-  delete[] _compiled_ic_data;
+  if (_compiled_ic_data != nullptr) {
+    delete[] _compiled_ic_data;
+  }
 
-  if (_immutable_data != blob_end()) {
+  if (_immutable_data != blob_end() && !AOTCodeCache::is_address_in_aot_cache((address)_oop_maps)) {
     // Free memory if this was the last nmethod referencing immutable data
     if (dec_immutable_data_ref_count() == 0) {
       os::free(_immutable_data);
@@ -2387,6 +2488,21 @@ void nmethod::post_compiled_method(CompileTask* task) {
   task->set_nm_content_size(content_size());
   task->set_nm_insts_size(insts_size());
   task->set_nm_total_size(total_size());
+
+  CompileTrainingData* ctd = task->training_data();
+  if (ctd != nullptr) {
+    // Record inline code size during training to help inlining during production run
+    assert(TrainingData::need_data(), "should be called only during training"); // training run
+    int inline_size = inline_instructions_size();
+    if (inline_size < 0) inline_size = 0;
+    ctd->set_inline_instructions_size(inline_size);
+  }
+
+  // task->is_aot_load() is true only for loaded AOT code.
+  // nmethod::_aot_code_entry is set for loaded and stored AOT code
+  // to invalidate the entry when nmethod is deoptimized.
+  // VerifyAOTCode is option to not store in archive AOT code.
+  guarantee((_aot_code_entry != nullptr) || !task->is_aot_load() || VerifyAOTCode, "sanity");
 
   // JVMTI -- compiled method notification (must be done outside lock)
   post_compiled_method_load_event();
@@ -3146,9 +3262,13 @@ void nmethod::verify() {
     fatal("find_nmethod did not find this nmethod (" INTPTR_FORMAT ")", p2i(this));
   }
 
-  for (PcDesc* p = scopes_pcs_begin(); p < scopes_pcs_end(); p++) {
-    if (! p->verify(this)) {
-      tty->print_cr("\t\tin nmethod at " INTPTR_FORMAT " (pcs)", p2i(this));
+  // Verification can triggered during shutdown after AOTCodeCache is closed.
+  // If the Scopes data is in the AOT code cache, then we should avoid verification during shutdown.
+  if (!is_aot() || AOTCodeCache::is_on()) {
+    for (PcDesc* p = scopes_pcs_begin(); p < scopes_pcs_end(); p++) {
+      if (! p->verify(this)) {
+        tty->print_cr("\t\tin nmethod at " INTPTR_FORMAT " (pcs)", p2i(this));
+      }
     }
   }
 
@@ -3159,7 +3279,9 @@ void nmethod::verify() {
 
   assert(_oops_do_mark_link == nullptr, "_oops_do_mark_link for %s should be nullptr but is " PTR_FORMAT,
          nm->method()->external_name(), p2i(_oops_do_mark_link));
-  verify_scopes();
+  if (!is_aot() || AOTCodeCache::is_on()) {
+    verify_scopes();
+  }
 
   CompiledICLocker nm_verify(this);
   VerifyMetadataClosure vmc;
@@ -3314,6 +3436,9 @@ void nmethod::print_on_impl(outputStream* st) const {
                                              p2i(scopes_data_begin()),
                                              p2i(scopes_data_end()),
                                              scopes_data_size());
+  if (AOTCodeCache::is_on() && _aot_code_entry != nullptr) {
+    _aot_code_entry->print(st);
+  }
 }
 
 void nmethod::print_code() {
@@ -3413,11 +3538,11 @@ void nmethod::print_scopes_on(outputStream* st) {
 #endif
 
 #ifndef PRODUCT  // RelocIterator does support printing only then.
-void nmethod::print_relocations() {
+void nmethod::print_relocations_on(outputStream* st) {
   ResourceMark m;       // in case methods get printed via the debugger
-  tty->print_cr("relocations:");
+  st->print_cr("relocations:");
   RelocIterator iter(this);
-  iter.print_on(tty);
+  iter.print_on(st);
 }
 #endif
 
@@ -4242,3 +4367,22 @@ void nmethod::print_statistics() {
 }
 
 #endif // !PRODUCT
+
+void nmethod::prepare_for_archiving_impl() {
+  CodeBlob::prepare_for_archiving_impl();
+  _deoptimization_generation = 0;
+  _gc_epoch = 0;
+  _osr_link = nullptr;
+  _method = nullptr;
+  _immutable_data = nullptr;
+  _pc_desc_container = nullptr;
+  _exception_cache = nullptr;
+  _gc_data = nullptr;
+  _oops_do_mark_link = nullptr;
+  _compiled_ic_data = nullptr;
+  _osr_entry_point = nullptr;
+  _compile_id = -1;
+  _deoptimization_status = not_marked;
+  _is_unloading_state = 0;
+  _state = not_installed;
+}

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -47,6 +47,8 @@ class JvmtiThreadState;
 class MetadataClosure;
 class NativeCallWrapper;
 class OopIterateClosure;
+class AOTCodeReader;
+class AOTCodeEntry;
 class ScopeDesc;
 class xmlStream;
 
@@ -204,6 +206,8 @@ class nmethod : public CodeBlob {
 
   CompiledICData* _compiled_ic_data;
 
+  AOTCodeEntry* _aot_code_entry;
+
   // offsets for entry points
   address  _osr_entry_point;       // entry point for on stack replacement
   uint16_t _entry_offset;          // entry point with class check
@@ -257,15 +261,21 @@ public:
       UNSAFE_ACCESS = 1 << 0,
       WIDE_VECTORS  = 1 << 1,
       MONITORS      = 1 << 2,
-      SCOPED_ACCESS = 1 << 3
+      SCOPED_ACCESS = 1 << 3,
+      CLINIT_BARRIERS = 1 << 4
     };
 
     Flags() : _bits(0) {}
-    Flags(bool has_unsafe_access, bool has_wide_vectors, bool has_monitors, bool has_scoped_access) :
+    Flags(bool has_unsafe_access,
+          bool has_wide_vectors,
+          bool has_monitors,
+          bool has_scoped_access,
+          bool has_clinit_barriers) :
       _bits((has_unsafe_access ? UNSAFE_ACCESS : 0) |
             (has_wide_vectors  ? WIDE_VECTORS  : 0) |
             (has_monitors      ? MONITORS      : 0) |
-            (has_scoped_access ? SCOPED_ACCESS : 0))
+            (has_scoped_access ? SCOPED_ACCESS : 0) |
+            (has_clinit_barriers ? CLINIT_BARRIERS : 0))
     {}
 
     // May fault due to unsafe access
@@ -279,6 +289,9 @@ public:
 
     // Used by shared scope closure (scopedMemoryAccess.cpp)
     bool has_scoped_access() const { return (_bits & SCOPED_ACCESS) != 0; }
+
+    // AOT preload code has clinit barriers
+    bool has_clinit_barriers() const {  return (_bits & CLINIT_BARRIERS) != 0; }
   };
 
 private:
@@ -293,6 +306,9 @@ private:
 
   // Used by JVMTI to track if an event has been posted for this nmethod
   bool _load_reported;
+
+  // This AOT code was preloaded before method is called
+  bool _preloaded;
 
   enum DeoptimizationStatus : u1 {
     not_marked,
@@ -486,6 +502,19 @@ private:
   // transitions).
   void oops_do_set_strong_done(nmethod* old_head);
 
+  void record_nmethod_dependency();
+#if INCLUDE_CDS
+  nmethod* restore(address code_cache_buffer,
+                   const methodHandle& method,
+                   AOTCodeReader* aot_code_reader);
+
+public:
+  // create nmethod using archived nmethod from AOT code cache
+  static nmethod* new_nmethod(nmethod* archived_nm,
+                              const methodHandle& method,
+                              AbstractCompiler* compiler,
+                              AOTCodeReader* aot_code_reader);
+#endif
 public:
   enum class InvalidationReason : s1 {
     NOT_INVALIDATED = -1,
@@ -587,10 +616,12 @@ public:
                                      int exception_handler = -1);
 
   Method* method       () const { return _method; }
+  uint16_t entry_bci   () const { return _entry_bci; }
   bool is_native_method() const { return _method != nullptr && _method->is_native(); }
   bool is_java_method  () const { return _method != nullptr && !_method->is_native(); }
   bool is_osr_method   () const { return _entry_bci != InvocationEntryBci; }
 
+  int  orig_pc_offset() { return _orig_pc_offset; }
   bool is_relocatable();
 
   // Compiler task identification.  Note that all OSR methods
@@ -598,6 +629,8 @@ public:
   // and native method wrappers are also numbered independently if
   // CICountNative is true.
   int compile_id() const { return _compile_id; }
+  void set_compile_id(int compile_id) { _compile_id = compile_id; }
+  int comp_level() const { return _comp_level; }
   const char* compile_kind() const;
 
   inline bool  is_compiled_by_c1   () const { return _compiler_type == compiler_c1; }
@@ -638,6 +671,8 @@ public:
   address scopes_data_end       () const { return           _immutable_data + _immutable_data_ref_count_offset ; }
   address immutable_data_ref_count_begin () const { return  _immutable_data + _immutable_data_ref_count_offset ; }
 
+  void set_immutable_data(address data) { _immutable_data = data; }
+
   // Sizes
   int immutable_data_size() const { return _immutable_data_size; }
   int consts_size        () const { return int(          consts_end       () -           consts_begin       ()); }
@@ -675,6 +710,8 @@ public:
   address entry_point() const          { return code_begin() + _entry_offset;          } // normal entry point
   address verified_entry_point() const { return code_begin() + _verified_entry_offset; } // if klass is correct
 
+  int inline_instructions_size() const { return insts_end() - verified_entry_point() - skipped_instructions_size(); }
+
   enum : signed char { not_installed = -1, // in construction, only the owner doing the construction is
                                            // allowed to advance state
                        in_use        = 0,  // executable nmethod
@@ -696,12 +733,13 @@ public:
   bool make_in_use() {
     return try_transition(in_use);
   }
+
   // Make the nmethod non entrant. The nmethod will continue to be
   // alive.  It is used when an uncommon trap happens.  Returns true
   // if this thread changed the state of the nmethod or false if
   // another thread performed the transition.
-  bool  make_not_entrant(InvalidationReason invalidation_reason);
-  bool  make_not_used() { return make_not_entrant(InvalidationReason::NOT_USED); }
+  bool  make_not_entrant(InvalidationReason invalidation_reason, bool keep_aot_entry = false);
+  bool  make_not_used() { return make_not_entrant(InvalidationReason::NOT_USED, true /* keep AOT entry */); }
 
   bool  is_marked_for_deoptimization() const { return deoptimization_status() != not_marked; }
   bool  has_been_deoptimized() const { return deoptimization_status() == deoptimize_done; }
@@ -732,6 +770,10 @@ public:
   bool  has_monitors() const                      { return _flags.has_monitors(); }
   bool  has_scoped_access() const                 { return _flags.has_scoped_access(); }
   bool  has_wide_vectors() const                  { return _flags.has_wide_vectors(); }
+  bool  has_clinit_barriers() const               { return _flags.has_clinit_barriers(); }
+
+  bool  preloaded() const                         { return _preloaded; }
+  void  set_preloaded(bool z)                     { _preloaded = z; }
 
   bool  has_flushed_dependencies() const          { return _has_flushed_dependencies; }
   void  set_has_flushed_dependencies(bool z)      {
@@ -745,7 +787,9 @@ public:
       _is_unlinked = true;
   }
 
-  int   comp_level() const                        { return _comp_level; }
+  bool is_aot() const                             { return _aot_code_entry != nullptr; }
+  void set_aot_code_entry(AOTCodeEntry* entry)    { _aot_code_entry = entry; }
+  AOTCodeEntry* aot_code_entry() const            { return _aot_code_entry; }
 
   // Support for oops in scopes and relocs:
   // Note: index 0 is reserved for null.
@@ -766,6 +810,7 @@ public:
     return &metadata_begin()[index - 1];
   }
 
+  void copy_values(GrowableArray<Handle>* array);
   void copy_values(GrowableArray<jobject>* oops);
   void copy_values(GrowableArray<Metadata*>* metadata);
   void copy_values(GrowableArray<address>* metadata) {} // Nothing to do
@@ -781,6 +826,8 @@ protected:
 public:
   void fix_oop_relocations(ICacheInvalidationContext* icic);
   void fix_oop_relocations();
+
+  void create_reloc_immediates_list(JavaThread* thread, GrowableArray<Handle>& oop_list, GrowableArray<Metadata*>& metadata_list);
 
   bool is_at_poll_return(address pc);
   bool is_at_poll_or_poll_return(address pc);
@@ -948,8 +995,6 @@ public:
   void copy_scopes_pcs(PcDesc* pcs, int count);
   void copy_scopes_data(address buffer, int size);
 
-  int orig_pc_offset() { return _orig_pc_offset; }
-
   // Post successful compilation
   void post_compiled_method(CompileTask* task);
 
@@ -979,7 +1024,7 @@ public:
 
 #if defined(SUPPORT_DATA_STRUCTS)
   // print output in opt build for disassembler library
-  void print_relocations()                        PRODUCT_RETURN;
+  void print_relocations_on(outputStream* st)     PRODUCT_RETURN;
   void print_pcs_on(outputStream* st);
   void print_scopes() { print_scopes_on(tty); }
   void print_scopes_on(outputStream* st)          PRODUCT_RETURN;
@@ -1048,6 +1093,8 @@ public:
   void make_deoptimized();
   void finalize_relocations();
 
+  void prepare_for_archiving_impl();
+
   class Vptr : public CodeBlob::Vptr {
     void print_on(const CodeBlob* instance, outputStream* st) const override {
       ttyLocker ttyl;
@@ -1056,6 +1103,9 @@ public:
     void print_value_on(const CodeBlob* instance, outputStream* st) const override {
       instance->as_nmethod()->print_value_on_impl(st);
     }
+    void prepare_for_archiving(CodeBlob* instance) const override {
+      ((nmethod*)instance)->prepare_for_archiving_impl();
+    };
   };
 
   static const Vptr _vpntr;

--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -179,12 +179,12 @@ RelocIterator::RelocIterator(CodeSection* cs, address begin, address limit) {
 }
 
 RelocIterator::RelocIterator(CodeBlob* cb) {
-  initialize_misc();
   if (cb->is_nmethod()) {
-    _code = cb->as_nmethod();
-  } else {
-    _code = nullptr;
+    initialize(cb->as_nmethod(), nullptr, nullptr);
+    return;
   }
+  initialize_misc();
+  _code = nullptr;
   _current = cb->relocation_begin() - 1;
   _end     = cb->relocation_end();
   _addr    = cb->content_begin();
@@ -794,11 +794,11 @@ void internal_word_Relocation::fix_relocation_after_move(const CodeBuffer* src, 
   set_value(target);
 }
 
-void internal_word_Relocation::fix_relocation_after_aot_load(address orig_base_addr, address current_base_addr) {
+void internal_word_Relocation::fix_relocation_after_aot_load(address current_base_addr, int delta) {
   address target = _target;
   if (target == nullptr) {
     target = this->target();
-    target = current_base_addr + (target - orig_base_addr);
+    target = current_base_addr + delta;
   }
   set_value(target);
 }
@@ -864,8 +864,8 @@ void RelocIterator::print_current_on(outputStream* st) {
         raw_oop   = *oop_addr;
         oop_value = r->oop_value();
       }
-      st->print(" | [oop_addr=" INTPTR_FORMAT " *=" INTPTR_FORMAT "]",
-                 p2i(oop_addr), p2i(raw_oop));
+      st->print(" | [oop_addr=" INTPTR_FORMAT " *=" INTPTR_FORMAT " index=%d]",
+                 p2i(oop_addr), p2i(raw_oop), r->oop_index());
       // Do not print the oop by default--we want this routine to
       // work even during GC or other inconvenient times.
       if (WizardMode && oop_value != nullptr) {
@@ -887,8 +887,8 @@ void RelocIterator::print_current_on(outputStream* st) {
         raw_metadata   = *metadata_addr;
         metadata_value = r->metadata_value();
       }
-      st->print(" | [metadata_addr=" INTPTR_FORMAT " *=" INTPTR_FORMAT "]",
-                 p2i(metadata_addr), p2i(raw_metadata));
+      st->print(" | [metadata_addr=" INTPTR_FORMAT " *=" INTPTR_FORMAT " index=%d]",
+                 p2i(metadata_addr), p2i(raw_metadata), r->metadata_index());
       if (metadata_value != nullptr) {
         st->print("metadata_value=" INTPTR_FORMAT ": ", p2i(metadata_value));
         metadata_value->print_value_on(st);
@@ -931,7 +931,7 @@ void RelocIterator::print_current_on(outputStream* st) {
       } else {
         CodeBlob* cb = CodeCache::find_blob(dest);
         if (cb != nullptr) {
-          st->print(" %s", cb->name());
+          st->print(" Blob::%s", cb->name());
         } else {
           ResourceMark rm;
           const int buflen = 1024;

--- a/src/hotspot/share/code/relocInfo.hpp
+++ b/src/hotspot/share/code/relocInfo.hpp
@@ -1286,6 +1286,24 @@ class trampoline_stub_Relocation : public Relocation {
 
   void pack_data_to(CodeSection * dest) override;
   void unpack_data() override;
+#if defined(AARCH64) && !defined(ZERO)
+  address pd_destination     ();
+  void    pd_set_destination (address x);
+#else
+  address pd_destination     () {
+    fatal("trampoline_stub_Relocation::destination() unimplemented");
+    return (address)-1;
+  }
+  void    pd_set_destination (address x) {
+    fatal("trampoline_stub_Relocation::set_destination() unimplemented");
+  }
+#endif
+  address destination() {
+    return pd_destination();
+  }
+  void    set_destination(address x) {
+    pd_set_destination(x);
+  }
 
   // Find the trampoline stub for a call.
   static address get_trampoline_for(address call, nmethod* code);
@@ -1376,7 +1394,7 @@ class internal_word_Relocation : public DataRelocation {
   void unpack_data() override;
 
   void fix_relocation_after_move(const CodeBuffer* src, CodeBuffer* dest) override;
-  void fix_relocation_after_aot_load(address orig_base_addr, address current_base_addr);
+  void fix_relocation_after_aot_load(address current_base_addr, int delta);
 
   address  target();        // if _target==nullptr, fetch addr from code stream
   int      section()        { return _section;   }

--- a/src/hotspot/share/compiler/abstractCompiler.hpp
+++ b/src/hotspot/share/compiler/abstractCompiler.hpp
@@ -33,6 +33,7 @@ typedef void (*initializer)(void);
 
 // Per-compiler statistics
 class CompilerStatistics {
+ public:
   class Data {
     friend class VMStructs;
   public:
@@ -50,9 +51,11 @@ class CompilerStatistics {
     }
   };
 
- public:
   Data _standard;  // stats for non-OSR compilations
   Data _osr;       // stats for OSR compilations
+  Data _bailout;
+  Data _invalidated;
+  Data _made_not_entrant;
   uint _nmethods_size; //
   uint _nmethods_code_size;
 

--- a/src/hotspot/share/compiler/aotCompileBroker.cpp
+++ b/src/hotspot/share/compiler/aotCompileBroker.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "cds/aotCacheAccess.hpp"
+#include "cds/archiveBuilder.hpp"
+#include "cds/cdsConfig.hpp"
+#include "cds/runTimeClassInfo.hpp"
+#include "code/aotCodeCache.hpp"
+#include "compiler/aotCompileBroker.hpp"
+#include "compiler/compilationPolicy.hpp"
+#include "compiler/compileBroker.hpp"
+#include "compiler/compiler_globals.hpp"
+#include "logging/logStream.hpp"
+#include "memory/allocation.hpp"
+#include "oops/trainingData.hpp"
+#include "runtime/handles.inline.hpp"
+
+class AOTCompileIterator : StackObj {
+private:
+  CompLevel _comp_level;
+  bool      _for_preload;
+  Thread*   _thread;
+  GrowableArray<Method*> _methods;
+
+public:
+  AOTCompileIterator(CompLevel comp_level, bool for_preload, JavaThread* thread)
+  : _comp_level(comp_level), _for_preload(for_preload), _thread(thread) {
+    assert(TrainingData::have_data(), "sanity");
+  }
+
+  bool include(MethodTrainingData* mtd) {
+    Method* m = mtd->holder();
+    if (m->is_native() || m->is_abstract() || !m->method_holder()->is_linked()) {
+      return false;
+    }
+    CompilerDirectiveMatcher matcher(methodHandle(_thread, m), _comp_level);
+    if (matcher.directive_set()->DontAOTCompileOption) {
+      return false;
+    }
+    int high_top_level = mtd->highest_top_level();
+    switch (_comp_level) {
+      case CompLevel_simple:
+      case CompLevel_full_optimization:
+        // For final C1/C2 compilations, we only compile when there was relevant compilation during training.
+        return _comp_level == high_top_level;
+      case CompLevel_limited_profile:
+        // For profiled C1 compilations, generate limited profile when there was limited/full
+        // profiled compilation in training.
+        return CompLevel_limited_profile <= high_top_level && high_top_level <= CompLevel_full_profile;
+      case CompLevel_full_profile:
+        // We do not include C1 full profiled methods at this time.
+        return false;
+      default:
+        assert(false, "Missed the case: %d", _comp_level);
+    }
+    // Do not include methods by default.
+    return false;
+  }
+
+  void apply(TrainingData* td) {
+    if (td->is_MethodTrainingData()) {
+      MethodTrainingData* mtd = td->as_MethodTrainingData();
+      if (mtd->has_holder() && include(mtd)) {
+        _methods.push(mtd->holder());
+      }
+    }
+  }
+
+  static MethodTrainingData* method_training_data(Method* m) {
+    if (m->method_holder()->is_loaded()) {
+      return MethodTrainingData::find(methodHandle(Thread::current(), m));
+    }
+    return nullptr;
+  }
+
+  // We sort methods by compile ID, presuming the methods that compiled earlier
+  // are more important. This only matters for preload code, which is loaded
+  // asynchronously; other levels are sorted for better consistency between training
+  // runs. Since we can accept methods from multiple levels, we use the compile ID
+  // from the lowest level.
+  static int compare_methods(Method** m1, Method** m2) {
+    int c1 = compile_id(*m1);
+    int c2 = compile_id(*m2);
+    if (c1 < c2) return -1;
+    if (c1 > c2) return +1;
+    return 0;
+  }
+
+  static int compile_id(Method* m) {
+    // Methods without recorded compilations are treated as "compiled last"
+    int id = INT_MAX;
+    MethodTrainingData* mtd = method_training_data(m);
+    if (mtd != nullptr) {
+      for (int level = CompLevel_simple; level <= CompilationPolicy::highest_compile_level(); level++) {
+        CompileTrainingData* ctd = mtd->last_toplevel_compile(level);
+        if (ctd != nullptr) {
+          id = MIN2(id, ctd->compile_id());
+        }
+      }
+    }
+    return id;
+  }
+
+  void schedule_compilations(TRAPS) {
+    for (int i = 0; i < _methods.length(); i++) {
+      Method* m = _methods.at(i);
+      methodHandle mh(THREAD, m);
+      assert(mh()->method_holder()->is_linked(), "required");
+      if (!AOTCacheAccess::can_generate_aot_code(m)) {
+        continue; // Method is not archived
+      }
+      assert(!HAS_PENDING_EXCEPTION, "");
+      CompileBroker::compile_method(mh, InvocationEntryBci, _comp_level,
+                                    0, nullptr /*requires_online_comp*/,
+                                    _for_preload ? CompileTask::Reason_AOTCompileForPreload : CompileTask::Reason_AOTCompile,
+                                    THREAD);
+      if (HAS_PENDING_EXCEPTION) {
+        CLEAR_PENDING_EXCEPTION;
+      }
+    }
+  }
+
+  void print_compilation_status(ArchiveBuilder* builder) {
+    LogStreamHandle(Info, aot, compilation) logi;
+    if (!logi.is_enabled()) {
+      return;
+    }
+    int success_count = 0;
+    const int log_comp_level = _comp_level + (_for_preload ? 1 : 0);
+
+    for (int i = 0; i < _methods.length(); i++) {
+      Method* m = _methods.at(i);
+
+      bool is_success = !m->is_not_compilable(_comp_level);
+      if (is_success) {
+        success_count++;
+      }
+
+      LogStreamHandle(Debug, aot, compilation) log;
+      if (log.is_enabled()) {
+        ResourceMark rm;
+        log.print("[%4d] T%d Compiled %s [%p", i, log_comp_level, m->external_name(), m);
+        if (builder != nullptr) {
+          Method* requested_m = builder->to_requested(builder->get_buffered_addr(m));
+          log.print(" -> %p", requested_m);
+        }
+        log.print_cr("] {%d} [%d] (%s)", compile_id(m), AOTCodeCache::store_entries_cnt(), (is_success ? "success" : "FAILED"));
+      }
+    }
+
+    logi.print_cr("AOT Compilation for level %d finished (%d successful out of %d total)",
+                  log_comp_level, success_count, _methods.length());
+  }
+
+  void compile(ArchiveBuilder* builder, TRAPS) {
+    _methods.sort(&compare_methods);
+    schedule_compilations(THREAD);
+    CompileBroker::wait_for_no_active_tasks();
+    print_compilation_status(builder);
+  }
+};
+
+void AOTCompileBroker::compile_aot_code(ArchiveBuilder* builder, TRAPS) {
+  assert(AOTCodeCache::is_dumping_code(), "sanity");
+  if (TrainingData::have_data()) {
+    ResourceMark rm;
+    CompLevel highest_level = CompilationPolicy::highest_compile_level();
+    if (highest_level >= CompLevel_full_optimization && ClassInitBarrierMode > 0) {
+      AOTCompileIterator aci(CompLevel_full_optimization, true /*for_preload*/, THREAD);
+      TrainingData::iterate([&](TrainingData* td) {
+        aci.apply(td);
+      });
+      aci.compile(builder, THREAD);
+    }
+
+    for (int level = CompLevel_simple; level <= highest_level; level++) {
+      AOTCompileIterator aci((CompLevel)level, false /*for_preload*/, THREAD);
+      TrainingData::iterate([&](TrainingData* td) {
+        aci.apply(td);
+      });
+      aci.compile(builder, THREAD);
+    }
+  }
+}

--- a/src/hotspot/share/compiler/aotCompileBroker.hpp
+++ b/src/hotspot/share/compiler/aotCompileBroker.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_COMPILER_AOTCOMPILEBROKER_HPP
+#define SHARE_COMPILER_AOTCOMPILEBROKER_HPP
+
+#include "memory/allStatic.hpp"
+#include "utilities/exceptions.hpp"
+
+class ArchiveBuilder;
+
+class AOTCompileBroker : AllStatic  {
+public:
+  static void compile_aot_code(ArchiveBuilder* builder, TRAPS) NOT_CDS_RETURN;
+};
+
+#endif // SHARE_COMPILER_AOTCOMPILEBROKER_HPP

--- a/src/hotspot/share/compiler/compilationLog.cpp
+++ b/src/hotspot/share/compiler/compilationLog.cpp
@@ -36,6 +36,7 @@ CompilationLog::CompilationLog() : StringEventLog("Compilation events", "jit") {
 }
 
 void CompilationLog::log_compile(JavaThread* thread, CompileTask* task) {
+  ResourceMark rm;
   StringLogMessage lm;
   stringStream sstr(lm.buffer(), lm.size());
   // msg.time_stamp().update_to(tty->time_stamp().ticks());
@@ -44,12 +45,13 @@ void CompilationLog::log_compile(JavaThread* thread, CompileTask* task) {
 }
 
 void CompilationLog::log_nmethod(JavaThread* thread, nmethod* nm) {
-  log(thread, "nmethod %d%s " INTPTR_FORMAT " code [" INTPTR_FORMAT ", " INTPTR_FORMAT "]",
-      nm->compile_id(), nm->is_osr_method() ? "%" : "",
+  log(thread, "nmethod %d %s " INTPTR_FORMAT " code [" INTPTR_FORMAT ", " INTPTR_FORMAT "]",
+      nm->compile_id(), nm->compile_kind(),
       p2i(nm), p2i(nm->code_begin()), p2i(nm->code_end()));
 }
 
 void CompilationLog::log_failure(JavaThread* thread, CompileTask* task, const char* reason, const char* retry_message) {
+  ResourceMark rm;
   StringLogMessage lm;
   stringStream sstr(lm.buffer(), lm.size());
   if (task == nullptr) {

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "cds/aotLinkedClassBulkLoader.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/scopeDesc.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
@@ -52,6 +53,7 @@
 int64_t CompilationPolicy::_start_time = 0;
 int CompilationPolicy::_c1_count = 0;
 int CompilationPolicy::_c2_count = 0;
+int CompilationPolicy::_ac_count = 0;
 double CompilationPolicy::_increase_threshold_at_ratio = 0;
 
 CompilationPolicy::TrainingReplayQueue CompilationPolicy::_training_replay_queue;
@@ -83,28 +85,51 @@ bool CompilationPolicy::must_be_compiled(const methodHandle& m, int comp_level) 
          (AlwaysCompileLoopMethods && m->has_loops() && CompileBroker::should_compile_new_jobs()); // eagerly compile loop methods
 }
 
-void CompilationPolicy::maybe_compile_early(const methodHandle& m, TRAPS) {
+AOTCodeEntry* find_aot_code_entry(const methodHandle& method, int comp_level,
+                                  CompileTask::CompileReason compile_reason) {
+  precond(compile_reason == CompileTask::Reason_AOTLoad ||
+          compile_reason == CompileTask::Reason_Tiered  ||
+          compile_reason == CompileTask::Reason_MustBeCompiled);
+  if (AOTCodeCache::is_using_code()) {
+    AOTCodeEntry* aot_code_entry = AOTCodeCache::find_code_entry(method, comp_level);
+    if (aot_code_entry != nullptr && !aot_code_entry->is_loaded() && !aot_code_entry->not_entrant()) {
+      return aot_code_entry;
+    }
+  }
+  return nullptr;
+}
+
+void CompilationPolicy::maybe_compile_early(const methodHandle& m, MethodTrainingData* mtd, TRAPS) {
   if (m->method_holder()->is_not_initialized()) {
     // 'is_not_initialized' means not only '!is_initialized', but also that
     // initialization has not been started yet ('!being_initialized')
     // Do not force compilation of methods in uninitialized classes.
     return;
   }
-  if (!m->is_native() && MethodTrainingData::have_data()) {
-    MethodTrainingData* mtd = MethodTrainingData::find_fast(m);
-    if (mtd == nullptr) {
-      return;              // there is no training data recorded for m
+  // Consider replacing conservatively compiled AOT Preload code with faster AOT code or normal JITed code
+  nmethod* nm = m->code();
+  bool recompile = (nm != nullptr) && nm->preloaded();
+  CompLevel cur_level = static_cast<CompLevel>(m->highest_comp_level());
+  CompLevel next_level = trained_transition(m, cur_level, mtd, THREAD);
+  if ((next_level != cur_level || recompile) && can_be_compiled(m, next_level) && !CompileBroker::compilation_is_in_queue(m)) {
+    // We are here because some of CTD have all init dependencies satisfied.
+    CompileTrainingData* ctd = mtd->compile_data_for_aot_code(next_level);
+    if (ctd == nullptr || (ctd->init_deps_left_acquire() > 0)) {
+      // Skip compilation beacuse CTD is absent or not all dependencies are ready
+      return;
     }
-    CompLevel cur_level = static_cast<CompLevel>(m->highest_comp_level());
-    CompLevel next_level = trained_transition(m, cur_level, mtd, THREAD);
-    if (next_level != cur_level && can_be_compiled(m, next_level) && !CompileBroker::compilation_is_in_queue(m)) {
-      if (PrintTieredEvents) {
-        print_event(FORCE_COMPILE, m(), m(), InvocationEntryBci, next_level);
-      }
-      CompileBroker::compile_method(m, InvocationEntryBci, next_level, 0, CompileTask::Reason_MustBeCompiled, THREAD);
-      if (HAS_PENDING_EXCEPTION) {
-        CLEAR_PENDING_EXCEPTION;
-      }
+    CompileTask::CompileReason reason = CompileTask::Reason_AOTLoad;
+    AOTCodeEntry* aot_code_entry = find_aot_code_entry(m, next_level, reason);
+    if (aot_code_entry == nullptr) {
+      // Request normal JIT compilation if there is no next_level aot code for this method
+      reason = CompileTask::Reason_MustBeCompiled;
+    }
+    if (PrintTieredEvents) {
+      print_event(FORCE_COMPILE, m(), m(), InvocationEntryBci, next_level);
+    }
+    CompileBroker::compile_method(m, InvocationEntryBci, next_level, 0, aot_code_entry, reason, THREAD);
+    if (HAS_PENDING_EXCEPTION) {
+      CLEAR_PENDING_EXCEPTION;
     }
   }
 }
@@ -128,10 +153,25 @@ void CompilationPolicy::compile_if_required(const methodHandle& m, TRAPS) {
   if (must_be_compiled(m)) {
     // This path is unusual, mostly used by the '-Xcomp' stress test mode.
     CompLevel level = initial_compile_level(m);
+    CompileTask::CompileReason reason = CompileTask::Reason_MustBeCompiled;
     if (PrintTieredEvents) {
       print_event(FORCE_COMPILE, m(), m(), InvocationEntryBci, level);
     }
-    CompileBroker::compile_method(m, InvocationEntryBci, level, 0, CompileTask::Reason_MustBeCompiled, THREAD);
+    // Check AOT code too
+    if (TrainingData::have_data()) {
+      MethodTrainingData* mtd = MethodTrainingData::find_fast(m);
+      if (mtd != nullptr) {
+        CompileTrainingData* ctd = mtd->last_toplevel_compile(level);
+        if (ctd != nullptr && (ctd->init_deps_left_acquire() == 0)) {
+          AOTCodeEntry* aot_code_entry = find_aot_code_entry(m, level, reason);
+          if (aot_code_entry != nullptr) {
+            CompileBroker::compile_method(m, InvocationEntryBci, level, 0, aot_code_entry, reason, THREAD);
+          } // Request normal JIT compilation too for -Xcomp
+        }
+      }
+    }
+    // Request normal JIT compilation
+    CompileBroker::compile_method(m, InvocationEntryBci, level, 0, nullptr, reason, THREAD);
   }
 }
 
@@ -145,16 +185,22 @@ void CompilationPolicy::replay_training_at_init_impl(InstanceKlass* klass, JavaT
       guarantee(ktd->has_holder(), "");
       ktd->notice_fully_initialized(); // sets klass->has_init_deps_processed bit
       assert(klass->has_init_deps_processed(), "");
+
       if (AOTCompileEagerly) {
+        GrowableArray<MethodTrainingData*> mtds;
         ktd->iterate_comp_deps([&](CompileTrainingData* ctd) {
           if (ctd->init_deps_left_acquire() == 0) {
             MethodTrainingData* mtd = ctd->method();
             if (mtd->has_holder()) {
-              const methodHandle mh(current, const_cast<Method*>(mtd->holder()));
-              CompilationPolicy::maybe_compile_early(mh, current);
+              mtds.push(mtd);
             }
           }
         });
+        for (int i = 0; i < mtds.length(); i++) {
+          MethodTrainingData* mtd = mtds.at(i);
+          const methodHandle mh(current, const_cast<Method*>(mtd->holder()));
+          CompilationPolicy::maybe_compile_early(mh, mtd, current);
+        }
       }
     }
   }
@@ -519,6 +565,16 @@ void CompilationPolicy::initialize() {
 
 #ifdef _LP64
     // Turn on ergonomic compiler count selection
+    if (AOTCodeCache::maybe_dumping_code()) {
+      // Assembly phase runs C1 and C2 compilation in separate phases,
+      // and can use all the CPU threads it can reach. Adjust the common
+      // options before policy starts overwriting them.
+      FLAG_SET_ERGO_IF_DEFAULT(UseDynamicNumberOfCompilerThreads, false);
+      FLAG_SET_ERGO_IF_DEFAULT(CICompilerCountPerCPU, false);
+      if (FLAG_IS_DEFAULT(CICompilerCount)) {
+        count =  MAX2(count, os::active_processor_count());
+      }
+    }
     if (FLAG_IS_DEFAULT(CICompilerCountPerCPU) && FLAG_IS_DEFAULT(CICompilerCount)) {
       FLAG_SET_DEFAULT(CICompilerCountPerCPU, true);
     }
@@ -527,6 +583,8 @@ void CompilationPolicy::initialize() {
       int log_cpu = log2i(os::active_processor_count());
       int loglog_cpu = log2i(MAX2(log_cpu, 1));
       count = MAX2(log_cpu * loglog_cpu * 3 / 2, min_count);
+    }
+    if (FLAG_IS_DEFAULT(CICompilerCount)) {
       // Make sure there is enough space in the code cache to hold all the compiler buffers
       size_t c1_size = 0;
 #ifdef COMPILER1
@@ -574,6 +632,9 @@ void CompilationPolicy::initialize() {
     } else {
       set_c1_count(MAX2(count / 3, 1));
       set_c2_count(MAX2(count - c1_count(), 1));
+    }
+    if (AOTCodeCache::is_code_load_thread_on()) {
+      set_ac_count((c1_only || c2_only) ? 1 : 2); // At minimum we need 2 threads to load C1 and C2 AOT code in parallel
     }
     assert(count == c1_count() + c2_count(), "inconsistent compiler thread count");
     set_increase_threshold_at_ratio();
@@ -704,6 +765,11 @@ CompileTask* CompilationPolicy::select_task(CompileQueue* compile_queue, JavaThr
       task = next_task;
       continue;
     }
+    if (task->is_aot_load()) {
+      // AOTCodeCache tasks are on separate queue, and they should load fast. There is no need to walk
+      // the rest of the queue, just take the task and go.
+      return task;
+    }
     if (task->is_blocking() && task->compile_reason() == CompileTask::Reason_Whitebox) {
       // CTW tasks, submitted as blocking Whitebox requests, do not participate in rate
       // selection and/or any level adjustments. Just return them in order.
@@ -721,7 +787,7 @@ CompileTask* CompilationPolicy::select_task(CompileQueue* compile_queue, JavaThr
       continue;
     }
     update_rate(t, mh);
-    if (max_task == nullptr || compare_methods(method, max_method)) {
+    if (max_task == nullptr || compare_methods(method, max_method) || compare_tasks(task, max_task)) {
       // Select a method with the highest rate
       max_task = task;
       max_method = method;
@@ -754,7 +820,9 @@ CompileTask* CompilationPolicy::select_task(CompileQueue* compile_queue, JavaThr
         max_task->set_comp_level(CompLevel_limited_profile);
         max_task->transfer_directive(directive_matcher);
 
-        if (CompileBroker::compilation_is_complete(max_method_h, max_task->osr_bci(), CompLevel_limited_profile)) {
+        if (CompileBroker::compilation_is_complete(max_method_h, max_task->osr_bci(), CompLevel_limited_profile,
+                                                   nullptr /* requires_online_compilation */,
+                                                   CompileTask::Reason_None)) {
           if (PrintTieredEvents) {
             print_event(REMOVE_FROM_QUEUE, max_method, max_method, max_task->osr_bci(), (CompLevel)max_task->comp_level());
           }
@@ -887,7 +955,24 @@ void CompilationPolicy::compile(const methodHandle& mh, int bci, CompLevel level
     }
     int hot_count = (bci == InvocationEntryBci) ? mh->invocation_count() : mh->backedge_count();
     update_rate(nanos_to_millis(os::javaTimeNanos()), mh);
-    CompileBroker::compile_method(mh, bci, level, hot_count, CompileTask::Reason_Tiered, THREAD);
+    CompileTask::CompileReason reason = CompileTask::Reason_Tiered;
+    // Check AOT code too
+    if (TrainingData::have_data() && (bci == InvocationEntryBci)) {
+      MethodTrainingData* mtd = MethodTrainingData::find_fast(mh);
+      if (mtd != nullptr) {
+        CompileTrainingData* ctd = mtd->last_toplevel_compile(level);
+        if (ctd != nullptr && (ctd->init_deps_left_acquire() == 0)) {
+          AOTCodeEntry* aot_code_entry = find_aot_code_entry(mh, level, reason);
+          if (aot_code_entry != nullptr) {
+            CompileBroker::compile_method(mh, InvocationEntryBci, level, hot_count, aot_code_entry, reason, THREAD);
+            if (UseInterpreter) {
+              return;
+            } // Request normal JIT compilation too for -Xcomp
+          }
+        }
+      }
+    }
+    CompileBroker::compile_method(mh, bci, level, hot_count, nullptr, reason, THREAD);
   }
 }
 
@@ -967,6 +1052,14 @@ bool CompilationPolicy::compare_methods(Method* x, Method* y) {
         return true;
       }
     }
+  return false;
+}
+
+bool CompilationPolicy::compare_tasks(CompileTask* x, CompileTask* y) {
+  assert(!x->is_aot_load() && !y->is_aot_load(), "AOT code caching tasks are not expected here");
+  if (x->compile_reason() != y->compile_reason() && x->compile_reason() == CompileTask::Reason_MustBeCompiled) {
+    return true;
+  }
   return false;
 }
 

--- a/src/hotspot/share/compiler/compilationPolicy.hpp
+++ b/src/hotspot/share/compiler/compilationPolicy.hpp
@@ -246,7 +246,7 @@ class CompilationPolicy : AllStatic {
   typedef CompilationPolicyUtils::Queue<InstanceKlass> TrainingReplayQueue;
 
   static int64_t _start_time;
-  static int _c1_count, _c2_count;
+  static int _c1_count, _c2_count, _ac_count;
   static double _increase_threshold_at_ratio;
   static TrainingReplayQueue _training_replay_queue;
 
@@ -297,6 +297,7 @@ class CompilationPolicy : AllStatic {
   inline static double weight(Method* method);
   // Apply heuristics and return true if x should be compiled before y
   inline static bool compare_methods(Method* x, Method* y);
+  inline static bool compare_tasks(CompileTask* x, CompileTask* y);
   // Compute event rate for a given method. The rate is the number of event (invocations + backedges)
   // per millisecond.
   inline static void update_rate(int64_t t, const methodHandle& method);
@@ -313,6 +314,7 @@ class CompilationPolicy : AllStatic {
 
   static void set_c1_count(int x) { _c1_count = x;    }
   static void set_c2_count(int x) { _c2_count = x;    }
+  static void set_ac_count(int x) { _ac_count = x;    }
 
   enum EventType { CALL, LOOP, COMPILE, FORCE_COMPILE, FORCE_RECOMPILE, REMOVE_FROM_QUEUE, UPDATE_IN_QUEUE, REPROFILE, MAKE_NOT_ENTRANT };
   static void print_event_on(outputStream *st, EventType type, Method* m, Method* im, int bci, CompLevel level);
@@ -336,12 +338,13 @@ class CompilationPolicy : AllStatic {
 
   // m must be compiled before executing it
   static bool must_be_compiled(const methodHandle& m, int comp_level = CompLevel_any);
-  static void maybe_compile_early(const methodHandle& m, TRAPS);
+  static void maybe_compile_early(const methodHandle& m, MethodTrainingData* mtd, TRAPS);
   static void replay_training_at_init_impl(InstanceKlass* klass, JavaThread* current);
  public:
   static int min_invocations() { return Tier4MinInvocationThreshold; }
   static int c1_count() { return _c1_count; }
   static int c2_count() { return _c2_count; }
+  static int ac_count() { return _ac_count; }
   static int compiler_count(CompLevel comp_level);
   // If m must_be_compiled then request a compilation from the CompileBroker.
   // This supports the -Xcomp option.

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -27,6 +27,7 @@
 #include "classfile/symbolTable.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/codeCache.hpp"
 #include "code/codeHeapState.hpp"
 #include "code/dependencyContext.hpp"
@@ -67,7 +68,7 @@
 #include "runtime/safepointVerifiers.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/threads.hpp"
-#include "runtime/threadSMR.hpp"
+#include "runtime/threadSMR.inline.hpp"
 #include "runtime/timerTrace.hpp"
 #include "runtime/vframe.inline.hpp"
 #include "utilities/debug.hpp"
@@ -128,13 +129,16 @@ AbstractCompiler* CompileBroker::_compilers[2];
 // The maximum numbers of compiler threads to be determined during startup.
 int CompileBroker::_c1_count = 0;
 int CompileBroker::_c2_count = 0;
+int CompileBroker::_ac_count = 0;
 
 // An array of compiler names as Java String objects
 jobject* CompileBroker::_compiler1_objects = nullptr;
 jobject* CompileBroker::_compiler2_objects = nullptr;
+jobject* CompileBroker::_ac_objects = nullptr;
 
 CompileLog** CompileBroker::_compiler1_logs = nullptr;
 CompileLog** CompileBroker::_compiler2_logs = nullptr;
+CompileLog** CompileBroker::_ac_logs = nullptr;
 
 // These counters are used to assign an unique ID to each compilation.
 volatile jint CompileBroker::_compilation_id     = 0;
@@ -174,6 +178,7 @@ elapsedTimer CompileBroker::_t_bailedout_compilation;
 
 uint CompileBroker::_total_bailout_count            = 0;
 uint CompileBroker::_total_invalidated_count        = 0;
+uint CompileBroker::_total_not_entrant_count        = 0;
 uint CompileBroker::_total_compile_count            = 0;
 uint CompileBroker::_total_osr_compile_count        = 0;
 uint CompileBroker::_total_standard_compile_count   = 0;
@@ -188,9 +193,13 @@ uint CompileBroker::_sum_nmethod_code_size          = 0;
 jlong CompileBroker::_peak_compilation_time        = 0;
 
 CompilerStatistics CompileBroker::_stats_per_level[CompLevel_full_optimization];
+CompilerStatistics CompileBroker::_aot_stats;
+CompilerStatistics CompileBroker::_aot_stats_per_level[CompLevel_full_optimization + 1];
 
 CompileQueue* CompileBroker::_c2_compile_queue     = nullptr;
 CompileQueue* CompileBroker::_c1_compile_queue     = nullptr;
+CompileQueue* CompileBroker::_ac1_compile_queue    = nullptr;
+CompileQueue* CompileBroker::_ac2_compile_queue    = nullptr;
 
 bool compileBroker_init() {
   if (LogEvents) {
@@ -491,17 +500,15 @@ void CompileQueue::remove_and_mark_stale(CompileTask* task) {
 // methods in the compile queue need to be marked as used on the stack
 // so that they don't get reclaimed by Redefine Classes
 void CompileQueue::mark_on_stack() {
-  CompileTask* task = _first;
-  while (task != nullptr) {
+  for (CompileTask* task = _first; task != nullptr; task = task->next()) {
     task->mark_on_stack();
-    task = task->next();
   }
 }
 
 
-CompileQueue* CompileBroker::compile_queue(int comp_level) {
-  if (is_c2_compile(comp_level)) return _c2_compile_queue;
-  if (is_c1_compile(comp_level)) return _c1_compile_queue;
+CompileQueue* CompileBroker::compile_queue(int comp_level, bool is_aot) {
+  if (is_c2_compile(comp_level)) return ((is_aot && (_ac_count > 0)) ? _ac2_compile_queue : _c2_compile_queue);
+  if (is_c1_compile(comp_level)) return ((is_aot && (_ac_count > 0)) ? _ac1_compile_queue : _c1_compile_queue);
   return nullptr;
 }
 
@@ -526,6 +533,12 @@ void CompileBroker::print_compile_queues(outputStream* st) {
   }
   if (_c2_compile_queue != nullptr) {
     _c2_compile_queue->print(st);
+  }
+  if (_ac1_compile_queue != nullptr) {
+    _ac1_compile_queue->print(st);
+  }
+  if (_ac2_compile_queue != nullptr) {
+    _ac2_compile_queue->print(st);
   }
 }
 
@@ -587,6 +600,7 @@ void CompileBroker::compilation_init(JavaThread* THREAD) {
   // Set the interface to the current compiler(s).
   _c1_count = CompilationPolicy::c1_count();
   _c2_count = CompilationPolicy::c2_count();
+  _ac_count = CompilationPolicy::ac_count();
 
 #ifdef COMPILER1
   if (_c1_count > 0) {
@@ -708,7 +722,15 @@ void CompileBroker::compilation_init(JavaThread* THREAD) {
                                           CHECK);
   }
 
+  if (AOTCodeCache::is_on()) {
+    log_info(aot, codecache, init)("CompileBroker is initialized");
+  }
   _initialized = true;
+}
+
+Handle CompileBroker::create_thread_oop(const char* name, TRAPS) {
+  Handle thread_oop = JavaThread::create_system_thread_object(name, CHECK_NH);
+  return thread_oop;
 }
 
 void TrainingReplayThread::training_replay_thread_entry(JavaThread* thread, TRAPS) {
@@ -874,6 +896,17 @@ static void print_compiler_threads(stringStream& msg) {
   }
 }
 
+static void print_compiler_thread(JavaThread *ct) {
+  if (trace_compiler_threads()) {
+    ResourceMark rm;
+    ThreadsListHandle tlh;  // name() depends on the TLH.
+    assert(tlh.includes(ct), "ct=" INTPTR_FORMAT " exited unexpectedly.", p2i(ct));
+    stringStream msg;
+    msg.print("Added initial compiler thread %s", ct->name());
+    print_compiler_threads(msg);
+  }
+}
+
 void CompileBroker::init_compiler_threads() {
   // Ensure any exceptions lead to vm_exit_during_initialization.
   EXCEPTION_MARK;
@@ -893,6 +926,18 @@ void CompileBroker::init_compiler_threads() {
     _compiler1_logs = NEW_C_HEAP_ARRAY(CompileLog*, _c1_count, mtCompiler);
   }
 
+  if (_ac_count > 0) {
+    if (_c1_count > 0) { // C1 is present
+      _ac1_compile_queue  = new CompileQueue("C1 AOT code compile queue");
+    }
+    if (_c2_count > 0) { // C2 is present
+      _ac2_compile_queue  = new CompileQueue("C2 AOT code compile queue");
+    }
+    _ac_objects = NEW_C_HEAP_ARRAY(jobject, _ac_count, mtCompiler);
+    _ac_logs = NEW_C_HEAP_ARRAY(CompileLog*, _ac_count, mtCompiler);
+  }
+  char name_buffer[256];
+
   for (int i = 0; i < _c2_count; i++) {
     // Create a name for our thread.
     jobject thread_handle = create_compiler_thread(_compilers[1], i, CHECK);
@@ -903,14 +948,7 @@ void CompileBroker::init_compiler_threads() {
       JavaThread *ct = make_thread(compiler_t, thread_handle, _c2_compile_queue, _compilers[1], THREAD);
       assert(ct != nullptr, "should have been handled for initial thread");
       _compilers[1]->set_num_compiler_threads(i + 1);
-      if (trace_compiler_threads()) {
-        ResourceMark rm;
-        ThreadsListHandle tlh;  // name() depends on the TLH.
-        assert(tlh.includes(ct), "ct=" INTPTR_FORMAT " exited unexpectedly.", p2i(ct));
-        stringStream msg;
-        msg.print("Added initial compiler thread %s", ct->name());
-        print_compiler_threads(msg);
-      }
+      print_compiler_thread(ct);
     }
   }
 
@@ -924,14 +962,34 @@ void CompileBroker::init_compiler_threads() {
       JavaThread *ct = make_thread(compiler_t, thread_handle, _c1_compile_queue, _compilers[0], THREAD);
       assert(ct != nullptr, "should have been handled for initial thread");
       _compilers[0]->set_num_compiler_threads(i + 1);
-      if (trace_compiler_threads()) {
-        ResourceMark rm;
-        ThreadsListHandle tlh;  // name() depends on the TLH.
-        assert(tlh.includes(ct), "ct=" INTPTR_FORMAT " exited unexpectedly.", p2i(ct));
-        stringStream msg;
-        msg.print("Added initial compiler thread %s", ct->name());
-        print_compiler_threads(msg);
-      }
+      print_compiler_thread(ct);
+    }
+  }
+
+  if (_ac_count > 0) {
+    int i = 0;
+    if (_c1_count > 0) { // C1 is present
+      os::snprintf_checked(name_buffer, sizeof(name_buffer), "C%d AOT code caching CompilerThread", 1);
+      Handle thread_oop = create_thread_oop(name_buffer, CHECK);
+      jobject thread_handle = JNIHandles::make_global(thread_oop);
+      _ac_objects[i] = thread_handle;
+      _ac_logs[i] = nullptr;
+      i++;
+
+      JavaThread *ct = make_thread(compiler_t, thread_handle, _ac1_compile_queue, _compilers[0], THREAD);
+      assert(ct != nullptr, "should have been handled for initial thread");
+      print_compiler_thread(ct);
+    }
+    if (_c2_count > 0) { // C2 is present
+      os::snprintf_checked(name_buffer, sizeof(name_buffer), "C%d AOT code caching CompilerThread", 2);
+      Handle thread_oop = create_thread_oop(name_buffer, CHECK);
+      jobject thread_handle = JNIHandles::make_global(thread_oop);
+      _ac_objects[i] = thread_handle;
+      _ac_logs[i] = nullptr;
+
+      JavaThread *ct = make_thread(compiler_t, thread_handle, _ac2_compile_queue, _compilers[1], THREAD);
+      assert(ct != nullptr, "should have been handled for initial thread");
+      print_compiler_thread(ct);
     }
   }
 
@@ -1055,6 +1113,12 @@ void CompileBroker::mark_on_stack() {
   if (_c1_compile_queue != nullptr) {
     _c1_compile_queue->mark_on_stack();
   }
+  if (_ac1_compile_queue != nullptr) {
+    _ac1_compile_queue->mark_on_stack();
+  }
+  if (_ac2_compile_queue != nullptr) {
+    _ac2_compile_queue->mark_on_stack();
+  }
 }
 
 // ------------------------------------------------------------------
@@ -1062,6 +1126,7 @@ void CompileBroker::mark_on_stack() {
 //
 // Request compilation of a method.
 void CompileBroker::compile_method_base(const methodHandle& method,
+                                        AOTCodeEntry* aot_code_entry,
                                         int osr_bci,
                                         int comp_level,
                                         int hot_count,
@@ -1069,29 +1134,49 @@ void CompileBroker::compile_method_base(const methodHandle& method,
                                         bool blocking,
                                         Thread* thread) {
   guarantee(!method->is_abstract(), "cannot compile abstract methods");
-  assert(method->method_holder()->is_instance_klass(),
-         "sanity check");
-  assert(!method->method_holder()->is_not_initialized(),
-         "method holder must be initialized");
+  precond(method->method_holder()->is_instance_klass());
+  precond(compile_reason != CompileTask::Reason_AOTPreload || aot_code_entry != nullptr);
+  assert(!method->method_holder()->is_not_initialized()   ||
+         compile_reason == CompileTask::Reason_AOTPreload    ||
+         CompileTask::reason_is_aot_compile(compile_reason), "method holder must be initialized");
   assert(!method->is_method_handle_intrinsic(), "do not enqueue these guys");
 
   if (CIPrintRequests) {
-    tty->print("request: ");
-    method->print_short_name(tty);
+    ResourceMark rm;
+    stringStream ss;
+    const char* aotn = (compile_reason == CompileTask::Reason_AOTPreload) ? "AP" :
+                       (aot_code_entry != nullptr ? " A" : "  ");
+    ss.print("request %16s: %s%d", CompileTask::reason_name(compile_reason), aotn, comp_level);
     if (osr_bci != InvocationEntryBci) {
-      tty->print(" osr_bci: %d", osr_bci);
+      ss.print(" osr_bci: %d", osr_bci);
     }
-    tty->print(" level: %d comment: %s count: %d", comp_level, CompileTask::reason_name(compile_reason), hot_count);
-    if (hot_count > 0) {
-      tty->print(" hot: yes");
-    }
-    tty->cr();
+    ss.print(" hot_count: %d", hot_count);
+    method->print_short_name(&ss);
+    tty->print_cr("%s", ss.freeze());
   }
-
+  LogStreamHandle(Debug, aot, codecache, compilation) log;
+  if (log.is_enabled() && AOTCodeCache::is_using_code()) {
+    ResourceMark rm;
+    MethodTrainingData* mtd = MethodTrainingData::have_data() ? MethodTrainingData::find_fast(method) : nullptr;
+    MethodCounters* mc = method->method_counters();
+    const char* name = method->name_and_sig_as_C_string(true /* use_double_colon */);
+    const char* aotn = (compile_reason == CompileTask::Reason_AOTPreload) ? "AP" :
+                       (aot_code_entry != nullptr ? " A" : "  ");
+    const char* osrn = (osr_bci != InvocationEntryBci) ? "% " : "";
+    log.print("request %16s: %s%d %s%s", CompileTask::reason_name(compile_reason), aotn, comp_level, osrn, name);
+    if (mtd != nullptr) {
+      log.print(" (MTD invoke: %d, backedge: %d)", mtd->invocation_count(), mtd->backedge_count());
+    }
+    if (mc != nullptr) {
+      log.print(" (MC invoke: %d, backedge: %d)", mc->invocation_counter()->count(),
+                   mc->backedge_counter()->count());
+    }
+    log.cr();
+  }
   // A request has been made for compilation.  Before we do any
   // real work, check to see if the method has been compiled
   // in the meantime with a definitive result.
-  if (compilation_is_complete(method, osr_bci, comp_level)) {
+  if (compilation_is_complete(method, osr_bci, comp_level, aot_code_entry, compile_reason)) {
     return;
   }
 
@@ -1120,11 +1205,15 @@ void CompileBroker::compile_method_base(const methodHandle& method,
 
   // Tiered policy requires MethodCounters to exist before adding a method to
   // the queue. Create if we don't have them yet.
-  method->get_method_counters(thread);
+  if (method->get_method_counters(thread) == nullptr) {
+    return; // metaspace has hit an OOM
+  }
+
+  bool is_aot = (aot_code_entry != nullptr);
 
   // Outputs from the following MutexLocker block:
-  CompileTask* task     = nullptr;
-  CompileQueue* queue  = compile_queue(comp_level);
+  CompileTask* task = nullptr;
+  CompileQueue* queue = compile_queue(comp_level, is_aot);
 
   // Acquire our lock.
   {
@@ -1140,7 +1229,7 @@ void CompileBroker::compile_method_base(const methodHandle& method,
     // We need to check again to see if the compilation has
     // completed.  A previous compilation may have registered
     // some result.
-    if (compilation_is_complete(method, osr_bci, comp_level)) {
+    if (compilation_is_complete(method, osr_bci, comp_level, aot_code_entry, compile_reason)) {
       return;
     }
 
@@ -1194,7 +1283,7 @@ void CompileBroker::compile_method_base(const methodHandle& method,
     task = create_compile_task(queue,
                                compile_id, method,
                                osr_bci, comp_level,
-                               hot_count, compile_reason,
+                               hot_count, aot_code_entry, compile_reason,
                                blocking);
   }
 
@@ -1203,9 +1292,51 @@ void CompileBroker::compile_method_base(const methodHandle& method,
   }
 }
 
+void CompileBroker::preload_aot_method(const methodHandle& method, AOTCodeEntry* aot_code_entry, TRAPS) {
+  // Don't need most of the checks for AOT code preloading.
+  precond(_initialized);
+  precond(aot_code_entry != nullptr && aot_code_entry->for_preload());
+  // If the compiler is shut off due to code cache getting full
+  // fail out now so blocking compiles don't hang the java thread
+  if (should_compile_new_jobs()) {
+    int osr_bci = InvocationEntryBci;
+    int comp_level = CompLevel_full_optimization;
+    int hot_count  = 0;
+    CompileTask::CompileReason compile_reason = CompileTask::Reason_AOTPreload;
+
+    AbstractCompiler *comp = CompileBroker::compiler(comp_level);
+    assert(comp != nullptr, "Ensure we have a compiler");
+
+    nmethod* method_code = method->code();
+    if (method_code != nullptr) {
+      if (compilation_is_complete(method, osr_bci, comp_level, aot_code_entry, compile_reason)) {
+        return;
+      }
+    }
+    if (method->is_not_compilable(comp_level)) {
+      return;
+    }
+
+    // JVMTI -- post_compile_event requires jmethod_id() that may require
+    // a lock the compiling thread can not acquire. Prefetch it here.
+    if (JvmtiExport::should_post_compiled_method_load()) {
+      method->jmethod_id();
+    }
+
+    CompilerDirectiveMatcher matcher(method, comp_level);
+    bool is_blocking = ReplayCompiles                                             ||
+                       !matcher.directive_set()->BackgroundCompilationOption      ||
+                       (AOTPreloadBlocking && (compile_reason == CompileTask::Reason_AOTPreload));
+    // CompileBroker::compile_method can trap and can have pending async exception.
+    compile_method_base(method, aot_code_entry, osr_bci, comp_level, hot_count, compile_reason,
+                        is_blocking, THREAD);
+  }
+}
+
 nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
                                        int comp_level,
                                        int hot_count,
+                                       AOTCodeEntry* aot_code_entry,
                                        CompileTask::CompileReason compile_reason,
                                        TRAPS) {
   // Do nothing if compilebroker is not initialized or compiles are submitted on level none
@@ -1218,13 +1349,14 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
 
   CompilerDirectiveMatcher matcher(method, comp_level);
   // CompileBroker::compile_method can trap and can have pending async exception.
-  nmethod* nm = CompileBroker::compile_method(method, osr_bci, comp_level, hot_count, compile_reason, matcher.directive_set(), THREAD);
+  nmethod* nm = CompileBroker::compile_method(method, osr_bci, comp_level, hot_count, aot_code_entry, compile_reason, matcher.directive_set(), THREAD);
   return nm;
 }
 
 nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
                                          int comp_level,
                                          int hot_count,
+                                         AOTCodeEntry* aot_code_entry,
                                          CompileTask::CompileReason compile_reason,
                                          DirectiveSet* directive,
                                          TRAPS) {
@@ -1233,8 +1365,15 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
   assert(method->method_holder()->is_instance_klass(), "not an instance method");
   assert(osr_bci == InvocationEntryBci || (0 <= osr_bci && osr_bci < method->code_size()), "bci out of range");
   assert(!method->is_abstract() && (osr_bci == InvocationEntryBci || !method->is_native()), "cannot compile abstract/native methods");
-  assert(!method->method_holder()->is_not_initialized(), "method holder must be initialized");
+  assert(!method->method_holder()->is_not_initialized()   ||
+         compile_reason == CompileTask::Reason_AOTPreload    ||
+         CompileTask::reason_is_aot_compile(compile_reason), "method holder must be initialized");
   // return quickly if possible
+  bool aot_compilation = CDSConfig::is_dumping_aot_code();
+  if (aot_compilation && !CompileTask::reason_is_aot_compile(compile_reason)) {
+    // Skip normal compilations when compiling AOT code to speedup AOT compilation
+    return nullptr;
+  }
 
   // lock, make sure that the compilation
   // isn't prohibited in a straightforward way.
@@ -1247,7 +1386,7 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
     // standard compilation
     nmethod* method_code = method->code();
     if (method_code != nullptr) {
-      if (compilation_is_complete(method, osr_bci, comp_level)) {
+      if (compilation_is_complete(method, osr_bci, comp_level, aot_code_entry, compile_reason)) {
         return method_code;
       }
     }
@@ -1264,7 +1403,9 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
 
   assert(!HAS_PENDING_EXCEPTION, "No exception should be present");
   // some prerequisites that are compiler specific
-  if (comp->is_c2()) {
+  if (compile_reason != CompileTask::Reason_AOTPreload &&
+      !CompileTask::reason_is_aot_compile(compile_reason) &&
+      comp->is_c2()) {
     InternalOOMEMark iom(THREAD);
     method->constants()->resolve_string_constants(CHECK_AND_CLEAR_NONASYNC_NULL);
     // Resolve all classes seen in the signature of the method
@@ -1319,8 +1460,10 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
     if (!should_compile_new_jobs()) {
       return nullptr;
     }
-    bool is_blocking = !directive->BackgroundCompilationOption || ReplayCompiles;
-    compile_method_base(method, osr_bci, comp_level, hot_count, compile_reason, is_blocking, THREAD);
+    bool is_blocking = ReplayCompiles                                             ||
+                       !directive->BackgroundCompilationOption                    ||
+                       (AOTPreloadBlocking && (compile_reason == CompileTask::Reason_AOTPreload));
+    compile_method_base(method, aot_code_entry, osr_bci, comp_level, hot_count, compile_reason, is_blocking, THREAD);
   }
 
   // return requested nmethod
@@ -1336,9 +1479,14 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
 // CompileBroker::compilation_is_complete
 //
 // See if compilation of this method is already complete.
-bool CompileBroker::compilation_is_complete(const methodHandle& method,
-                                            int                 osr_bci,
-                                            int                 comp_level) {
+bool CompileBroker::compilation_is_complete(const methodHandle&        method,
+                                            int                        osr_bci,
+                                            int                        comp_level,
+                                            AOTCodeEntry*              aot_code_entry,
+                                            CompileTask::CompileReason compile_reason) {
+  if (CompileTask::reason_is_aot_compile(compile_reason)) {
+    return false;
+  }
   bool is_osr = (osr_bci != standard_entry_bci);
   if (is_osr) {
     if (method->is_not_osr_compilable(comp_level)) {
@@ -1352,8 +1500,20 @@ bool CompileBroker::compilation_is_complete(const methodHandle& method,
       return true;
     } else {
       nmethod* result = method->code();
-      if (result == nullptr) return false;
-      return comp_level == result->comp_level();
+      if (result == nullptr) {
+        return false;
+      }
+      if (result->is_aot()) {
+        if (aot_code_entry == nullptr) {
+          return false; // Allow replace AOT code with normal JITed code
+        } else if (aot_code_entry == result->aot_code_entry()) {
+          return true;
+        } else if (result->preloaded()) {
+           // Allow replace preloaded AOT code with regular AOT code of the same level
+          return (comp_level != result->comp_level());
+        }
+      }
+      return (comp_level == result->comp_level());
     }
   }
 }
@@ -1468,10 +1628,12 @@ CompileTask* CompileBroker::create_compile_task(CompileQueue*       queue,
                                                 int                 osr_bci,
                                                 int                 comp_level,
                                                 int                 hot_count,
+                                                AOTCodeEntry*       aot_code_entry,
                                                 CompileTask::CompileReason compile_reason,
                                                 bool                blocking) {
   CompileTask* new_task = new CompileTask(compile_id, method, osr_bci, comp_level,
-                                          hot_count, compile_reason, blocking);
+                                          hot_count, aot_code_entry, compile_reason,
+                                          blocking);
   queue->add(new_task);
   return new_task;
 }
@@ -1591,6 +1753,8 @@ void CompileBroker::free_buffer_blob_if_allocated(CompilerThread* thread) {
 void CompileBroker::shutdown_compiler_runtime(AbstractCompiler* comp, CompilerThread* thread) {
   free_buffer_blob_if_allocated(thread);
 
+  log_info(compilation)("shutdown_compiler_runtime: " INTPTR_FORMAT, p2i(thread));
+
   if (comp->should_perform_shutdown()) {
     // There are two reasons for shutting down the compiler
     // 1) compiler runtime initialization failed
@@ -1608,6 +1772,14 @@ void CompileBroker::shutdown_compiler_runtime(AbstractCompiler* comp, CompilerTh
 
     if (_c2_compile_queue != nullptr) {
       _c2_compile_queue->delete_all();
+    }
+
+    if (_ac1_compile_queue != nullptr) {
+      _ac1_compile_queue->delete_all();
+    }
+
+    if (_ac2_compile_queue != nullptr) {
+      _ac2_compile_queue->delete_all();
     }
 
     // Set flags so that we continue execution with using interpreter only.
@@ -1634,6 +1806,11 @@ CompileLog* CompileBroker::get_log(CompilerThread* ct) {
   assert(logs != nullptr, "must be initialized at this point");
   int count = c1 ? _c1_count : _c2_count;
 
+  if (ct->queue() == _ac1_compile_queue || ct->queue() == _ac2_compile_queue) {
+    compiler_objects = _ac_objects;
+    logs  = _ac_logs;
+    count = _ac_count;
+  }
   // Find Compiler number by its threadObj.
   oop compiler_obj = ct->threadObj();
   int compiler_number = 0;
@@ -1756,7 +1933,9 @@ void CompileBroker::compiler_thread_loop() {
         task->set_failure_reason("breakpoints are present");
       }
 
-      if (UseDynamicNumberOfCompilerThreads) {
+      // Don't use AOT compiler threads for dynamic C1 and C2 threads creation.
+      if (UseDynamicNumberOfCompilerThreads &&
+          (queue == _c1_compile_queue || queue == _c2_compile_queue)) {
         possibly_add_compiler_threads(thread);
         assert(!thread->has_pending_exception(), "should have been handled");
       }
@@ -2041,10 +2220,10 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
       comp->compile_method(&ci_env, target, osr_bci, true, directive);
 
       /* Repeat compilation without installing code for profiling purposes */
-      int repeat_compilation_count = directive->RepeatCompilationOption;
+      int repeat_compilation_count = task->is_aot_load() ? 0 : directive->RepeatCompilationOption;
       if (repeat_compilation_count > 0) {
         CHeapStringHolder failure_reason;
-        failure_reason.set(ci_env._failure_reason.get());
+        failure_reason.set(ci_env.failure_reason());
         while (repeat_compilation_count > 0) {
           ResourceMark rm(thread);
           task->print_ul("NO CODE INSTALLED");
@@ -2058,11 +2237,18 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
     }
 
 
-    if (!ci_env.failing() && !task->is_success()) {
+    if (!ci_env.failing() && !task->is_success() && !task->is_aot_compile()) {
       const char* reason = task->failure_reason();
       assert(reason != nullptr, "compiler should always document failure");
-      // Do not attempt further compilations of this method.
-      ci_env.record_method_not_compilable(reason != nullptr ? reason : "compile failed: reason unknown");
+      if (reason == nullptr) {
+        reason = "compile failed: reason unknown";
+      }
+      if (task->is_aot_load()) {
+        ci_env._failure_reason.set(reason);
+      } else {
+        // Do not attempt further compilations of this method.
+        ci_env.record_method_not_compilable(reason);
+      }
     }
 
     // Copy this bit to the enclosing block:
@@ -2269,6 +2455,17 @@ void CompileBroker::collect_statistics(CompilerThread* thread, elapsedTimer time
       _perf_total_bailout_count->inc();
     }
     _t_bailedout_compilation.add(time);
+
+    if (CITime || log_is_enabled(Info, init)) {
+      CompilerStatistics* stats = nullptr;
+      if (task->is_aot_load()) {
+        int level = task->preload() ? CompLevel_full_optimization : (comp_level - 1);
+        stats = &_aot_stats_per_level[level];
+      } else {
+        stats = &_stats_per_level[comp_level-1];
+      }
+      stats->_bailout.update(time, 0);
+    }
   } else if (!task->is_success()) {
     if (UsePerfData) {
       _perf_last_invalidated_method->set_value(counters->current_method());
@@ -2277,9 +2474,20 @@ void CompileBroker::collect_statistics(CompilerThread* thread, elapsedTimer time
     }
     _total_invalidated_count++;
     _t_invalidated_compilation.add(time);
+
+    if (CITime || log_is_enabled(Info, init)) {
+      CompilerStatistics* stats = nullptr;
+      if (task->is_aot_load()) {
+        int level = task->preload() ? CompLevel_full_optimization : (comp_level - 1);
+        stats = &_aot_stats_per_level[level];
+      } else {
+        stats = &_stats_per_level[comp_level-1];
+      }
+      stats->_invalidated.update(time, 0);
+    }
   } else {
     // Compilation succeeded
-    if (CITime) {
+    if (CITime || log_is_enabled(Info, init)) {
       int bytes_compiled = method->code_size() + task->num_inlined_bytecodes();
       if (is_osr) {
         _t_osr_compilation.add(time);
@@ -2290,7 +2498,16 @@ void CompileBroker::collect_statistics(CompilerThread* thread, elapsedTimer time
       }
 
       // Collect statistic per compilation level
-      if (comp_level > CompLevel_none && comp_level <= CompLevel_full_optimization) {
+      if (task->is_aot_load()) {
+        _aot_stats._standard.update(time, bytes_compiled);
+        _aot_stats._nmethods_size += task->nm_total_size();
+        _aot_stats._nmethods_code_size += task->nm_insts_size();
+        int level = task->preload() ? CompLevel_full_optimization : (comp_level - 1);
+        CompilerStatistics* stats = &_aot_stats_per_level[level];
+        stats->_standard.update(time, bytes_compiled);
+        stats->_nmethods_size += task->nm_total_size();
+        stats->_nmethods_code_size += task->nm_insts_size();
+      } else if (comp_level > CompLevel_none && comp_level <= CompLevel_full_optimization) {
         CompilerStatistics* stats = &_stats_per_level[comp_level-1];
         if (is_osr) {
           stats->_osr.update(time, bytes_compiled);
@@ -2305,7 +2522,7 @@ void CompileBroker::collect_statistics(CompilerThread* thread, elapsedTimer time
 
       // Collect statistic per compiler
       AbstractCompiler* comp = task->compiler();
-      if (comp) {
+      if (comp && !task->is_aot_load()) {
         CompilerStatistics* stats = comp->stats();
         if (is_osr) {
           stats->_osr.update(time, bytes_compiled);
@@ -2314,7 +2531,7 @@ void CompileBroker::collect_statistics(CompilerThread* thread, elapsedTimer time
         }
         stats->_nmethods_size += task->nm_total_size();
         stats->_nmethods_code_size += task->nm_insts_size();
-      } else { // if (!comp)
+      } else if (!task->is_aot_load()) { // if (!comp)
         assert(false, "Compiler object must exist");
       }
     }
@@ -2377,6 +2594,24 @@ jlong CompileBroker::total_compilation_ticks() {
   return _perf_total_compilation != nullptr ? _perf_total_compilation->get_value() : 0;
 }
 
+void CompileBroker::log_not_entrant(nmethod* nm) {
+  _total_not_entrant_count++;
+  if (CITime || log_is_enabled(Info, init)) {
+    CompilerStatistics* stats = nullptr;
+    int level = nm->comp_level();
+    if (nm->is_aot()) {
+      if (nm->preloaded()) {
+        assert(level == CompLevel_full_optimization, "%d", level);
+        level = CompLevel_full_optimization + 1;
+      }
+      stats = &_aot_stats_per_level[level - 1];
+    } else {
+      stats = &_stats_per_level[level - 1];
+    }
+    stats->_made_not_entrant._count++;
+  }
+}
+
 void CompileBroker::print_times(const char* name, CompilerStatistics* stats) {
   tty->print_cr("  %s {speed: %6.3f bytes/s; standard: %6.3f s, %u bytes, %u methods; osr: %6.3f s, %u bytes, %u methods; nmethods_size: %u bytes; nmethods_code_size: %u bytes}",
                 name, stats->bytes_per_second(),
@@ -2385,11 +2620,100 @@ void CompileBroker::print_times(const char* name, CompilerStatistics* stats) {
                 stats->_nmethods_size, stats->_nmethods_code_size);
 }
 
+static void print_helper(outputStream* st, const char* name, CompilerStatistics::Data data, bool print_time = true) {
+  if (data._count > 0) {
+    st->print("; %s: %4u methods", name, data._count);
+    if (print_time) {
+      st->print(" (in %.3fs)", data._time.seconds());
+    }
+  }
+}
+
+static void print_tier_helper(outputStream* st, const char* prefix, int tier, CompilerStatistics* stats) {
+  st->print("    %s%d: %5u methods", prefix, tier, stats->_standard._count);
+  if (stats->_standard._count > 0) {
+    st->print(" (in %.3fs)", stats->_standard._time.seconds());
+  }
+  print_helper(st, "osr",     stats->_osr);
+  print_helper(st, "bailout", stats->_bailout);
+  print_helper(st, "invalid", stats->_invalidated);
+  print_helper(st, "not_entrant", stats->_made_not_entrant, false);
+  st->cr();
+}
+
+static void print_queue_info(outputStream* st, CompileQueue* queue) {
+  if (queue != nullptr) {
+    MutexLocker ml(MethodCompileQueue_lock);
+
+    uint  total_cnt = 0;
+    uint active_cnt = 0;
+    for (JavaThread* jt : *ThreadsSMRSupport::get_java_thread_list()) {
+      guarantee(jt != nullptr, "");
+      if (jt->is_Compiler_thread()) {
+        CompilerThread* ct = (CompilerThread*)jt;
+
+        guarantee(ct != nullptr, "");
+        if (ct->queue() == queue) {
+          ++total_cnt;
+          CompileTask* task = ct->task();
+          if (task != nullptr) {
+            ++active_cnt;
+          }
+        }
+      }
+    }
+
+    st->print("  %s (%d active / %d total threads): %u tasks",
+              queue->name(), active_cnt, total_cnt, queue->size());
+    if (queue->size() > 0) {
+      uint counts[] = {0, 0, 0, 0, 0}; // T1 ... T5
+      for (CompileTask* task = queue->first(); task != nullptr; task = task->next()) {
+        int tier = task->comp_level();
+        if (task->is_aot_load() && task->preload()) {
+          assert(tier == CompLevel_full_optimization, "%d", tier);
+          tier = CompLevel_full_optimization + 1;
+        }
+        counts[tier-1]++;
+      }
+      st->print(":");
+      for (int tier = CompLevel_simple; tier <= CompilationPolicy::highest_compile_level() + 1; tier++) {
+        uint cnt = counts[tier-1];
+        if (cnt > 0) {
+          st->print(" T%d: %u tasks;", tier, cnt);
+        }
+      }
+    }
+    st->cr();
+  }
+}
+void CompileBroker::print_statistics_on(outputStream* st) {
+  st->print_cr("  Total: %u methods; %u bailouts, %u invalidated, %u non_entrant",
+               _total_compile_count, _total_bailout_count, _total_invalidated_count, _total_not_entrant_count);
+  for (int tier = CompLevel_simple; tier <= CompilationPolicy::highest_compile_level(); tier++) {
+    print_tier_helper(st, "Tier", tier, &_stats_per_level[tier-1]);
+  }
+  st->cr();
+
+  if (AOTCodeCaching) {
+    for (int tier = CompLevel_simple; tier <= CompilationPolicy::highest_compile_level() + 1; tier++) {
+      if (tier != CompLevel_full_profile) {
+        print_tier_helper(st, "AOT Code T", tier, &_aot_stats_per_level[tier - 1]);
+      }
+    }
+    st->cr();
+  }
+
+  print_queue_info(st, _c1_compile_queue);
+  print_queue_info(st, _c2_compile_queue);
+  print_queue_info(st, _ac1_compile_queue);
+  print_queue_info(st, _ac2_compile_queue);
+}
+
 void CompileBroker::print_times(bool per_compiler, bool aggregate) {
   if (per_compiler) {
     if (aggregate) {
       tty->cr();
-      tty->print_cr("Individual compiler times (for compiled methods only)");
+      tty->print_cr("[%dms] Individual compiler times (for compiled methods only)", (int)tty->time_stamp().milliseconds());
       tty->print_cr("------------------------------------------------");
       tty->cr();
     }
@@ -2398,6 +2722,9 @@ void CompileBroker::print_times(bool per_compiler, bool aggregate) {
       if (comp != nullptr) {
         print_times(comp->name(), comp->stats());
       }
+    }
+    if (_aot_stats._standard._count > 0) {
+      print_times("AC", &_aot_stats);
     }
     if (aggregate) {
       tty->cr();
@@ -2410,6 +2737,13 @@ void CompileBroker::print_times(bool per_compiler, bool aggregate) {
       CompilerStatistics* stats = &_stats_per_level[tier-1];
       os::snprintf_checked(tier_name, sizeof(tier_name), "Tier%d", tier);
       print_times(tier_name, stats);
+    }
+    for (int tier = CompLevel_simple; tier <= CompilationPolicy::highest_compile_level() + 1; tier++) {
+      CompilerStatistics* stats = &_aot_stats_per_level[tier-1];
+      if (stats->_standard._bytes > 0) {
+        os::snprintf_checked(tier_name, sizeof(tier_name), "AOT Code T%d", tier);
+        print_times(tier_name, stats);
+      }
     }
   }
 
@@ -2452,6 +2786,10 @@ void CompileBroker::print_times(bool per_compiler, bool aggregate) {
                 CompileBroker::_t_invalidated_compilation.seconds(),
                 total_invalidated_count == 0 ? 0.0 : CompileBroker::_t_invalidated_compilation.seconds() / total_invalidated_count);
 
+  if (AOTCodeCaching) { // Check flags because AOT code cache could be closed already
+    tty->cr();
+    AOTCodeCache::print_timers_on(tty);
+  }
   AbstractCompiler *comp = compiler(CompLevel_simple);
   if (comp != nullptr) {
     tty->cr();

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -184,13 +184,13 @@ class CompileBroker: AllStatic {
   static AbstractCompiler* _compilers[2];
 
   // The maximum numbers of compiler threads to be determined during startup.
-  static int _c1_count, _c2_count;
+  static int _c1_count, _c2_count, _ac_count;
 
   // An array of compiler thread Java objects
-  static jobject *_compiler1_objects, *_compiler2_objects;
+  static jobject *_compiler1_objects, *_compiler2_objects, *_ac_objects;
 
   // An array of compiler logs
-  static CompileLog **_compiler1_logs, **_compiler2_logs;
+  static CompileLog **_compiler1_logs, **_compiler2_logs, **_ac_logs;
 
   // These counters are used for assigning id's to each compilation
   static volatile jint _compilation_id;
@@ -199,6 +199,8 @@ class CompileBroker: AllStatic {
 
   static CompileQueue* _c2_compile_queue;
   static CompileQueue* _c1_compile_queue;
+  static CompileQueue* _ac1_compile_queue;
+  static CompileQueue* _ac2_compile_queue;
 
   // performance counters
   static PerfCounter* _perf_total_compilation;
@@ -234,6 +236,7 @@ class CompileBroker: AllStatic {
   static uint _total_compile_count;
   static uint _total_bailout_count;
   static uint _total_invalidated_count;
+  static uint _total_not_entrant_count;
   static uint _total_native_compile_count;
   static uint _total_osr_compile_count;
   static uint _total_standard_compile_count;
@@ -246,6 +249,8 @@ class CompileBroker: AllStatic {
   static jlong _peak_compilation_time;
 
   static CompilerStatistics _stats_per_level[];
+  static CompilerStatistics _aot_stats;
+  static CompilerStatistics _aot_stats_per_level[];
 
   static volatile int _print_compilation_warning;
 
@@ -255,6 +260,7 @@ class CompileBroker: AllStatic {
     training_replay_t
   };
 
+  static Handle create_thread_oop(const char* name, TRAPS);
   static JavaThread* make_thread(ThreadType type, jobject thread_oop, CompileQueue* queue, AbstractCompiler* comp, JavaThread* THREAD);
   static void init_compiler_threads();
   static void init_training_replay();
@@ -267,9 +273,14 @@ class CompileBroker: AllStatic {
                                           int                 osr_bci,
                                           int                 comp_level,
                                           int                 hot_count,
+                                          AOTCodeEntry*       aot_code_entry,
                                           CompileTask::CompileReason compile_reason,
                                           bool                blocking);
   static void wait_for_completion(CompileTask* task);
+public:
+  static void wait_for_no_active_tasks();
+
+private:
   static void free_buffer_blob_if_allocated(CompilerThread* thread);
 
   static void invoke_compiler_on_method(CompileTask* task);
@@ -280,6 +291,7 @@ class CompileBroker: AllStatic {
   static void collect_statistics(CompilerThread* thread, elapsedTimer time, CompileTask* task);
 
   static void compile_method_base(const methodHandle& method,
+                                  AOTCodeEntry* aot_code_entry,
                                   int osr_bci,
                                   int comp_level,
                                   int hot_count,
@@ -287,7 +299,7 @@ class CompileBroker: AllStatic {
                                   bool blocking,
                                   Thread* thread);
 
-  static CompileQueue* compile_queue(int comp_level);
+  static CompileQueue* compile_queue(int comp_level, bool is_aot);
   static bool init_compiler_runtime();
   static void shutdown_compiler_runtime(AbstractCompiler* comp, CompilerThread* thread);
 
@@ -303,11 +315,14 @@ public:
     return nullptr;
   }
 
-  static bool compilation_is_complete(const methodHandle& method, int osr_bci, int comp_level);
+  static bool initialized() { return _initialized; }
+  static bool compilation_is_complete(const methodHandle& method, int osr_bci, int comp_level,
+                                      AOTCodeEntry* aot_code_entry,
+                                      CompileTask::CompileReason compile_reason);
   static bool compilation_is_in_queue(const methodHandle& method);
   static void print_compile_queues(outputStream* st);
-  static int queue_size(int comp_level) {
-    CompileQueue *q = compile_queue(comp_level);
+  static int queue_size(int comp_level, bool is_aot = false) {
+    CompileQueue *q = compile_queue(comp_level, is_aot);
     return q != nullptr ? q->size() : 0;
   }
   static void compilation_init(JavaThread* THREAD);
@@ -316,7 +331,11 @@ public:
                                  int osr_bci,
                                  int comp_level,
                                  int hot_count,
+                                 AOTCodeEntry* aot_code_entry,
                                  CompileTask::CompileReason compile_reason,
+                                 TRAPS);
+  static void preload_aot_method(const methodHandle& method,
+                                 AOTCodeEntry* aot_code_entry,
                                  TRAPS);
   static CompileQueue* c1_compile_queue();
   static CompileQueue* c2_compile_queue();
@@ -326,6 +345,7 @@ private:
                                    int osr_bci,
                                    int comp_level,
                                    int hot_count,
+                                   AOTCodeEntry* aot_code_entry,
                                    CompileTask::CompileReason compile_reason,
                                    DirectiveSet* directive,
                                    TRAPS);
@@ -377,8 +397,6 @@ public:
     return AtomicAccess::load(&_should_compile_new_jobs) == shutdown_compilation;
   }
 
-  static void wait_for_no_active_tasks();
-
   static void handle_full_code_cache(CodeBlobType code_blob_type);
   // Ensures that warning is only printed once.
   static bool should_print_compiler_warning() {
@@ -413,6 +431,12 @@ public:
     return _compiler2_objects[idx];
   }
 
+  static jobject ac_object(int idx) {
+    assert(_ac_objects != nullptr, "must be initialized");
+    assert(idx < _ac_count, "oob");
+    return _ac_objects[idx];
+  }
+
   static AbstractCompiler* compiler1() { return _compilers[0]; }
   static AbstractCompiler* compiler2() { return _compilers[1]; }
 
@@ -437,8 +461,12 @@ public:
   static jlong get_peak_compilation_time() {        return _peak_compilation_time; }
   static jlong get_total_compilation_time() {       return _t_total_compilation.milliseconds(); }
 
+  static void log_not_entrant(nmethod* nm);
+
   // Log that compilation profiling is skipped because metaspace is full.
   static void log_metaspace_failure();
+
+  static void print_statistics_on(outputStream* st);
 
   // CodeHeap State Analytics.
   static void print_info(outputStream *out);

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -43,6 +43,7 @@ CompileTask::CompileTask(int compile_id,
                          int osr_bci,
                          int comp_level,
                          int hot_count,
+                         AOTCodeEntry* aot_code_entry,
                          CompileReason compile_reason,
                          bool is_blocking) :
   _compile_id(compile_id),
@@ -57,6 +58,7 @@ CompileTask::CompileTask(int compile_id,
   _nm_insts_size(0),
   _comp_level(comp_level),
   _compiler(CompileBroker::compiler(comp_level)),
+  _aot_code_entry(aot_code_entry),
   _comp_directive_matcher(method, static_cast<CompLevel>(comp_level)),
   _num_inlined_bytecodes(0),
   _next(nullptr),
@@ -65,6 +67,8 @@ CompileTask::CompileTask(int compile_id,
   _time_queued(0),
   _time_started(0),
   _time_finished(0),
+  _aot_load_start(0),
+  _aot_load_finish(0),
   _hot_count(hot_count),
   _compile_reason(compile_reason),
   _failure_reason(nullptr),
@@ -167,22 +171,31 @@ void CompileTask::print_tty() {
 
 void CompileTask::print_post(outputStream* st) {
   bool is_osr_method = osr_bci() != InvocationEntryBci;
+  bool is_aot = is_aot_load();
+  bool is_preload = preload();
+  if (is_aot_compile()) {
+    // Tag AOT compilation too
+    is_aot = true;
+    is_preload = (compile_reason() == Reason_AOTCompileForPreload);
+  }
   print_impl(st, is_unloaded() ? nullptr : method(), compile_id(), comp_level(),
-             is_osr_method, osr_bci(), is_blocking(),
+             is_osr_method, osr_bci(), is_blocking(), is_aot, is_preload,
              compiler()->name(), nullptr, false /* short_form */, true /* cr */,
              true /* after_compile_details */,
              _num_inlined_bytecodes, _nm_total_size, _nm_insts_size,
-             _time_created, _time_queued, _time_started, _time_finished);
+             _time_created, _time_queued, _time_started, _time_finished,
+             _aot_load_start, _aot_load_finish);
 }
 
 // ------------------------------------------------------------------
 // CompileTask::print_impl
 void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, int comp_level,
-                             bool is_osr_method, int osr_bci, bool is_blocking,
+                             bool is_osr_method, int osr_bci, bool is_blocking, bool is_aot, bool is_preload,
                              const char* compiler_name,
                              const char* msg, bool short_form, bool cr, bool after_compile_details,
                              int inlined_bytecodes, int nm_total_size, int nm_insts_size,
-                             jlong time_created, jlong time_queued, jlong time_started, jlong time_finished) {
+                             jlong time_created, jlong time_queued, jlong time_started, jlong time_finished,
+                             jlong aot_load_start, jlong aot_load_finish) {
   // Use stringStream to avoid breaking the line
   stringStream sst;
   if (after_compile_details) {
@@ -209,6 +222,13 @@ void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, i
       stringStream ss;
       if (time_started != 0 && time_finished != 0) {
         ss.print("C%.1f", TimeHelper::counter_to_millis(time_finished - time_started));
+      }
+      sst.print("%7s ", ss.freeze());
+    }
+    { // Time to load from AOT code cache
+      stringStream ss;
+      if (aot_load_start != 0 && aot_load_finish != 0) {
+        ss.print("A%.1f", TimeHelper::counter_to_millis(aot_load_finish - aot_load_start));
       }
       sst.print("%7s ", ss.freeze());
     }
@@ -245,9 +265,11 @@ void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, i
   const char exception_char = has_exception_handler           ? '!' : ' ';
   const char blocking_char  = is_blocking                     ? 'b' : ' ';
   const char native_char    = is_native                       ? 'n' : ' ';
+  const char aot_char       = is_aot                          ? 'A' : ' ';
+  const char preload_char   = is_preload                      ? 'P' : ' ';
 
   // print method attributes
-  sst.print("%c%c%c%c%c ", compile_type, sync_char, exception_char, blocking_char, native_char);
+  sst.print("%c%c%c%c%c%c%c ", compile_type, sync_char, exception_char, blocking_char, native_char, aot_char, preload_char);
 
   if (TieredCompilation) {
     if (comp_level != -1)  sst.print("%d ", comp_level);
@@ -290,8 +312,15 @@ void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, i
 // CompileTask::print_compilation
 void CompileTask::print(outputStream* st, const char* msg, bool short_form, bool cr) {
   bool is_osr_method = osr_bci() != InvocationEntryBci;
+  bool is_aot = is_aot_load();
+  bool is_preload = preload();
+  if (is_aot_compile()) {
+    // Tag AOT compilation too
+    is_aot = true;
+    is_preload = (compile_reason() == Reason_AOTCompileForPreload);
+  }
   print_impl(st, is_unloaded() ? nullptr : method(), compile_id(), comp_level(),
-             is_osr_method, osr_bci(), is_blocking(),
+             is_osr_method, osr_bci(), is_blocking(), is_aot, is_preload,
              compiler()->name(), msg, short_form, cr);
 }
 
@@ -306,6 +335,10 @@ void CompileTask::log_task(xmlStream* log) {
   log->print(" compile_id='%d'", _compile_id);
   if (_osr_bci != CompileBroker::standard_entry_bci) {
     log->print(" compile_kind='osr'");  // same as nmethod::compile_kind
+  } else if (preload()) {
+    log->print(" compile_kind='AP'");
+  } else if (is_aot_load()) {
+    log->print(" compile_kind='A'");
   } // else compile_kind='c2c'
   if (!method.is_null())  log->method(method());
   if (_osr_bci != CompileBroker::standard_entry_bci) {
@@ -317,7 +350,6 @@ void CompileTask::log_task(xmlStream* log) {
   if (_is_blocking) {
     log->print(" blocking='1'");
   }
-  log->stamp();
 }
 
 // ------------------------------------------------------------------
@@ -335,15 +367,17 @@ void CompileTask::log_task_queued() {
   if (_hot_count != 0) {
     xtty->print(" hot_count='%d'", _hot_count);
   }
+  xtty->stamp();
   xtty->end_elem();
 }
 
 
 // ------------------------------------------------------------------
 // CompileTask::log_task_start
-void CompileTask::log_task_start(CompileLog* log)   {
+void CompileTask::log_task_start(CompileLog* log) {
   log->begin_head("task");
   log_task(log);
+  log->stamp();
   log->end_head();
 }
 
@@ -485,8 +519,8 @@ void CompileTask::print_ul(const nmethod* nm, const char* msg) {
     print_impl(&ls, nm->method(), nm->compile_id(),
                nm->comp_level(), nm->is_osr_method(),
                nm->is_osr_method() ? nm->osr_entry_bci() : -1,
-               /*is_blocking*/ false,
-               nm->compiler_name(),
+               /*is_blocking*/ false, nm->is_aot(),
+               nm->preloaded(), nm->compiler_name(),
                msg, /* short form */ true, /* cr */ true);
   }
 }

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -33,7 +33,10 @@
 #include "runtime/mutexLocker.hpp"
 #include "utilities/xmlstream.hpp"
 
+class AOTCodeEntry;
+class CompileQueue;
 class CompileTrainingData;
+class DirectiveSet;
 
 enum class InliningResult { SUCCESS, FAILURE };
 
@@ -60,6 +63,10 @@ class CompileTask : public CHeapObj<mtCompiler> {
       Reason_Replay,           // ciReplay
       Reason_Whitebox,         // Whitebox API
       Reason_MustBeCompiled,   // Used for -Xcomp or AlwaysCompileLoopMethods (see CompilationPolicy::must_be_compiled())
+      Reason_AOTLoad,          // load AOT code
+      Reason_AOTPreload,       // pre-load AOT code
+      Reason_AOTCompile,
+      Reason_AOTCompileForPreload,
       Reason_Count
   };
 
@@ -72,9 +79,18 @@ class CompileTask : public CHeapObj<mtCompiler> {
       "replay",
       "whitebox",
       "must_be_compiled",
-      "bootstrap"
+      "bootstrap",
+      "aot_load",
+      "aot_preload",
+      "aot_compile",
+      "aot_compile_for_preload",
     };
     return reason_names[compile_reason];
+  }
+
+  static bool reason_is_aot_compile(CompileTask::CompileReason compile_reason) {
+    return (compile_reason == CompileTask::Reason_AOTCompile) ||
+           (compile_reason == CompileTask::Reason_AOTCompileForPreload);
   }
 
  private:
@@ -91,6 +107,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
   CodeSection::csize_t _nm_insts_size;
   int                  _comp_level;
   AbstractCompiler*    _compiler;
+  AOTCodeEntry*        _aot_code_entry;
   CompilerDirectiveMatcher _comp_directive_matcher;
   int                  _num_inlined_bytecodes;
   CompileTask*         _next;
@@ -100,6 +117,8 @@ class CompileTask : public CHeapObj<mtCompiler> {
   jlong                _time_queued;  // time when task was enqueued
   jlong                _time_started; // time when compilation started
   jlong                _time_finished; // time when compilation finished
+  jlong                _aot_load_start;
+  jlong                _aot_load_finish;
   int                  _hot_count;    // information about its invocation counter
   CompileReason        _compile_reason;      // more info about the task
   const char*          _failure_reason;
@@ -110,26 +129,32 @@ class CompileTask : public CHeapObj<mtCompiler> {
 
  public:
   CompileTask(int compile_id, const methodHandle& method, int osr_bci, int comp_level,
-              int hot_count, CompileReason compile_reason, bool is_blocking);
+                  int hot_count, AOTCodeEntry* aot_code_entry,
+                  CompileTask::CompileReason compile_reason,
+                  bool is_blocking);
   ~CompileTask();
 
   static void wait_for_no_active_tasks();
 
-  int          compile_id() const                { return _compile_id; }
-  Method*      method() const                    { return _method; }
-  int          osr_bci() const                   { return _osr_bci; }
-  bool         is_complete() const               { return _is_complete; }
-  bool         is_blocking() const               { return _is_blocking; }
-  bool         is_success() const                { return _is_success; }
-  DirectiveSet* directive() const                { return _comp_directive_matcher.directive_set(); }
+  int          compile_id() const                   { return _compile_id; }
+  Method*      method() const                       { return _method; }
+  int          osr_bci() const                      { return _osr_bci; }
+  bool         is_complete() const                  { return _is_complete; }
+  bool         is_blocking() const                  { return _is_blocking; }
+  bool         is_success() const                   { return _is_success; }
+  bool         is_aot_load() const                  { return _aot_code_entry != nullptr; }
+  AOTCodeEntry* aot_code_entry()                    { return _aot_code_entry; }
+  DirectiveSet* directive() const                   { return _comp_directive_matcher.directive_set(); }
   void         transfer_directive(CompilerDirectiveMatcher& matcher) { _comp_directive_matcher.transfer_from(matcher); }
-  CompileReason compile_reason() const           { return _compile_reason; }
+  CompileReason compile_reason() const              { return _compile_reason; }
+
   CodeSection::csize_t nm_content_size() { return _nm_content_size; }
   void         set_nm_content_size(CodeSection::csize_t size) { _nm_content_size = size; }
   CodeSection::csize_t nm_insts_size() { return _nm_insts_size; }
   void         set_nm_insts_size(CodeSection::csize_t size) { _nm_insts_size = size; }
   CodeSection::csize_t nm_total_size() { return _nm_total_size; }
   void         set_nm_total_size(CodeSection::csize_t size) { _nm_total_size = size; }
+  bool         preload() const                   { return (_compile_reason == Reason_AOTPreload); }
   bool         can_become_stale() const          {
     switch (_compile_reason) {
       case Reason_BackedgeCount:
@@ -141,11 +166,17 @@ class CompileTask : public CHeapObj<mtCompiler> {
     }
   }
 
+  bool is_aot_compile() {
+    return reason_is_aot_compile(compile_reason());
+  }
+
   void         mark_complete()                   { _is_complete = true; }
   void         mark_success()                    { _is_success = true; }
   void         mark_queued(jlong time)           { _time_queued = time; }
   void         mark_started(jlong time)          { _time_started = time; }
   void         mark_finished(jlong time)         { _time_finished = time; }
+  void         mark_aot_load_start(jlong time)   { _aot_load_start = time; }
+  void         mark_aot_load_finish(jlong time)  { _aot_load_finish = time; }
   int          comp_level()                      { return _comp_level;}
   void         set_comp_level(int comp_level)    { _comp_level = comp_level;}
 
@@ -176,12 +207,14 @@ class CompileTask : public CHeapObj<mtCompiler> {
 private:
   static void  print_impl(outputStream* st, Method* method, int compile_id, int comp_level,
                                       bool is_osr_method = false, int osr_bci = -1, bool is_blocking = false,
+                                      bool is_aot = false, bool is_preload = false,
                                       const char* compiler_name = nullptr,
                                       const char* msg = nullptr, bool short_form = false, bool cr = true,
                                       bool after_compile_details = false,
                                       int inlined_bytecodes = 0, int nm_total_size = 0, int nm_insts_size = 0,
                                       jlong time_created = 0, jlong time_queued = 0,
-                                      jlong time_started = 0, jlong time_finished = 0);
+                                      jlong time_started = 0, jlong time_finished = 0,
+                                      jlong aot_load_start = 0, jlong aot_load_finish = 0);
 
 public:
   void         print(outputStream* st = tty, const char* msg = nullptr, bool short_form = false, bool cr = true);
@@ -189,6 +222,7 @@ public:
   static void  print(outputStream* st, const nmethod* nm, const char* msg = nullptr, bool short_form = false, bool cr = true) {
     print_impl(st, nm->method(), nm->compile_id(), nm->comp_level(),
                nm->is_osr_method(), nm->is_osr_method() ? nm->osr_entry_bci() : -1, /*is_blocking*/ false,
+               nm->is_aot(), nm->preloaded(),
                nm->compiler_name(), msg, short_form, cr);
   }
   static void  print_ul(const nmethod* nm, const char* msg = nullptr);

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -52,7 +52,10 @@
     cflags(DumpReplay,              bool, false, DumpReplay) \
     cflags(DumpInline,              bool, false, DumpInline) \
     cflags(CompilerDirectivesIgnoreCompileCommands, bool, CompilerDirectivesIgnoreCompileCommands, Unknown) \
-    cflags(RepeatCompilation,       intx, RepeatCompilation, RepeatCompilation)
+    cflags(RepeatCompilation,       intx, RepeatCompilation, RepeatCompilation) \
+    cflags(DontAOTCompile,          bool, false, DontAOTCompile) \
+    cflags(DontPreload,             bool, false, DontPreload) \
+    cflags(IgnoreAOTCompiled,       bool, false, IgnoreAOTCompiled)
 #define compilerdirectives_common_string_flags(cflags)                           \
   cflags(DisableIntrinsic,        ccstrlist, DisableIntrinsic, DisableIntrinsic) \
   cflags(ControlIntrinsic,        ccstrlist, ControlIntrinsic, ControlIntrinsic)

--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -95,6 +95,9 @@ NOT_PRODUCT(option(TraceMergeStores, "TraceMergeStores", Ccstrlist)) \
   option(CloneMapDebug, "CloneMapDebug", Bool) \
   option(IncrementalInlineForceCleanup, "IncrementalInlineForceCleanup", Bool) \
   option(MaxNodeLimit, "MaxNodeLimit", Intx)  \
+  option(DontAOTCompile, "DontAOTCompile", Bool) \
+  option(DontPreload, "DontPreload", Bool) \
+  option(IgnoreAOTCompiled, "IgnoreAOTCompiled", Bool) \
 NOT_PRODUCT(option(TestOptionInt,    "TestOptionInt",    Intx)) \
 NOT_PRODUCT(option(TestOptionUint,   "TestOptionUint",   Uintx)) \
 NOT_PRODUCT(option(TestOptionBool,   "TestOptionBool",   Bool)) \

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -383,6 +383,45 @@
           "If compilation is stopped with an error, capture diagnostic "    \
           "information at the bailout point")                               \
                                                                             \
+  /* AOT Code Caching flags */                                              \
+                                                                            \
+  product(uint, DisableAOTCode, 0, DIAGNOSTIC,                              \
+          "Disable AOT code on some compilation levels "                    \
+          "(T1=1; T2=10; T4=1000; T5/preload=10000)")                       \
+          constraint(DisableAOTCodeConstraintFunc, AtParse)                 \
+                                                                            \
+  product(uint, ClassInitBarrierMode, 0, DIAGNOSTIC,                        \
+          "Produce AOT preload code which could be called on first "        \
+          "method invocation, add class initialization barriers, "          \
+          "other checks and constraints if needed "                         \
+          "(0: no barriers; 1: uncommon trap)")                             \
+          range(0, 1)                                                       \
+                                                                            \
+  product(uint, AOTCodePreloadStart, 0, DIAGNOSTIC,                         \
+          "The id of the first AOT code to preload")                        \
+                                                                            \
+  product(uint, AOTCodePreloadStop, max_jint, DIAGNOSTIC,                   \
+          "The id of the last AOT code to preload")                         \
+                                                                            \
+  product(double, AOTCodeInvokeBase, 100.0, DIAGNOSTIC,                     \
+          "AOT code invocation base limit")                                 \
+          range(1.0, DBL_MAX)                                               \
+                                                                            \
+  product(double, AOTCodeInvokeScale, 1.0, DIAGNOSTIC,                      \
+          "scale AOT code invocation limit")                                \
+          range(0.001, DBL_MAX)                                             \
+                                                                            \
+  product(bool, UseAOTCodeCounters, true, DIAGNOSTIC,                       \
+          "Use AOT code counter to trigger JIT compilation")                \
+                                                                            \
+  product(bool, VerifyAOTCode, false, DIAGNOSTIC,                           \
+          "Load AOT code but not publish")                                  \
+                                                                            \
+  product(bool, AOTPreloadBlocking, false, DIAGNOSTIC,                      \
+          "Preload code is processed with blocking. Startup would not "     \
+          "proceed until all preloaded code is done loading.")              \
+                                                                            \
+
 // end of COMPILER_FLAGS
 
 DECLARE_FLAGS(COMPILER_FLAGS)

--- a/src/hotspot/share/compiler/oopMap.cpp
+++ b/src/hotspot/share/compiler/oopMap.cpp
@@ -111,6 +111,18 @@ OopMap::OopMap(int frame_size, int arg_count) {
 #endif
 }
 
+OopMap::OopMap(int data_size) {
+  // OopMaps are usually quite so small, so pick a small initial size
+  set_write_stream(new CompressedWriteStream(data_size));
+  set_omv_count(0);
+  _num_oops = 0;
+  _has_derived_oops = false;
+  _index = -1;
+#ifdef ASSERT
+  _locs_length = 0;
+  _locs_used   = nullptr;
+#endif
+}
 
 OopMap::OopMap(OopMap::DeepCopyToken, OopMap* source) {
   // This constructor does a deep copy
@@ -363,6 +375,8 @@ void OopMap::set_derived_oop(VMReg reg, VMReg derived_from_local_register ) {
 // OopMapSet
 
 OopMapSet::OopMapSet() : _list(MinOopMapAllocation) {}
+
+OopMapSet::OopMapSet(int size) : _list(size) {}
 
 int OopMapSet::add_gc_map(int pc_offset, OopMap *map ) {
   map->set_offset(pc_offset);

--- a/src/hotspot/share/compiler/oopMap.hpp
+++ b/src/hotspot/share/compiler/oopMap.hpp
@@ -154,6 +154,7 @@ class OopMap: public ResourceObj {
   friend class VMStructs;
   friend class OopMapSet;
   friend class OopMapSort;
+  friend class AOTCodeReader;
  private:
   int  _pc_offset; // offset in the code that this OopMap corresponds to
   int  _omv_count; // number of OopMapValues in the stream
@@ -180,6 +181,7 @@ class OopMap: public ResourceObj {
 
  public:
   OopMap(int frame_size, int arg_count);
+  OopMap(int data_size);
 
   // pc-offset handling
   int offset() const     { return _pc_offset; }
@@ -216,6 +218,7 @@ class OopMap: public ResourceObj {
 
 class OopMapSet : public ResourceObj {
   friend class VMStructs;
+  friend class AOTCodeReader;
  private:
   GrowableArray<OopMap*> _list;
 
@@ -223,6 +226,7 @@ class OopMapSet : public ResourceObj {
 
  public:
   OopMapSet();
+  OopMapSet(int size);
 
   // returns the number of OopMaps in this OopMapSet
   int size() const            { return _list.length(); }

--- a/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.hpp
+++ b/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.hpp
@@ -137,6 +137,7 @@ public:
 };
 
 class ShenandoahBarrierSetC1 : public BarrierSetC1 {
+  friend class AOTCodeAddressTable;
 private:
   CodeBlob* _pre_barrier_c1_runtime_code_blob;
   CodeBlob* _load_reference_barrier_strong_rt_code_blob;

--- a/src/hotspot/share/gc/z/c1/zBarrierSetC1.hpp
+++ b/src/hotspot/share/gc/z/c1/zBarrierSetC1.hpp
@@ -88,6 +88,7 @@ public:
 };
 
 class ZBarrierSetC1 : public BarrierSetC1 {
+  friend class AOTCodeAddressTable;
 private:
   address _load_barrier_on_oop_field_preloaded_runtime_stub;
   address _load_barrier_on_weak_oop_field_preloaded_runtime_stub;

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3702,6 +3702,10 @@ const char* InstanceKlass::init_state_name() const {
   return state_names[init_state()];
 }
 
+const char* InstanceKlass::state2name(ClassState s) {
+  return state_names[s];
+}
+
 void InstanceKlass::print_class_flags(outputStream* st) const {
   AccessFlags flags(compute_modifier_flags());
   if (flags.is_public    ()) st->print("public ");

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -539,6 +539,8 @@ public:
   const char* init_state_name() const;
   bool is_rewritten() const                { return _misc_flags.rewritten(); }
 
+  static const char* state2name(ClassState state);
+
   // is this a sealed class
   bool is_sealed() const;
 

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -407,9 +407,14 @@ Symbol* Method::klass_name() const {
 }
 
 void Method::metaspace_pointers_do(MetaspaceClosure* it) {
-  log_trace(aot)("Iter(Method): %p", this);
-
-  if (!method_holder()->is_rewritten()) {
+  LogStreamHandle(Trace, aot) lsh;
+  if (lsh.is_enabled()) {
+    lsh.print("Iter(Method): %p ", this);
+    print_external_name(&lsh);
+    lsh.cr();
+  }
+  if (method_holder() != nullptr && !method_holder()->is_rewritten()) {
+    // holder is null for MH intrinsic methods
     it->push(&_constMethod, MetaspaceClosure::_writable);
   } else {
     it->push(&_constMethod);
@@ -438,6 +443,12 @@ void Method::remove_unshareable_info() {
     _adapter->remove_unshareable_info();
     _adapter = nullptr;
   }
+  if (method_data() != nullptr) {
+    method_data()->remove_unshareable_info();
+  }
+  if (method_counters() != nullptr) {
+    method_counters()->remove_unshareable_info();
+  }
   JFR_ONLY(REMOVE_METHOD_ID(this);)
 }
 
@@ -452,6 +463,12 @@ void Method::restore_unshareable_info(TRAPS) {
   if (_adapter != nullptr) {
     assert(_adapter->is_linked(), "must be");
     _from_compiled_entry = _adapter->get_c2i_entry();
+  }
+  if (method_data() != nullptr) {
+    method_data()->restore_unshareable_info(CHECK);
+  }
+  if (method_counters() != nullptr) {
+    method_counters()->restore_unshareable_info(CHECK);
   }
   assert(!queued_for_compilation(), "method's queued_for_compilation flag should not be set");
 }

--- a/src/hotspot/share/oops/methodCounters.cpp
+++ b/src/hotspot/share/oops/methodCounters.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "cds/cdsConfig.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compiler_globals.hpp"
 #include "compiler/compilerOracle.hpp"
 #include "memory/metaspaceClosure.hpp"
@@ -40,6 +41,9 @@ MethodCounters::MethodCounters(const methodHandle& mh) :
   _highest_comp_level(0),
   _highest_osr_comp_level(0)
 {
+#if INCLUDE_CDS
+  set_aot_preload_code_entry(nullptr);
+#endif
   set_interpreter_throwout_count(0);
   JVMTI_ONLY(clear_number_of_breakpoints());
   invocation_counter()->init();
@@ -73,6 +77,12 @@ MethodCounters* MethodCounters::allocate_with_exception(const methodHandle& mh, 
 void MethodCounters::clear_counters() {
   invocation_counter()->reset();
   backedge_counter()->reset();
+#if INCLUDE_CDS
+  if (aot_preload_code_entry() != nullptr) {
+    AOTCodeCache::invalidate(aot_preload_code_entry());
+    set_aot_preload_code_entry(nullptr);
+  }
+#endif
   set_interpreter_throwout_count(0);
   set_prev_time(0);
   set_prev_event_count(0);
@@ -81,6 +91,15 @@ void MethodCounters::clear_counters() {
   set_highest_osr_comp_level(0);
 }
 
+#if INCLUDE_CDS
+void MethodCounters::deallocate_contents(ClassLoaderData* loader_data) {
+  if (aot_preload_code_entry() != nullptr) {
+    AOTCodeCache::invalidate(aot_preload_code_entry());
+    set_aot_preload_code_entry(nullptr);
+  }
+}
+#endif
+
 void MethodCounters::metaspace_pointers_do(MetaspaceClosure* it) {
   log_trace(aot, training)("Iter(MethodCounters): %p", this);
   it->push(&_method);
@@ -88,6 +107,11 @@ void MethodCounters::metaspace_pointers_do(MetaspaceClosure* it) {
 }
 
 #if INCLUDE_CDS
+void MethodCounters::set_aot_preload_code_entry(AOTCodeEntry* entry) {
+  precond(entry == nullptr || entry->for_preload());
+  _aot_preload_code_entry = entry;
+}
+
 void MethodCounters::remove_unshareable_info() {
 }
 void MethodCounters::restore_unshareable_info(TRAPS) {

--- a/src/hotspot/share/oops/methodCounters.hpp
+++ b/src/hotspot/share/oops/methodCounters.hpp
@@ -30,6 +30,7 @@
 #include "oops/metadata.hpp"
 #include "utilities/align.hpp"
 
+class AOTCodeEntry;
 class MethodTrainingData;
 
 class MethodCounters : public Metadata {
@@ -48,6 +49,9 @@ class MethodCounters : public Metadata {
   Method* _method;
 
   Metadata*         _method_training_data;
+#if INCLUDE_CDS
+  AOTCodeEntry*     _aot_preload_code_entry;      // AOT Code Cache entry for preload code
+#endif
   jlong             _prev_time;                   // Previous time the rate was acquired
   float             _rate;                        // Events (invocation and backedge counter increments) per millisecond
   int               _invoke_mask;                 // per-method Tier0InvokeNotifyFreqLog
@@ -71,7 +75,7 @@ class MethodCounters : public Metadata {
   static MethodCounters* allocate_no_exception(const methodHandle& mh);
   static MethodCounters* allocate_with_exception(const methodHandle& mh, TRAPS);
 
-  void deallocate_contents(ClassLoaderData* loader_data) {}
+  void deallocate_contents(ClassLoaderData* loader_data) NOT_CDS_RETURN;
 
   static int method_counters_size() {
     return align_up((int)sizeof(MethodCounters), wordSize) / wordSize;
@@ -165,6 +169,11 @@ class MethodCounters : public Metadata {
   }
 
 #if INCLUDE_CDS
+  void set_aot_preload_code_entry(AOTCodeEntry* entry);
+  AOTCodeEntry* aot_preload_code_entry() const   {
+    return _aot_preload_code_entry;
+  }
+
   void remove_unshareable_info();
   void restore_unshareable_info(TRAPS);
 #endif

--- a/src/hotspot/share/oops/trainingData.hpp
+++ b/src/hotspot/share/oops/trainingData.hpp
@@ -534,6 +534,9 @@ class CompileTrainingData : public TrainingData {
   const short _level;
   const int _compile_id;
 
+  // Size of nmethod code during training
+  int _inline_instructions_size;
+
   // classes that should be initialized before this JIT task runs
   DepList<KlassTrainingData*> _init_deps;
   // Number of uninitialized classes left, when it's 0, all deps are satisfied
@@ -650,7 +653,7 @@ private:
                       int level,
                       int compile_id)
       : TrainingData(),  // empty key
-        _method(mtd), _level(level), _compile_id(compile_id), _init_deps_left(0) { }
+        _method(mtd), _level(level), _compile_id(compile_id), _inline_instructions_size(0), _init_deps_left(0) { }
 public:
   ciRecords& ci_records() { return _ci_records; }
   static CompileTrainingData* make(CompileTask* task) NOT_CDS_RETURN_(nullptr);
@@ -662,6 +665,9 @@ public:
   int level() const { return _level; }
 
   int compile_id() const { return _compile_id; }
+
+  int inline_instructions_size() const { return _inline_instructions_size; }
+  void set_inline_instructions_size(int size) { _inline_instructions_size = size; }
 
   int init_dep_count() const {
     TrainingDataLocker::assert_locked();
@@ -790,6 +796,15 @@ class MethodTrainingData : public TrainingData {
       return _last_toplevel_compiles[level - 1];
     }
     return nullptr;
+  }
+
+  CompileTrainingData* compile_data_for_aot_code(int level) const {
+    CompileTrainingData* ctd = last_toplevel_compile(level);
+    if (ctd == nullptr && level == CompLevel_limited_profile) {
+      // We compile CompLevel_limited_profile AOT code for CompLevel_full_profile
+      ctd = _last_toplevel_compiles[CompLevel_full_profile - 1];
+    }
+    return ctd;
   }
 
   void notice_compilation(int level, bool inlined = false) {

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -909,6 +909,9 @@
           "Use StoreStore barrier instead of Release barrier at the end "   \
           "of constructors")                                                \
                                                                             \
+  product(bool, PreloadReduceTraps, true, DIAGNOSTIC,                       \
+          "Preload code should avoid traps as much as possible.")           \
+                                                                            \
   develop(bool, KillPathsReachableByDeadTypeNode, true,                     \
           "When a Type node becomes top, make paths where the node is "     \
           "used dead by replacing them with a Halt node. Turning this off " \

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "classfile/vmClasses.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compilationMemoryStatistic.hpp"
 #include "compiler/compilerDefinitions.inline.hpp"
 #include "jfr/support/jfrIntrinsics.hpp"
@@ -122,8 +123,14 @@ void C2Compiler::initialize() {
 
 void C2Compiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, bool install_code, DirectiveSet* directive) {
   assert(is_initialized(), "Compiler thread must be initialized");
-
   CompilationMemoryStatisticMark cmsm(directive);
+  CompileTask* task = env->task();
+  if (install_code && task->is_aot_load()) {
+    AOTCodeCache::load_nmethod(env, target, entry_bci, this, CompLevel_full_optimization);
+    // We want to go quickly through AOT code load requests
+    // instead of spending time on normal compilation.
+    return;
+  }
 
   bool subsume_loads = SubsumeLoads;
   bool do_escape_analysis = DoEscapeAnalysis;
@@ -132,7 +139,8 @@ void C2Compiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, boo
   bool eliminate_boxing = EliminateAutoBox;
   bool do_locks_coarsening = EliminateLocks;
   bool do_superword = UseSuperWord;
-
+  bool for_preload = (task->compile_reason() == CompileTask::Reason_AOTCompileForPreload);
+  assert(!for_preload || (ClassInitBarrierMode > 0), "sanity");
   while (!env->failing()) {
     ResourceMark rm;
     // Attempt to compile while subsuming loads into machine instructions.
@@ -143,6 +151,7 @@ void C2Compiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, boo
                     eliminate_boxing,
                     do_locks_coarsening,
                     do_superword,
+                    for_preload,
                     install_code);
     Compile C(env, target, entry_bci, options, directive);
 

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -573,10 +573,15 @@ void Compile::print_compile_messages() {
 
   if( PrintOpto ) {
     if (is_osr_compilation()) {
-      tty->print("[OSR]%3d", _compile_id);
-    } else {
-      tty->print("%3d", _compile_id);
+      tty->print("[OSR]");
+    } else if (env()->task()->is_aot_compile()) {
+      if (for_preload()) {
+        tty->print("[PRE]");
+      } else {
+        tty->print("[AOT]");
+      }
     }
+    tty->print("%3d", _compile_id);
   }
 #endif
 }
@@ -614,7 +619,8 @@ void Compile::print_ideal_ir(const char* compile_phase_name) const {
   if (xtty != nullptr) {
     xtty->head("ideal compile_id='%d'%s compile_phase='%s'",
                compile_id(),
-               is_osr_compilation() ? " compile_kind='osr'" : "",
+               is_osr_compilation() ? " compile_kind='osr'" :
+               (for_preload() ? " compile_kind='AP'" : ""),
                compile_phase_name);
   }
 
@@ -659,6 +665,7 @@ Compile::Compile(ciEnv* ci_env, ciMethod* target, int osr_bci,
       _trace_opto_output(directive->TraceOptoOutputOption),
 #endif
       _clinit_barrier_on_entry(false),
+      _has_clinit_barriers(false),
       _stress_seed(0),
       _comp_arena(mtCompiler, Arena::Tag::tag_comp),
       _barrier_set_state(BarrierSet::barrier_set()->barrier_set_c2()->create_barrier_state(comp_arena())),
@@ -739,9 +746,14 @@ Compile::Compile(ciEnv* ci_env, ciMethod* target, int osr_bci,
   set_print_intrinsics(directive->PrintIntrinsicsOption);
   set_has_irreducible_loop(true); // conservative until build_loop_tree() reset it
 
-  if (ProfileTraps) {
+  if ((ProfileTraps && !ci_env->is_aot_compile()) ||
+      AOTCodeCache::is_using_code()) {
     // Make sure the method being compiled gets its own MDO,
     // so we can at least track the decompile_count().
+    // Load recorded MDO from training run when AOT code
+    // is used - MDO may not created yet in such case.
+    // No need for AOT compilation - it is not
+    // executed during assembly phase.
     method()->ensure_method_data();
   }
 
@@ -944,6 +956,7 @@ Compile::Compile(ciEnv* ci_env,
       _trace_opto_output(directive->TraceOptoOutputOption),
 #endif
       _clinit_barrier_on_entry(false),
+      _has_clinit_barriers(false),
       _stress_seed(0),
       _comp_arena(mtCompiler, Arena::Tag::tag_comp),
       _barrier_set_state(BarrierSet::barrier_set()->barrier_set_c2()->create_barrier_state(comp_arena())),
@@ -1121,8 +1134,12 @@ void Compile::Init(bool aliasing) {
 
   _max_node_limit = _directive->MaxNodeLimitOption;
 
-  if (VM_Version::supports_fast_class_init_checks() && has_method() && !is_osr_compilation() && method()->needs_clinit_barrier()) {
+  if (VM_Version::supports_fast_class_init_checks() && has_method() && !is_osr_compilation() &&
+      (method()->needs_clinit_barrier() || (do_clinit_barriers() && method()->is_static()))) {
     set_clinit_barrier_on_entry(true);
+    if (do_clinit_barriers()) {
+      set_has_clinit_barriers(true); // Entry clinit barrier is in prolog code.
+    }
   }
   if (debug_info()->recording_non_safepoints()) {
     set_node_note_array(new(comp_arena()) GrowableArray<Node_Notes*>
@@ -4132,6 +4149,10 @@ bool Compile::final_graph_reshaping() {
 bool Compile::too_many_traps(ciMethod* method,
                              int bci,
                              Deoptimization::DeoptReason reason) {
+  if (PreloadReduceTraps && for_preload()) {
+    // Preload code should not have traps, if possible.
+    return true;
+  }
   ciMethodData* md = method->method_data();
   if (md->is_empty()) {
     // Assume the trap has not occurred, or that it occurred only
@@ -4157,6 +4178,10 @@ bool Compile::too_many_traps(ciMethod* method,
 // Less-accurate variant which does not require a method and bci.
 bool Compile::too_many_traps(Deoptimization::DeoptReason reason,
                              ciMethodData* logmd) {
+  if (PreloadReduceTraps && for_preload()) {
+    // Preload code should not have traps, if possible.
+    return true;
+  }
   if (trap_count(reason) >= Deoptimization::per_method_trap_limit(reason)) {
     // Too many traps globally.
     // Note that we use cumulative trap_count, not just md->trap_count.
@@ -4246,10 +4271,10 @@ bool Compile::needs_clinit_barrier(ciField* field, ciMethod* accessing_method) {
 }
 
 bool Compile::needs_clinit_barrier(ciInstanceKlass* holder, ciMethod* accessing_method) {
-  if (holder->is_initialized()) {
+  if (holder->is_initialized() && !do_clinit_barriers()) {
     return false;
   }
-  if (holder->is_being_initialized()) {
+  if (holder->is_being_initialized() || do_clinit_barriers()) {
     if (accessing_method->holder() == holder) {
       // Access inside a class. The barrier can be elided when access happens in <clinit>,
       // <init>, or a static method. In all those cases, there was an initialization

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -183,6 +183,7 @@ class Options {
   const bool _do_reduce_allocation_merges;  // Do try to reduce allocation merges.
   const bool _eliminate_boxing;      // Do boxing elimination.
   const bool _do_locks_coarsening;   // Do locks coarsening
+  const bool _for_preload;           // Generate code for preload (before Java method execution), do class init barriers
   const bool _do_superword;          // Do SuperWord
   const bool _install_code;          // Install the code that was compiled
  public:
@@ -193,6 +194,7 @@ class Options {
           bool eliminate_boxing,
           bool do_locks_coarsening,
           bool do_superword,
+          bool for_preload,
           bool install_code) :
           _subsume_loads(subsume_loads),
           _do_escape_analysis(do_escape_analysis),
@@ -200,6 +202,7 @@ class Options {
           _do_reduce_allocation_merges(do_reduce_allocation_merges),
           _eliminate_boxing(eliminate_boxing),
           _do_locks_coarsening(do_locks_coarsening),
+          _for_preload(for_preload),
           _do_superword(do_superword),
           _install_code(install_code) {
   }
@@ -212,6 +215,7 @@ class Options {
        /* do_reduce_allocation_merges = */ false,
        /* eliminate_boxing = */ false,
        /* do_lock_coarsening = */ false,
+       /* for_preload = */ false,
        /* do_superword = */ true,
        /* install_code = */ true
     );
@@ -369,6 +373,7 @@ class Compile : public Phase {
   bool                  _has_monitors;          // Metadata transfered to nmethod to enable Continuations lock-detection fastpath
   bool                  _has_scoped_access;     // For shared scope closure
   bool                  _clinit_barrier_on_entry; // True if clinit barrier is needed on nmethod entry
+  bool                  _has_clinit_barriers;   // True if compiled code has clinit barriers
   int                   _loop_opts_cnt;         // loop opts round
   uint                  _stress_seed;           // Seed for stress testing
 
@@ -581,6 +586,9 @@ public:
   bool              do_locks_coarsening() const { return _options._do_locks_coarsening; }
   bool              do_superword() const        { return _options._do_superword; }
 
+  bool              do_clinit_barriers()  const { return _options._for_preload; }
+  bool              for_preload()         const { return _options._for_preload; }
+
   // Other fixed compilation parameters.
   ciMethod*         method() const              { return _method; }
   int               entry_bci() const           { return _entry_bci; }
@@ -662,6 +670,8 @@ public:
   void          set_has_monitors(bool v)         { _has_monitors = v; }
   bool              has_scoped_access() const    { return _has_scoped_access; }
   void          set_has_scoped_access(bool v)    { _has_scoped_access = v; }
+  bool              has_clinit_barriers()        { return _has_clinit_barriers; }
+  void          set_has_clinit_barriers(bool z)  { _has_clinit_barriers = z; }
 
   // check the CompilerOracle for special behaviours for this compile
   bool          method_has_option(CompileCommandEnum option) const {

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -26,6 +26,7 @@
 #include "ci/ciMethodHandle.hpp"
 #include "ci/ciSymbols.hpp"
 #include "classfile/vmSymbols.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compileLog.hpp"
 #include "interpreter/linkResolver.hpp"
@@ -107,6 +108,14 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
   // Dtrace currently doesn't work unless all calls are vanilla
   if (env()->dtrace_method_probes()) {
     allow_inline = false;
+  }
+
+  if (AOTCodeCache::is_using_code()) {
+    // During production run, when AOT code is used,
+    // C2 compilation could be requested without collecting
+    // profiling. Instead use profiling from training run.
+    // Make sure training data is loaded for callee.
+    callee->ensure_method_data(true /*training_data_only*/);
   }
 
   // Note: When we get profiling during stage-1 compiles, we want to pull
@@ -514,6 +523,10 @@ bool Parse::can_not_compile_call_site(ciMethod *dest_method, ciInstanceKlass* kl
   if (!holder_klass->is_being_initialized() &&
       !holder_klass->is_initialized() &&
       !holder_klass->is_interface()) {
+    if (C->env()->task()->is_aot_compile()) {
+      ResourceMark rm;
+      log_debug(aot, compilation)("Emitting uncommon trap (cannot compile call site) in AOT code for %s", holder_klass->name()->as_klass_external_name());
+    }
     uncommon_trap(Deoptimization::Reason_uninitialized,
                   Deoptimization::Action_reinterpret,
                   holder_klass);

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2232,6 +2232,15 @@ Node* GraphKit::uncommon_trap(int trap_request,
                                                       trap_request), bci());
   }
 
+  if (PreloadReduceTraps && C->for_preload() && (action != Deoptimization::Action_none)) {
+    ResourceMark rm;
+    ciMethod* cim = C->method();
+    log_debug(aot, codecache, deoptimization)("Uncommon trap in preload code: reason=%s action=%s method=%s::%s bci=%d, %s",
+                  Deoptimization::trap_reason_name(reason), Deoptimization::trap_action_name(action),
+                  cim->holder()->name()->as_klass_external_name(), cim->name()->as_klass_external_name(),
+                  bci(), comment);
+  }
+
   CompileLog* log = C->log();
   if (log != nullptr) {
     int kid = (klass == nullptr)? -1: log->identify(klass);
@@ -3078,6 +3087,32 @@ bool GraphKit::seems_never_null(Node* obj, ciProfileData* data, bool& speculatin
   return false;
 }
 
+void GraphKit::guard_klass_is_initialized(Node* klass) {
+  assert(C->do_clinit_barriers(), "should be called only for clinit barriers");
+  if (ClassInitBarrierMode == 0) {
+    return;
+  }
+  precond(ClassInitBarrierMode == 1); // catch new value
+  int init_state_off = in_bytes(InstanceKlass::init_state_offset());
+  Node* adr = basic_plus_adr(top(), klass, init_state_off);
+  Node* init_state = LoadNode::make(_gvn, nullptr, immutable_memory(), adr,
+                                    adr->bottom_type()->is_ptr(), TypeInt::BYTE,
+                                    T_BYTE, MemNode::unordered);
+  init_state = _gvn.transform(init_state);
+
+  Node* initialized_state = makecon(TypeInt::make(InstanceKlass::fully_initialized));
+
+  Node* chk = _gvn.transform(new CmpINode(initialized_state, init_state));
+  Node* tst = _gvn.transform(new BoolNode(chk, BoolTest::eq));
+
+  { // uncommon trap on slow path
+    BuildCutout unless(this, tst, PROB_MAX);
+    // Do not deoptimize this nmethod. Go to Interpreter to initialize class.
+    uncommon_trap(Deoptimization::Reason_uninitialized, Deoptimization::Action_none);
+  }
+  C->set_has_clinit_barriers(true);
+}
+
 void GraphKit::guard_klass_being_initialized(Node* klass) {
   int init_state_off = in_bytes(InstanceKlass::init_state_offset());
   Node* adr = off_heap_plus_addr(klass, init_state_off);
@@ -3116,9 +3151,14 @@ void GraphKit::guard_init_thread(Node* klass) {
 }
 
 void GraphKit::clinit_barrier(ciInstanceKlass* ik, ciMethod* context) {
+  if (C->do_clinit_barriers()) {
+    Node* klass = makecon(TypeKlassPtr::make(ik, Type::trust_interfaces));
+    guard_klass_is_initialized(klass);
+    return;
+  }
   if (ik->is_being_initialized()) {
     if (C->needs_clinit_barrier(ik, context)) {
-      Node* klass = makecon(TypeKlassPtr::make(ik));
+      Node* klass = makecon(TypeKlassPtr::make(ik, Type::trust_interfaces));
       guard_klass_being_initialized(klass);
       guard_init_thread(klass);
       insert_mem_bar(Op_MemBarCPUOrder);
@@ -3126,6 +3166,10 @@ void GraphKit::clinit_barrier(ciInstanceKlass* ik, ciMethod* context) {
   } else if (ik->is_initialized()) {
     return; // no barrier needed
   } else {
+    if (C->env()->task()->is_aot_compile()) {
+      ResourceMark rm;
+      log_debug(aot, compilation)("Emitting uncommon trap (clinit barrier) in AOT code for %s", ik->name()->as_klass_external_name());
+    }
     uncommon_trap(Deoptimization::Reason_uninitialized,
                   Deoptimization::Action_reinterpret,
                   nullptr);

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -420,6 +420,7 @@ class GraphKit : public Phase {
   // Check the null_seen bit.
   bool seems_never_null(Node* obj, ciProfileData* data, bool& speculating);
 
+  void guard_klass_is_initialized(Node* klass);
   void guard_klass_being_initialized(Node* klass);
   void guard_init_thread(Node* klass);
 

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "classfile/javaClasses.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compileLog.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/c2/barrierSetC2.hpp"
@@ -2095,7 +2096,9 @@ Node *LoadNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 const Type*
 LoadNode::load_array_final_field(const TypeKlassPtr *tkls,
                                  ciKlass* klass) const {
-  assert(!UseCompactObjectHeaders || tkls->offset() != in_bytes(Klass::prototype_header_offset()),
+  assert(!UseCompactObjectHeaders ||
+         AOTCodeCache::is_on_for_dump() ||
+         tkls->offset() != in_bytes(Klass::prototype_header_offset()),
          "must not happen");
 
   if (tkls->isa_instklassptr() && tkls->offset() == in_bytes(InstanceKlass::access_flags_offset())) {
@@ -2276,7 +2279,9 @@ const Type* LoadNode::Value(PhaseGVN* phase) const {
         assert(Opcode() == Op_LoadI, "must load an int from _super_check_offset");
         return TypeInt::make(klass->super_check_offset());
       }
-      if (UseCompactObjectHeaders) {
+      // Class encoding in prototype header may change between runs.
+      // Force loading prototype header when AOT code is generated.
+      if (UseCompactObjectHeaders && !AOTCodeCache::is_on_for_dump()) {
         if (tkls->offset() == in_bytes(Klass::prototype_header_offset())) {
           // The field is Klass::_prototype_header. Return its (constant) value.
           assert(this->Opcode() == Op_LoadX, "must load a proper type from _prototype_header");

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1814,6 +1814,7 @@ void PhaseOutput::fill_buffer(C2_MacroAssembler* masm, uint* blk_starts) {
       stringStream dump_asm_str;
       dump_asm_on(&dump_asm_str, node_offsets, node_offset_limit);
 
+      // Make sure the end tag is coherent, and that xmlStream->pop_tag is done thread safe.
       NoSafepointVerifier nsv;
       ttyLocker ttyl2;
       // This output goes directly to the tty, not the compiler log.
@@ -1821,16 +1822,18 @@ void PhaseOutput::fill_buffer(C2_MacroAssembler* masm, uint* blk_starts) {
       // be sure to tag this tty output with the compile ID.
       if (xtty != nullptr) {
         xtty->head("opto_assembly compile_id='%d'%s", C->compile_id(),
-                   C->is_osr_compilation() ? " compile_kind='osr'" : "");
+                   C->is_osr_compilation() ? " compile_kind='osr'" :
+                   (C->for_preload() ? " compile_kind='AP'" : ""));
       }
+      const char* is_aot = C->env()->is_aot_compile() ? (C->for_preload() ? "(AP) " : "(A) -") : "-----";
       if (C->method() != nullptr) {
-        tty->print_cr("----------------------- MetaData before Compile_id = %d ------------------------", C->compile_id());
+        tty->print_cr("----------------------- MetaData before Compile_id = %d %s-------------------", C->compile_id(), is_aot);
         tty->print_raw(method_metadata_str.freeze());
       } else if (C->stub_name() != nullptr) {
         tty->print_cr("----------------------------- RuntimeStub %s -------------------------------", C->stub_name());
       }
       tty->cr();
-      tty->print_cr("------------------------ OptoAssembly for Compile_id = %d -----------------------", C->compile_id());
+      tty->print_cr("------------------------ OptoAssembly for Compile_id = %d %s------------------", C->compile_id(), is_aot);
       tty->print_raw(dump_asm_str.freeze());
       tty->print_cr("--------------------------------------------------------------------------------");
       if (xtty != nullptr) {
@@ -3166,9 +3169,7 @@ uint PhaseOutput::scratch_emit_size(const Node* n) {
 }
 
 void PhaseOutput::install() {
-  if (!C->should_install_code()) {
-    return;
-  } else if (C->stub_function() != nullptr) {
+  if (C->should_install_code() && C->stub_function() != nullptr) {
     install_stub(C->stub_name());
   } else {
     install_code(C->method(),
@@ -3218,15 +3219,19 @@ void PhaseOutput::install_code(ciMethod*         target,
                                      &_handler_table,
                                      inc_table(),
                                      compiler,
+                                     C->has_clinit_barriers(),
+                                     C->for_preload(),
                                      has_unsafe_access,
                                      SharedRuntime::is_wide_vector(C->max_vector_size()),
                                      C->has_monitors(),
                                      C->has_scoped_access(),
-                                     0);
+                                     0,
+                                     C->should_install_code());
 
     if (C->log() != nullptr) { // Print code cache state into compiler log
       C->log()->code_cache_state();
     }
+    assert(!C->has_clinit_barriers() || C->for_preload(), "class init barriers should be only in preload code");
   }
 }
 void PhaseOutput::install_stub(const char* stub_name) {

--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -583,6 +583,9 @@ class Parse : public GraphKit {
   // helper function for call statistics
   void count_compiled_calls(bool at_method_entry, bool is_inline) PRODUCT_RETURN;
 
+  // AOT compiled code invocations count
+  void count_aot_code_calls() NOT_CDS_RETURN;
+
   Node_Notes* make_node_notes(Node_Notes* caller_nn);
 
   // Helper functions for handling normal and abnormal exits.
@@ -613,8 +616,12 @@ class Parse : public GraphKit {
   void stress_trap(IfNode* orig_iff, Node* counter, Node* incr_store);
   // Increment counter used by StressUnstableIfTraps
   void increment_trap_stress_counter(Node*& counter, Node*& incr_store);
+  static volatile int _trap_stress_counter;
 
  public:
+  // Needed for AOT external address recording
+  static address trap_stress_counter_address() { return (address)&_trap_stress_counter; }
+
 #ifndef PRODUCT
   // Handle PrintOpto, etc.
   void show_parse_info();

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -23,9 +23,11 @@
  */
 
 #include "compiler/compileLog.hpp"
+#include "interpreter/invocationCounter.hpp"
 #include "interpreter/linkResolver.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/method.hpp"
+#include "oops/trainingData.hpp"
 #include "opto/addnode.hpp"
 #include "opto/c2compiler.hpp"
 #include "opto/castnode.hpp"
@@ -1156,9 +1158,18 @@ SafePointNode* Parse::create_entry_map() {
   _caller->map()->delete_replaced_nodes();
 
   // If this is an inlined method, we may have to do a receiver null check.
-  if (_caller->has_method() && is_normal_parse() && !method()->is_static()) {
+  if (_caller->has_method() && is_normal_parse()) {
     GraphKit kit(_caller);
-    kit.null_check_receiver_before_call(method());
+    if (!method()->is_static()) {
+      kit.null_check_receiver_before_call(method());
+    } else if (C->do_clinit_barriers() && C->needs_clinit_barrier(method()->holder(), _caller->method())) {
+      ciMethod* declared_method = kit.method()->get_method_at_bci(kit.bci());
+      const int nargs = declared_method->arg_size();
+      kit.inc_sp(nargs);
+      Node* holder = makecon(TypeKlassPtr::make(method()->holder(), Type::trust_interfaces));
+      kit.guard_klass_is_initialized(holder);
+      kit.dec_sp(nargs);
+    }
     _caller = kit.transfer_exceptions_into_jvms();
     if (kit.stopped()) {
       _exits.add_exception_states_from(_caller);
@@ -1225,6 +1236,110 @@ static bool is_auto_boxed_primitive(Node* n) {
           n->in(0)->is_CallJava() &&
           n->in(0)->as_CallJava()->method()->is_boxing_method());
 }
+
+#if INCLUDE_CDS
+static int scale_limit(int64_t limit) {
+ // To scale invocation limit a hyperbolic saturation curve formula
+ // is used with upper limit 100K.
+ return (int)(AOTCodeInvokeBase + limit / (1.0 + limit / (1000000.0 * AOTCodeInvokeScale)));
+}
+
+void Parse::count_aot_code_calls() {
+  bool is_aot_compilation = C->env()->is_aot_compile();
+  if (UseAOTCodeCounters && (depth() == 1) && is_aot_compilation) {
+    // Clear out dead values from the debug info in following runtime call
+    kill_dead_locals();
+
+    // Use method invocations count during training run and compare
+    // to invocations of AOT code during production run to trigger JIT
+    // compilation and replace AOT code with normal JITed code.
+    ciMetadata* mcp = method()->ensure_method_counters();
+    assert(mcp != nullptr, "CompileBroker should create MethodCounters if it is missing");
+    const TypePtr* mc_type = TypeMetadataPtr::make(TypePtr::Constant, mcp, 0);
+    Node* mc = makecon(mc_type);
+
+    assert(MethodTrainingData::have_data(), "TrainingData should be present for AOT compialtion");
+    methodHandle mh(Thread::current(), method()->get_Method());
+    MethodTrainingData* mtd = MethodTrainingData::find_fast(mh);
+    assert(mtd != nullptr, "AOT compilated method should have MethodTrainingData");
+    int64_t limit = mtd->invocation_count();
+    int step = InvocationCounter::count_increment;
+    int scaled_limit = step * scale_limit(limit);
+
+    // Count AOT compiled code invocations (use 32 bits because scaled limit fits into 32 bits)
+    intptr_t offset = in_bytes(MethodCounters::invocation_counter_offset());
+    Node* cnt_adr = off_heap_plus_addr(mc, offset);
+    Node* ctrl = control();
+    Node* cnt  = make_load(ctrl, cnt_adr, TypeInt::INT, T_INT, MemNode::unordered);
+    Node* incr = _gvn.transform(new AddINode(cnt, intcon(step)));
+    store_to_memory(ctrl, cnt_adr, incr, T_INT, MemNode::unordered);
+    // Preserve memory for Phi node below
+    Node* st_mem = MergeMemNode::make(map()->memory());
+    _gvn.set_type_bottom(st_mem);
+
+    Node* lim = intcon(scaled_limit);
+    Node* chk = _gvn.transform( new CmpINode(incr, lim) );
+    Node* tst = _gvn.transform( new BoolNode(chk, BoolTest::lt) );
+    IfNode* iff = create_and_map_if(control(), tst, PROB_ALWAYS, (float)limit);
+
+    RegionNode* result_rgn = new RegionNode(4);
+    record_for_igvn(result_rgn);
+
+    Node*  skip_call = _gvn.transform(new IfTrueNode(iff));
+    result_rgn->init_req(1, skip_call);
+
+    Node* in1_io  = i_o();
+    Node* in1_mem = st_mem;
+    // These two phis are pre-filled with copies of the fast IO and Memory
+    Node* io_phi   = PhiNode::make(result_rgn, in1_io,  Type::ABIO);
+    Node* mem_phi  = PhiNode::make(result_rgn, in1_mem, Type::MEMORY, TypePtr::BOTTOM);
+
+    Node* needs_call = _gvn.transform(new IfFalseNode(iff));
+    set_control(needs_call);
+
+    // InvocationCounter::carry_mask is private, calculate it from step
+    int carry_bits = step - 1;
+    Node* recomp_bit = intcon(carry_bits);
+    Node* rbit = _gvn.transform( new AndINode(incr, recomp_bit) );
+    Node* chk2 = _gvn.transform( new CmpINode(rbit, intcon(0)) );
+    Node* tst2 = _gvn.transform( new BoolNode(chk2, BoolTest::ne) );
+    IfNode* iff2 = create_and_map_if(control(), tst2, PROB_FAIR, COUNT_UNKNOWN);
+
+    Node*  skip_call2 = _gvn.transform(new IfTrueNode(iff2));
+    result_rgn->init_req(2, skip_call2);
+
+    Node* needs_call2 = _gvn.transform(new IfFalseNode(iff2));
+    set_control(needs_call2);
+
+    Node* new_val = _gvn.transform(new OrINode(incr, recomp_bit));
+    store_to_memory(control(), cnt_adr, new_val, T_INT, MemNode::unordered);
+
+    const TypePtr* m_type = TypeMetadataPtr::make(method());
+    Node* m = makecon(m_type);
+    Node* call = make_runtime_call(RC_NO_LEAF | RC_UNCOMMON,
+                          OptoRuntime::compile_method_Type(),
+                          OptoRuntime::compile_method_Java(),
+                          "compile_method", TypePtr::BOTTOM, m);
+
+    // State before call
+    io_phi ->init_req(2, in1_io);
+    mem_phi->init_req(2, in1_mem);
+
+    // State after call
+    result_rgn->init_req(3, control());
+    io_phi ->init_req(3, i_o());
+    mem_phi->init_req(3, reset_memory());
+
+    set_all_memory( _gvn.transform(mem_phi) );
+    set_i_o(        _gvn.transform(io_phi) );
+    set_control(    _gvn.transform(result_rgn) );
+  }
+}
+
+#undef AOT_COUNT_INC
+#undef AOT_RECOMPILE_BIT
+
+#endif
 
 //-----------------------------do_method_entry--------------------------------
 // Emit any code needed in the pseudo-block before BCI zero.
@@ -1309,6 +1424,8 @@ void Parse::do_method_entry() {
   // Feed profiling data for parameters to the type system so it can
   // propagate it as speculative types
   record_profiled_parameters_for_speculation();
+
+  CDS_ONLY( count_aot_code_calls(); )
 }
 
 //------------------------------init_blocks------------------------------------
@@ -1637,7 +1754,7 @@ void Parse::do_one_block() {
     if (failing()) return;
 
     assert(!have_se || stopped() || failing() || (sp() - pre_bc_sp) == depth,
-           "incorrect depth prediction: sp=%d, pre_bc_sp=%d, depth=%d", sp(), pre_bc_sp, depth);
+           "incorrect depth prediction: bc=%s bci=%d, sp=%d, pre_bc_sp=%d, depth=%d", Bytecodes::name(bc()), bci(), sp(), pre_bc_sp, depth);
 
     do_exceptions();
 
@@ -2224,6 +2341,9 @@ void Parse::call_register_finalizer() {
 
 // Add check to deoptimize once holder klass is fully initialized.
 void Parse::clinit_deopt() {
+  if (method()->holder()->is_initialized()) {
+    return; // in case do_clinit_barriers() is true
+  }
   assert(C->has_method(), "only for normal compilations");
   assert(depth() == 1, "only for main compiled method");
   assert(is_normal_parse(), "no barrier needed on osr entry");

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -1376,7 +1376,7 @@ inline int Parse::repush_if_args() {
 }
 
 // Used by StressUnstableIfTraps
-static volatile int _trap_stress_counter = 0;
+volatile int Parse::_trap_stress_counter = 0;
 
 void Parse::increment_trap_stress_counter(Node*& counter, Node*& incr_store) {
   Node* counter_addr = makecon(TypeRawPtr::make((address)&_trap_stress_counter));

--- a/src/hotspot/share/opto/rootnode.cpp
+++ b/src/hotspot/share/opto/rootnode.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include "code/aotCodeCache.hpp"
 #include "memory/allocation.inline.hpp"
 #include "opto/callnode.hpp"
 #include "opto/cfgnode.hpp"
@@ -70,6 +71,7 @@ HaltNode::HaltNode(Node* ctrl, Node* frameptr, const char* halt_reason, bool rea
   init_req(TypeFunc::Memory,   top);
   init_req(TypeFunc::FramePtr, frameptr    );
   init_req(TypeFunc::ReturnAdr,top);
+  AOTCodeCache::add_C_string(halt_reason);
 }
 
 const Type *HaltNode::bottom_type() const { return Type::BOTTOM; }

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -195,6 +195,7 @@ const TypeFunc* OptoRuntime::_fast_arraycopy_Type                 = nullptr;
 const TypeFunc* OptoRuntime::_checkcast_arraycopy_Type            = nullptr;
 const TypeFunc* OptoRuntime::_generic_arraycopy_Type              = nullptr;
 const TypeFunc* OptoRuntime::_slow_arraycopy_Type                 = nullptr;
+const TypeFunc* OptoRuntime::_compile_method_Type                 = nullptr;
 const TypeFunc* OptoRuntime::_unsafe_setmemory_Type               = nullptr;
 const TypeFunc* OptoRuntime::_array_fill_Type                     = nullptr;
 const TypeFunc* OptoRuntime::_array_sort_Type                     = nullptr;
@@ -289,6 +290,14 @@ void OptoRuntime::complete_monitor_locking_C(oopDesc* obj, BasicLock* lock, Java
   SharedRuntime::complete_monitor_locking_C(obj, lock, current);
 }
 
+JRT_ENTRY(void, OptoRuntime::compile_method_C(Method* method, JavaThread* current))
+  methodHandle m(current, method);
+  CompLevel level = CompLevel_full_optimization;
+  CompileBroker::compile_method(m, InvocationEntryBci, level, 0, nullptr, CompileTask::Reason_MustBeCompiled, current);
+  if (HAS_PENDING_EXCEPTION) {
+    CLEAR_PENDING_EXCEPTION;
+  }
+JRT_END
 
 //=============================================================================
 // Opto compiler runtime routines
@@ -676,6 +685,18 @@ static const TypeFunc* make_uncommon_trap_Type() {
   fields = TypeTuple::fields(0);
   const TypeTuple *range = TypeTuple::make(TypeFunc::Parms+0, fields);
 
+  return TypeFunc::make(domain, range);
+}
+
+static const TypeFunc* make_compile_method_Type() {
+  // create input type (domain)
+  const Type** fields = TypeTuple::fields(1);
+  fields[TypeFunc::Parms+0] = TypePtr::NOTNULL; // method to be compiled
+  const TypeTuple *domain = TypeTuple::make(TypeFunc::Parms+1, fields);
+
+  // create result type (range)
+  fields = TypeTuple::fields(0);
+  const TypeTuple* range = TypeTuple::make(TypeFunc::Parms+0,fields);
   return TypeFunc::make(domain, range);
 }
 
@@ -2312,6 +2333,7 @@ void OptoRuntime::initialize_types() {
   _checkcast_arraycopy_Type           = make_arraycopy_Type(ac_checkcast);
   _generic_arraycopy_Type             = make_arraycopy_Type(ac_generic);
   _slow_arraycopy_Type                = make_arraycopy_Type(ac_slow);
+  _compile_method_Type                = make_compile_method_Type();
   _unsafe_setmemory_Type              = make_setmemory_Type();
   _array_fill_Type                    = make_array_fill_Type();
   _array_sort_Type                    = make_array_sort_Type();

--- a/src/hotspot/share/opto/runtime.hpp
+++ b/src/hotspot/share/opto/runtime.hpp
@@ -148,6 +148,7 @@ class OptoRuntime : public AllStatic {
   static const TypeFunc* _checkcast_arraycopy_Type;
   static const TypeFunc* _generic_arraycopy_Type;
   static const TypeFunc* _slow_arraycopy_Type;
+  static const TypeFunc* _compile_method_Type;
   static const TypeFunc* _unsafe_setmemory_Type;
   static const TypeFunc* _array_fill_Type;
   static const TypeFunc* _array_sort_Type;
@@ -230,6 +231,7 @@ class OptoRuntime : public AllStatic {
                                oopDesc* dest, jint dest_pos,
                                jint length, JavaThread* thread);
   static void complete_monitor_locking_C(oopDesc* obj, BasicLock* lock, JavaThread* current);
+  static void compile_method_C(Method* method, JavaThread* current);
 
 public:
   static void monitor_notify_C(oopDesc* obj, JavaThread* current);
@@ -294,6 +296,7 @@ private:
 
   static address slow_arraycopy_Java()                   { return _slow_arraycopy_Java; }
   static address register_finalizer_Java()               { return _register_finalizer_Java; }
+  static address compile_method_Java()                   { return _compile_method_Java; }
 
   static address vthread_end_first_transition_Java()     { return _vthread_end_first_transition_Java; }
   static address vthread_start_final_transition_Java()   { return _vthread_start_final_transition_Java; }
@@ -460,6 +463,11 @@ private:
     // There are no intptr_t (int/long) arguments.
     return _slow_arraycopy_Type;
   }   // the full routine
+
+  static inline const TypeFunc* compile_method_Type() {
+    assert(_compile_method_Type != nullptr, "should be initialized");
+    return _compile_method_Type;
+  }
 
   static inline const TypeFunc* unsafe_setmemory_Type() {
     assert(_unsafe_setmemory_Type != nullptr, "should be initialized");

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1126,7 +1126,7 @@ bool WhiteBox::compile_method(Method* method, int comp_level, int bci, JavaThrea
   bool is_blocking = !matcher.directive_set()->BackgroundCompilationOption;
 
   // Compile method and check result
-  nmethod* nm = CompileBroker::compile_method(mh, bci, comp_level, mh->invocation_count(), CompileTask::Reason_Whitebox, CHECK_false);
+  nmethod* nm = CompileBroker::compile_method(mh, bci, comp_level, mh->invocation_count(), nullptr, CompileTask::Reason_Whitebox, CHECK_false);
   MutexLocker mu(THREAD, Compile_lock);
   bool is_queued = mh->queued_for_compilation();
   if ((!is_blocking && is_queued) || nm != nullptr) {

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -26,6 +26,7 @@
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "classfile/vmClasses.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/codeCache.hpp"
 #include "code/debugInfoRec.hpp"
 #include "code/nmethod.hpp"
@@ -1693,8 +1694,11 @@ static void log_deopt(nmethod* nm, Method* tm, intptr_t pc, frame& fr, int trap_
   if (lt.is_enabled()) {
     LogStream ls(lt);
     bool is_osr = nm->is_osr_method();
-    ls.print("cid=%4d %s level=%d",
-             nm->compile_id(), (is_osr ? "osr" : "   "), nm->comp_level());
+    ls.print("cid=%4d %s%s%s level=%d",
+             nm->compile_id(), (is_osr ? "osr" : "   "),
+             (nm->is_aot() ? "aot " : ""),
+             (nm->preloaded() ? "preload " : ""),
+             nm->comp_level());
     ls.print(" %s", tm->name_and_sig_as_C_string());
     ls.print(" trap_bci=%d ", trap_bci);
     if (is_osr) {
@@ -1759,7 +1763,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
     gather_statistics(reason, action, trap_bc);
 
     // Ensure that we can record deopt. history:
-    bool create_if_missing = ProfileTraps;
+    bool create_if_missing = ProfileTraps || AOTCodeCache::is_using_code();
 
     methodHandle profiled_method;
     profiled_method = trap_method;

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -453,3 +453,24 @@ JVMFlag::Error ControlIntrinsicConstraintFunc(ccstrlist value, bool verbose) {
   return JVMFlag::SUCCESS;
 }
 
+JVMFlag::Error DisableAOTCodeConstraintFunc(uint value, bool verbose) {
+  const int max_modes = 5;
+  uint original_value = value;
+  for (int i = 0; i < max_modes; i++) {
+    if (value % 10 > 1) {
+      JVMFlag::printError(verbose,
+                          "Invalid value (" UINT32_FORMAT ") "
+                          "in DisableAOTCode at position %d\n", value, i);
+      return JVMFlag::VIOLATES_CONSTRAINT;
+    }
+    value = value / 10;
+  }
+  if (value != 0) {
+    JVMFlag::printError(verbose,
+                        "Invalid value (" UINT32_FORMAT ") "
+                        "for DisableAOTCode: maximal %d digits\n", original_value, max_modes);
+    return JVMFlag::VIOLATES_CONSTRAINT;
+  }
+  return JVMFlag::SUCCESS;
+}
+

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.hpp
@@ -52,6 +52,7 @@
   f(intx,  InitArrayShortSizeConstraintFunc)            \
   f(ccstrlist, DisableIntrinsicConstraintFunc)          \
   f(ccstrlist, ControlIntrinsicConstraintFunc)          \
+  f(uint,  DisableAOTCodeConstraintFunc)                \
 COMPILER2_PRESENT(                                      \
   f(intx,  InteriorEntryAlignmentConstraintFunc)        \
   f(intx,  NodeLimitFudgeFactorConstraintFunc)          \

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -657,6 +657,8 @@ void frame::print_C_frame(outputStream* st, char* buf, int buflen, address pc) {
 // First letter indicates type of the frame:
 //    J: Java frame (compiled)
 //    j: Java frame (interpreted)
+//    A: Java frame (AOT compiled and loaded after class initialization)
+//    P: Java frame (AOT compiled and preloaded before class initialization)
 //    V: VM frame (C/C++)
 //    v: Other frames running VM generated code (e.g. stubs, adapters, etc.)
 //    C: C/C++ frame
@@ -697,7 +699,8 @@ void frame::print_on_error(outputStream* st, char* buf, int buflen, bool verbose
       nmethod* nm = _cb->as_nmethod();
       Method* m = nm->method();
       if (m != nullptr) {
-        st->print("J %d%s", nm->compile_id(), (nm->is_osr_method() ? "%" : ""));
+        st->print("%s", (nm->preloaded() ? "P" : (nm->is_aot() ? "A" : "J")));
+        st->print(" %d%s", nm->compile_id(), (nm->is_osr_method() ? "%" : ""));
         st->print(" %s", nm->compiler_name());
         m->name_and_sig_as_C_string(buf, buflen);
         st->print(" %s", buf);

--- a/src/hotspot/share/runtime/init.cpp
+++ b/src/hotspot/share/runtime/init.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include "cds/aotMetaspace.hpp"
 #include "classfile/stringTable.hpp"
 #include "classfile/symbolTable.hpp"
 #include "code/aotCodeCache.hpp"
@@ -129,6 +130,7 @@ jint init_globals() {
   bytecodes_init();
   classLoader_init1();
   compilationPolicy_init();
+  AOTMetaspace::get_aot_code_region_size();
   codeCache_init();
   VM_Version_init();              // depends on codeCache_init for emitting code
   icache_init2();                 // depends on VM_Version for choosing the mechanism

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -34,6 +34,7 @@
 #include "classfile/stringTable.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/codeCache.hpp"
 #include "compiler/compilationMemoryStatistic.hpp"
 #include "compiler/compilationPolicy.hpp"
@@ -250,9 +251,13 @@ static void print_bytecode_count() {}
 
 
 // General statistics printing (profiling ...)
-void print_statistics() {
+void print_statistics_before_exit() {
+  LogStreamHandle(Info, aot, codecache, stats) aot_log;
   if (CITime) {
     CompileBroker::print_times();
+    AOTCodeCache::print_timers_on(tty);
+  } else if (aot_log.is_enabled()) {
+    AOTCodeCache::print_timers_on(&aot_log);
   }
 
 #ifdef COMPILER1
@@ -285,6 +290,9 @@ void print_statistics() {
 
   if (PrintNMethodStatistics) {
     nmethod::print_statistics();
+    AOTCodeCache::print_statistics_on(tty);
+  } else if (aot_log.is_enabled()) {
+    AOTCodeCache::print_statistics_on(&aot_log);
   }
   if (CountCompiledCalls) {
     print_method_invocation_histogram();
@@ -499,7 +507,7 @@ void before_exit(JavaThread* thread, bool halt) {
   }
   #endif
 
-  print_statistics();
+  print_statistics_before_exit();
 
   { MutexLocker ml(BeforeExit_lock);
     _before_exit_status = BEFORE_EXIT_DONE;

--- a/src/hotspot/share/runtime/java.hpp
+++ b/src/hotspot/share/runtime/java.hpp
@@ -58,6 +58,8 @@ extern void vm_shutdown_during_initialization(const char* error, const char* mes
 
 extern void vm_exit_during_cds_dumping(const char* error, const char* message = nullptr);
 
+extern void print_statistics_before_exit();
+
 // This is defined in linkType.cpp due to linking restraints
 extern bool is_vm_statically_linked();
 

--- a/src/hotspot/share/runtime/stubDeclarations.hpp
+++ b/src/hotspot/share/runtime/stubDeclarations.hpp
@@ -228,6 +228,7 @@
   do_stub(monitor_notifyAll, 0, false, false)                          \
   do_stub(rethrow, 2, true, true)                                      \
   do_stub(slow_arraycopy, 0, false, false)                             \
+  do_stub(compile_method, 0,  true, false)                             \
   do_stub(register_finalizer, 0, false, false)                         \
   do_stub(vthread_end_first_transition, 0, false, false)               \
   do_stub(vthread_start_final_transition, 0, false, false)             \

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -165,6 +165,7 @@ public:
   // Dependencies
   friend class StubGenerator;
   friend class VMStructs;
+  friend class AOTCodeAddressTable;
 
 #include CPU_HEADER(stubRoutines)
 

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -35,6 +35,7 @@
 #include "classfile/systemDictionary.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
+#include "code/aotCodeCache.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compilerThread.hpp"
 #include "compiler/compileTask.hpp"
@@ -813,6 +814,9 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
     // startup with the proper message that CodeCache size is too small.
     initialize_class(vmSymbols::jdk_internal_vm_Continuation(), CHECK_JNI_ERR);
   }
+
+  // Pre-load AOT compiled methods
+  AOTCodeCache::preload_code(CHECK_JNI_ERR);
 
   if (NativeHeapTrimmer::enabled()) {
     NativeHeapTrimmer::initialize();

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -29,6 +29,7 @@
 #include "classfile/javaThreadStatus.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/codeBlob.hpp"
 #include "code/codeCache.hpp"
 #include "code/compiledIC.hpp"
@@ -536,7 +537,10 @@
   nonstatic_field(nmethod,                     _immutable_data_size,                          int)                                   \
   nonstatic_field(nmethod,                     _compile_id,                                   int)                                   \
   nonstatic_field(nmethod,                     _comp_level,                                   CompLevel)                             \
+  nonstatic_field(nmethod,                     _aot_code_entry,                               AOTCodeEntry*)                         \
   volatile_nonstatic_field(nmethod,            _exception_cache,                              ExceptionCache*)                       \
+                                                                                                                                     \
+  nonstatic_field(AOTCodeEntry,                _for_preload,                                  bool)                                  \
                                                                                                                                      \
   nonstatic_field(Deoptimization::UnrollBlock, _size_of_deoptimized_frame,                    int)                                   \
   nonstatic_field(Deoptimization::UnrollBlock, _caller_adjustment,                            int)                                   \
@@ -1093,6 +1097,7 @@
   declare_toplevel_type(CompileTask)                                      \
   declare_toplevel_type(Deoptimization)                                   \
   declare_toplevel_type(Deoptimization::UnrollBlock)                      \
+  declare_toplevel_type(AOTCodeEntry)                                     \
                                                                           \
   /************************/                                              \
   /* ImmutableOopMap      */                                              \

--- a/src/hotspot/share/utilities/nativeStackPrinter.cpp
+++ b/src/hotspot/share/utilities/nativeStackPrinter.cpp
@@ -45,7 +45,7 @@ void NativeStackPrinter::print_stack_from_frame(outputStream* st, frame fr,
                                                 bool print_source_info, int max_frames) {
   // see if it's a valid frame
   if (fr.pc()) {
-    st->print_cr("Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)");
+    st->print_cr("Native frames: (J=compiled Java code, A=AOT compiled, P=AOT preloaded, j=interpreted, Vv=VM code, C=native code)");
     const int limit = max_frames == -1 ? StackPrintLimit
                                        : MIN2(max_frames, StackPrintLimit);
     int count = 0;

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -319,7 +319,7 @@ void VMError::print_stack_trace(outputStream* st, JavaThread* jt,
   }
 #else
   if (jt->has_last_Java_frame()) {
-    st->print_cr("Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)");
+    st->print_cr("Java frames: (J=compiled Java code, A=AOT compiled, P=AOT preloaded, j=interpreted, Vv=VM code)");
     for (StackFrameStream sfs(jt, true /* update */, true /* process_frames */); !sfs.is_done(); sfs.next()) {
       sfs.current()->print_on_error(st, buf, buflen, verbose);
       st->cr();

--- a/test/hotspot/jtreg/ProblemList-AotJdk.txt
+++ b/test/hotspot/jtreg/ProblemList-AotJdk.txt
@@ -53,9 +53,18 @@ compiler/intrinsics/klass/TestIsPrimitive.java        0000000 generic-all
 # However when AOTClassLinking is enabled, Integer is always resolved at JVM start-up.
 compiler/ciReplay/TestInliningProtectionDomain.java   0000000 generic-all
 
+# Error: GC triggered before VM initialization completed. Try increasing NewSize
+gc/arguments/TestG1HeapSizeFlags.java 8366026 generic-all
+
 # These tests fail often with AotJdk due to JDK-8323727
 compiler/arguments/TestStressReflectiveCode.java 8323727 generic-all
 compiler/arraycopy/TestCloneWithStressReflectiveCode.java 8323727 generic-all
+
+serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation 8382548 linux-aarch64
+
+compiler/calls/NativeCalls.java 8383780 generic-all
+
+vmTestbase/vm/mlvm/indy/stress/jdi/breakpointInCompiledCode/Test.java 8383781 generic-all
 
 #############################################################################
 

--- a/test/hotspot/jtreg/compiler/compilercontrol/commands/CompileLevelPrintTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/commands/CompileLevelPrintTest.java
@@ -165,12 +165,12 @@ public class CompileLevelPrintTest {
                 "[0-9.]+: \\[(call|loop|compile|force-compile|remove-from-queue|update-in-queue|reprofile|make-not-entrant) "
                       + "level=\\d \\[([^]]+)] @-?\\d+ queues=(\\d+),(\\d+).*]");
         private static final Pattern reCompilation = Pattern.compile(
-                "(\\d+) (C1|C2|no compiler): *(\\d+) ([ %][ s][ !][ b][ n]) ([-0-4 ]) +([^ ]+).*");
+                "(\\d+) (C1|C2|no compiler): *(\\d+) ([ %][ s][ !][ b][ n][ A][ P]) ([-0-4 ]) +([^ ]+).*");
         private static final Pattern reExcludeCompile = Pattern.compile(
                 ".*made not compilable on level (\\d) +([^ ]+) .* excluded by CompileCommand");
         private static final Pattern reCompiledMethod = Pattern.compile(
                 ".*-{35} Assembly -{35}\\n(?:\\[[0-9.]+s]\\[warning]\\[os] Loading hsdis library failed\\n)?\\nCompiled method \\((?:c1|c2)\\) (\\d+) ([Cc][12]): *"
-                      + "(\\d+) ([ %][ s][ !][ b][ n]) ([-0-4 ]) +([^ ]+) +(@ -?[0-9]+ +)?\\(\\d+ bytes\\)", Pattern.DOTALL);
+                      + "(\\d+) ([ %][ s][ !][ b][ n][ A][ P]) ([-0-4 ]) +([^ ]+) +(@ -?[0-9]+ +)?\\(\\d+ bytes\\)", Pattern.DOTALL);
         private static final Pattern reMethodData = Pattern.compile(
                 ".*-{72}\\nstatic ([^\\n]+)\\n *interpreter_invocation_count: *\\d+\\n *invocation_counter: *\\d+", Pattern.DOTALL);
         private static final Pattern reEndOfLog = Pattern.compile("<hotspot_log_done .*/>");

--- a/test/hotspot/jtreg/compiler/inlining/LateInlinePrinting.java
+++ b/test/hotspot/jtreg/compiler/inlining/LateInlinePrinting.java
@@ -84,19 +84,16 @@ public class LateInlinePrinting {
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
         analyzer.shouldHaveExitValue(0);
 
-        analyzer.shouldContain("""
-compiler.inlining.LateInlinePrinting$TestLateInlining::test2 (7 bytes)
-                            @ 0   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined1 (1 bytes)   inline (hot)   late inline succeeded
-                            @ 3   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined2 (1 bytes)   inline (hot)   late inline succeeded
-                            """);
-        analyzer.shouldContain("""
-compiler.inlining.LateInlinePrinting$TestLateInlining::test1 (13 bytes)
-                            @ 0   compiler.inlining.LateInlinePrinting$TestLateInlining::test3 (1 bytes)   inline (hot)   late inline succeeded
-                            @ 3   compiler.inlining.LateInlinePrinting$TestLateInlining::testFailInline (1 bytes)   failed to inline: disallowed by CompileCommand
-                            @ 6   compiler.inlining.LateInlinePrinting$TestLateInlining::testFailInline (1 bytes)   failed to inline: disallowed by CompileCommand
-                            @ 9   compiler.inlining.LateInlinePrinting$TestLateInlining::test2 (7 bytes)   inline (hot)   late inline succeeded
-                              @ 0   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined1 (1 bytes)   inline (hot)   late inline succeeded
-                              @ 3   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined2 (1 bytes)   inline (hot)   late inline succeeded
-                              """);
+        analyzer.shouldContain("compiler.inlining.LateInlinePrinting$TestLateInlining::test2 (7 bytes)");
+        analyzer.shouldContain("@ 0   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined1 (1 bytes)   inline (hot)   late inline succeeded");
+        analyzer.shouldContain("@ 3   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined2 (1 bytes)   inline (hot)   late inline succeeded");
+
+        analyzer.shouldContain("compiler.inlining.LateInlinePrinting$TestLateInlining::test1 (13 bytes)");
+        analyzer.shouldContain("@ 0   compiler.inlining.LateInlinePrinting$TestLateInlining::test3 (1 bytes)   inline (hot)   late inline succeeded");
+        analyzer.shouldContain("@ 3   compiler.inlining.LateInlinePrinting$TestLateInlining::testFailInline (1 bytes)   failed to inline: disallowed by CompileCommand");
+        analyzer.shouldContain("@ 6   compiler.inlining.LateInlinePrinting$TestLateInlining::testFailInline (1 bytes)   failed to inline: disallowed by CompileCommand");
+        analyzer.shouldContain("@ 9   compiler.inlining.LateInlinePrinting$TestLateInlining::test2 (7 bytes)   inline (hot)   late inline succeeded");
+        analyzer.shouldContain("@ 0   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined1 (1 bytes)   inline (hot)   late inline succeeded");
+        analyzer.shouldContain("@ 3   compiler.inlining.LateInlinePrinting$TestLateInlining::inlined2 (1 bytes)   inline (hot)   late inline succeeded");
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -146,6 +146,7 @@ public class TestFramework {
                     "LogCompilation",
                     "UseCompactObjectHeaders",
                     "UseFMA",
+                    "AOTCache",
                     // Riscv
                     "UseRVV",
                     "UseZbb",

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@
  *          java.instrument
  * @requires vm.jvmti & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  * @requires vm.compMode != "Xcomp"
+ * @comment  Can't use AOT cache because -XX:TypeProfileLevel=222 invalidates training data
+ * @requires !vm.cds.supports.aot.code.caching | vm.opt.AOTCache == null
  * @build compiler.profiling.spectrapredefineclass.Agent
  * @run driver jdk.test.lib.helpers.ClassFileInstaller compiler.profiling.spectrapredefineclass.Agent
  * @run driver compiler.profiling.spectrapredefineclass.Launcher

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@
  *          java.instrument
  * @requires vm.jvmti & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  * @requires vm.compMode != "Xcomp"
+ * @comment  Can't use AOT cache because -XX:TypeProfileLevel=222 invalidates training data
+ * @requires !vm.cds.supports.aot.code.caching | vm.opt.AOTCache == null
  * @build compiler.profiling.spectrapredefineclass_classloaders.Agent
  *        compiler.profiling.spectrapredefineclass_classloaders.Test
  *        compiler.profiling.spectrapredefineclass_classloaders.A

--- a/test/hotspot/jtreg/compiler/runtime/safepoints/TestMachTempsAcrossSafepoints.java
+++ b/test/hotspot/jtreg/compiler/runtime/safepoints/TestMachTempsAcrossSafepoints.java
@@ -34,6 +34,8 @@ import java.lang.ref.SoftReference;
  * @key randomness
  * @library /test/lib /
  * @requires vm.gc.G1 & vm.bits == 64 & vm.opt.final.UseCompressedOops == true
+ * @comment  Can't use AOT cache because training data may affect shape of test's code
+ * @requires !vm.cds.supports.aot.code.caching | vm.opt.AOTCache == null
  * @run driver compiler.runtime.safepoints.TestMachTempsAcrossSafepoints
  */
 

--- a/test/hotspot/jtreg/runtime/cds/MetaspaceAllocGaps.java
+++ b/test/hotspot/jtreg/runtime/cds/MetaspaceAllocGaps.java
@@ -42,9 +42,12 @@ public class MetaspaceAllocGaps {
     public static void main(String[] args) throws Exception {
         String appJar = ClassFileInstaller.getJarPath("hello.jar");
         for (int i = 0; i < 2; i++) {
+            // Exclude AOT training data for consistency.
             String compressedOops = "-XX:" + (i == 0 ? "-" : "+") + "UseCompressedOops";
             SimpleCDSAppTester.of("MetaspaceAllocGaps" + i)
                 .addVmArgs("-Xlog:aot=debug,aot+alloc=trace",
+                           "-XX:+UnlockDiagnosticVMOptions",
+                           "-XX:-AOTRecordTraining",
                            "-XX:+UseCompactObjectHeaders")
                 .classpath(appJar)
                 .appCommandLine("Hello")

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTCompileEagerly.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTCompileEagerly.java
@@ -83,7 +83,7 @@ public class AOTCompileEagerly {
         System.out.println("Production Run with AOTCache and eager compilation explicitly ON");
         pb = ProcessTools.createLimitedTestJavaProcessBuilder(
             "-XX:AOTCache=" + aotCacheFile,
-            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+UnlockDiagnosticVMOptions",
             "-XX:+AOTCompileEagerly",
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod-eager-on");
@@ -93,7 +93,7 @@ public class AOTCompileEagerly {
         System.out.println("Production Run with AOTCache and eager compilation explicitly OFF");
         pb = ProcessTools.createLimitedTestJavaProcessBuilder(
             "-XX:AOTCache=" + aotCacheFile,
-            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+UnlockDiagnosticVMOptions",
             "-XX:-AOTCompileEagerly",
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod-eager-off");

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/TestSetupAOTTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/TestSetupAOTTest.java
@@ -27,7 +27,7 @@
  * @summary This is a test case for creating an AOT cache using the setup_aot/TestSetupAOT.java program, which
  *          is used for running HotSpot tests in the "AOT mode"
  *          (E.g., make test JTREG=AOT_JDK=true TEST=open/test/hotspot/jtreg/runtime/invokedynamic)
- * @requires vm.cds
+ * @requires vm.cds.supports.aot.class.linking
  * @library /test/lib /test/setup_aot
  * @build TestSetupAOTTest JavacBenchApp TestSetupAOT
  * @run driver jdk.test.lib.helpers.ClassFileInstaller

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeCPUFeatureIncompatibilityTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeCPUFeatureIncompatibilityTest.java
@@ -85,9 +85,9 @@ public class AOTCodeCPUFeatureIncompatibilityTest {
             public String[] vmArgs(RunMode runMode) {
                 if (runMode == RunMode.ASSEMBLY) {
                     if (mode == IncompatibilityMode.MISSING) {
-                        return new String[] {"-Xlog:aot+codecache*=debug"};
+                        return new String[] {"-Xlog:aot+codecache+exit=debug"};
                     } else {
-                        return new String[] {vmOption, "-Xlog:aot+codecache*=debug"};
+                        return new String[] {vmOption, "-Xlog:aot+codecache+exit=debug"};
                     }
                 } else if (runMode == RunMode.PRODUCTION) {
                     if (mode == IncompatibilityMode.MISSING) {
@@ -95,12 +95,12 @@ public class AOTCodeCPUFeatureIncompatibilityTest {
                                              "-XX:+UnlockDiagnosticVMOptions",
                                              // Prevent exiting VM on failure
                                              "-XX:-AbortVMOnAOTCodeFailure",
-                                             "-Xlog:aot+codecache*=debug"};
+                                             "-Xlog:aot+codecache+init=debug"};
                     } else {
                         return new String[] {"-XX:+UnlockDiagnosticVMOptions",
                                              // Prevent exiting VM on failure
                                              "-XX:-AbortVMOnAOTCodeFailure",
-                                             "-Xlog:aot+codecache*=debug"};
+                                             "-Xlog:aot+codecache+init=debug"};
                     }
                 }
                 return new String[]{};

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeCompressedOopsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeCompressedOopsTest.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Sanity test of AOT Code Cache with compressed oops configurations
  * @requires vm.cds.supports.aot.code.caching
- * @requires vm.compMode != "Xcomp"
+ * @requires vm.compMode != "Xcomp" & vm.compMode != "Xint"
  * @requires vm.bits == 64
  * @requires vm.opt.final.UseCompressedOops
  * @comment The test verifies AOT checks during VM startup and not code generation.
@@ -180,7 +180,7 @@ public class AOTCodeCompressedOopsTest {
                          line = list.get(i+2);
                          Matcher m = p.matcher(line);
                          if (!m.find()) {
-                             throw new RuntimeException("Pattern \"" + p + "\" not found in the output");
+                             throw new RuntimeException("Pattern \"" + p + "\" not found in the output. Got \"" + line + "\"");
                          }
                          aotCacheBase = Long.valueOf(m.group(1), 16);
                          aotCacheShift = Integer.valueOf(m.group(2));
@@ -188,7 +188,7 @@ public class AOTCodeCompressedOopsTest {
                          line = list.get(i+6);
                          m = p.matcher(line);
                          if (!m.find()) {
-                             throw new RuntimeException("Pattern \"" + p + "\" not found in the output");
+                             throw new RuntimeException("Pattern \"" + p + "\" not found in the output. Got \"" + line + "\"");
                          }
                          currentBase = Long.valueOf(m.group(1), 16);
                          currentShift = Integer.valueOf(m.group(2));

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
@@ -27,6 +27,9 @@
  * @requires vm.gc != "Z"
  * @summary Sanity test of combinations of the AOT Code Caching diagnostic flags
  * @requires vm.cds.supports.aot.code.caching
+ * @requires vm.compMode != "Xcomp" & vm.compMode != "Xint"
+ * @comment It runs for long time (hours) with -Xcomp and AOT code caching enabled
+ *          on (virtual) machine with small number of cores
  * @requires vm.compiler1.enabled & vm.compiler2.enabled
  * @comment Both C1 and C2 JIT compilers are required because the test verifies
  *          compiler's runtime blobs generation.
@@ -46,6 +49,9 @@
  * @requires vm.gc.Z
  * @summary Sanity test of combinations of the AOT Code Caching diagnostic flags
  * @requires vm.cds.supports.aot.code.caching
+ * @requires vm.compMode != "Xcomp" & vm.compMode != "Xint"
+ * @comment It runs for long time (hours) with -Xcomp and AOT code caching enabled
+ *          on (virtual) machine with small number of cores
  * @requires vm.compiler1.enabled & vm.compiler2.enabled
  * @comment Both C1 and C2 JIT compilers are required because the test verifies
  *          compiler's runtime blobs generation.
@@ -65,6 +71,9 @@
  * @requires vm.gc.Shenandoah
  * @summary Sanity test of combinations of the AOT Code Caching diagnostic flags
  * @requires vm.cds.supports.aot.code.caching
+ * @requires vm.compMode != "Xcomp" & vm.compMode != "Xint"
+ * @comment It runs for long time (hours) with -Xcomp and AOT code caching enabled
+ *          on (virtual) machine with small number of cores
  * @requires vm.compiler1.enabled & vm.compiler2.enabled
  * @comment Both C1 and C2 JIT compilers are required because the test verifies
  *          compiler's runtime blobs generation.
@@ -84,6 +93,9 @@
  * @requires vm.gc.Parallel
  * @summary Sanity test of combinations of the AOT Code Caching diagnostic flags
  * @requires vm.cds.supports.aot.code.caching
+ * @requires vm.compMode != "Xcomp" & vm.compMode != "Xint"
+ * @comment It runs for long time (hours) with -Xcomp and AOT code caching enabled
+ *          on (virtual) machine with small number of cores
  * @requires vm.compiler1.enabled & vm.compiler2.enabled
  * @comment Both C1 and C2 JIT compilers are required because the test verifies
  *          compiler's runtime blobs generation.
@@ -109,10 +121,10 @@ public class AOTCodeFlags {
     private static String gcName = null;
     public static void main(String... args) throws Exception {
         Tester t = new Tester(args.length == 0 ? null : args[0]);
-        // mode bits 0 and 1 encode AOTAdapterCaching and AOTStubCaching settings
+        // mode bits 0,1,2 encode AOTAdapterCaching, AOTStubCaching and AOTCodeCaching settings
         // aMode is used for assembly run, pMode for production run
-        for (int aMode = 0; aMode < 4; aMode++) {
-            for (int pMode = 0; pMode < 4; pMode++) {
+        for (int aMode = 0; aMode < 8; aMode++) {
+            for (int pMode = 0; pMode < 8; pMode++) {
                 t.setTestMode(aMode, pMode);
                 t.run(new String[] {"AOT", "--two-step-training"});
             }
@@ -137,6 +149,10 @@ public class AOTCodeFlags {
             return (mode & 0x2) != 0;
         }
 
+        boolean isCodeCachingOn(int mode) {
+            return (mode & 0x4) != 0;
+        }
+
         public void setTestMode(int aMode, int pMode) {
             this.aMode = aMode;
             this.pMode = pMode;
@@ -147,6 +163,7 @@ public class AOTCodeFlags {
             list.add("-XX:+UnlockDiagnosticVMOptions");
             list.add(isAdapterCachingOn(mode) ? "-XX:+AOTAdapterCaching" : "-XX:-AOTAdapterCaching");
             list.add(isStubCachingOn(mode) ? "-XX:+AOTStubCaching" : "-XX:-AOTStubCaching");
+            list.add(isCodeCachingOn(mode) ? "-XX:+AOTCodeCaching" : "-XX:-AOTCodeCaching");
             return list;
         }
 
@@ -178,6 +195,7 @@ public class AOTCodeFlags {
             List<String> args = getGCArgs();
             args.addAll(List.of("-Xlog:aot+codecache+init=debug",
                                 "-Xlog:aot+codecache+exit=debug",
+                                "-Xlog:aot+codecache+nmethod=info",
                                 "-Xlog:aot+codecache+stubs=debug"));
             switch (runMode) {
             case RunMode.ASSEMBLY:
@@ -194,67 +212,89 @@ public class AOTCodeFlags {
 
         @Override
         public String[] appCommandLine(RunMode runMode) {
-            return new String[] { "JavacBenchApp", "10" };
+            return new String[] { "JavacBenchApp", "1" };
         }
 
         @Override
         public void checkExecution(OutputAnalyzer out, RunMode runMode) throws Exception {
             if (runMode == RunMode.ASSEMBLY) {
-                if (!isAdapterCachingOn(aMode) && !isStubCachingOn(aMode)) { // this is equivalent to completely disable AOT code cache
-                    out.shouldNotMatch("Adapters:\\s+total");
-                    out.shouldNotMatch("Shared Blobs:\\s+total");
-                    out.shouldNotMatch("C1 Blobs:\\s+total");
-                    out.shouldNotMatch("C2 Blobs:\\s+total");
+                if (!isAdapterCachingOn(aMode) && !isStubCachingOn(aMode) && !isCodeCachingOn(aMode)) {
+                    // this is equivalent to completely disable AOT code cache
+                    out.shouldNotMatch("Adapter:\\s+total");
+                    out.shouldNotMatch("SharedBlob:\\s+total");
+                    out.shouldNotMatch("C1Blob:\\s+total");
+                    out.shouldNotMatch("C2Blob:\\s+total");
+                    out.shouldNotMatch("StubGenBlob:\\s+total");
+                    out.shouldNotMatch("Nmethod:\\s+total");
                 } else {
                     if (isAdapterCachingOn(aMode)) {
                         // AOTAdapterCaching is on, non-zero adapters should be stored
-                        out.shouldMatch("Adapters:\\s+total=[1-9][0-9]+");
+                        out.shouldMatch("Adapter:\\s+total=[1-9][0-9]+");
                     } else {
                         // AOTAdapterCaching is off, no adapters should be stored
-                        out.shouldMatch("Adapters:\\s+total=0");
+                        out.shouldMatch("Adapter:\\s+total=0");
                     }
                     if (isStubCachingOn(aMode)) {
                         // AOTStubCaching is on, non-zero stubs should be stored
-                        out.shouldMatch("Shared Blobs:\\s+total=[1-9][0-9]+");
-                        out.shouldMatch("C1 Blobs:\\s+total=[1-9][0-9]+");
-                        out.shouldMatch("C2 Blobs:\\s+total=[1-9][0-9]+");
+                        out.shouldMatch("SharedBlob:\\s+total=[1-9][0-9]+");
+                        out.shouldMatch("C1Blob:\\s+total=[1-9][0-9]+");
+                        out.shouldMatch("C2Blob:\\s+total=[1-9][0-9]+");
+                        out.shouldMatch("StubGenBlob:\\s+total=[1-9]+");
                     } else {
                         // AOTStubCaching is off, no stubs should be stored
-                        out.shouldMatch("Shared Blobs:\\s+total=0");
-                        out.shouldMatch("C1 Blobs:\\s+total=0");
-                        out.shouldMatch("C2 Blobs:\\s+total=0");
+                        out.shouldMatch("SharedBlob:\\s+total=0");
+                        out.shouldMatch("C1Blob:\\s+total=0");
+                        out.shouldMatch("C2Blob:\\s+total=0");
+                    }
+                    if (isCodeCachingOn(aMode)) {
+                        // AOTCodeCaching is on, non-zero nmethods should be stored/loaded
+                        out.shouldMatch("Nmethod:\\s+total=[1-9][0-9]+");
+                    } else {
+                        // AOTCodeCaching is off, no nmethods should be stored/loaded
+                        out.shouldMatch("Nmethod:\\s+total=0");
                     }
                 }
             } else if (runMode == RunMode.PRODUCTION) {
-                // Irrespective of assembly run mode, if both adapter and stub caching is disabled
+                // Irrespective of assembly run mode, if both all types of code caching is disabled
                 // in production run, then it is equivalent to completely disabling AOT code cache
-                if (!isAdapterCachingOn(pMode) && !isStubCachingOn(pMode)) {
-                    out.shouldNotMatch("Adapters:\\s+total");
-                    out.shouldNotMatch("Shared Blobs:\\s+total");
-                    out.shouldNotMatch("C1 Blobs:\\s+total");
-                    out.shouldNotMatch("C2 Blobs:\\s+total");
+                if (!isAdapterCachingOn(pMode) && !isStubCachingOn(pMode) && !isCodeCachingOn(pMode)) {
+                    out.shouldNotMatch("Adapter:\\s+total");
+                    out.shouldNotMatch("SharedBlob:\\s+total");
+                    out.shouldNotMatch("C1Blob:\\s+total");
+                    out.shouldNotMatch("C2Blob:\\s+total");
+                    out.shouldNotMatch("StubGenBlob:\\s+total");
+                    out.shouldNotMatch("Nmethod:\\s+total");
                 } else {
                     // If AOT code cache is effectively disabled in the assembly run, then production run
                     // would emit empty code cache message.
-                    if (!isAdapterCachingOn(aMode) && !isStubCachingOn(aMode)) {
-                        if (isAdapterCachingOn(pMode) || isStubCachingOn(pMode)) {
+                    if (!isAdapterCachingOn(aMode) && !isStubCachingOn(aMode) && !isCodeCachingOn(aMode)) {
+                        if (isAdapterCachingOn(pMode) || isStubCachingOn(pMode) || isCodeCachingOn(pMode)) {
                             out.shouldMatch("AOT Code Cache is empty");
                         }
                     } else {
                         if (isAdapterCachingOn(aMode)) {
                             if (isAdapterCachingOn(pMode)) {
-                                out.shouldMatch("Read blob.*kind=Adapter.*");
+                                out.shouldMatch("Loaded blob.*kind=Adapter.*");
                             } else {
-                                out.shouldNotMatch("Read blob.*kind=Adapter.*");
+                                out.shouldNotMatch("Loaded blob.*kind=Adapter.*");
                             }
                         }
                         if (isStubCachingOn(aMode)) {
                             if (isStubCachingOn(pMode)) {
-                                out.shouldMatch("Read blob.*kind=SharedBlob.*");
-                                out.shouldMatch("Read blob.*kind=C1Blob.*");
+                                out.shouldMatch("Loaded blob.*kind=SharedBlob.*");
+                                out.shouldMatch("Loaded blob.*kind=C1Blob.*");
+                                out.shouldMatch("Loaded blob.*kind=StubGenBlob.*");
                             } else {
-                                out.shouldNotMatch("Read blob.*kind=SharedBlob.*");
-                                out.shouldNotMatch("Read blob.*kind=C1Blob.*");
+                                out.shouldNotMatch("Loaded blob.*kind=SharedBlob.*");
+                                out.shouldNotMatch("Loaded blob.*kind=C1Blob.*");
+                                out.shouldNotMatch("Loaded blob.*kind=StubGenBlob.*");
+                            }
+                        }
+                        if (isCodeCachingOn(aMode)) {
+                            if (isCodeCachingOn(pMode)) {
+                                out.shouldMatch("Loaded nmethod .*");
+                            } else {
+                                out.shouldNotMatch("Loaded nmethod .*");
                             }
                         }
                     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeTest.java
@@ -187,9 +187,9 @@ public class AOTCodeTest {
                 out.shouldMatch("aot,codecache,exit.*\\s+AOT code cache size: [1-9]\\d+ bytes");
             } else if (runMode == RunMode.PRODUCTION) {
                 out.shouldMatch("aot,codecache,init.*\\s+Loaded [1-9]\\d+ AOT code entries from AOT Code Cache");
-                out.shouldMatch("aot,codecache,stubs.*\\s+Read blob.*kind=Adapter.*");
-                out.shouldMatch("aot,codecache,stubs.*\\s+Read blob.*kind=SharedBlob.*");
-                out.shouldMatch("aot,codecache,stubs.*\\s+Read blob.*kind=C1Blob.*");
+                out.shouldMatch("aot,codecache,stubs.*\\s+Loaded blob.*kind=Adapter.*");
+                out.shouldMatch("aot,codecache,stubs.*\\s+Loaded blob.*kind=SharedBlob.*");
+                out.shouldMatch("aot,codecache,stubs.*\\s+Loaded blob.*kind=C1Blob.*");
             }
         }
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/TestDisableAOTCode.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/TestDisableAOTCode.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @summary Sanity test of the diagnostic flag -XX:DisableAOTCode=n
+ * @requires vm.cds.supports.aot.class.linking
+ * @requires vm.flagless
+ * @requires vm.compiler1.enabled & vm.compiler2.enabled
+ * @comment Both C1 and C2 JIT compilers are required because the test verifies
+ *          all AOT code tiers generation (except tier 3).
+ * @library /test/lib /test/setup_aot
+ * @build TestDisableAOTCode JavacBenchApp
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar
+ *                 JavacBenchApp
+ *                 JavacBenchApp$ClassFile
+ *                 JavacBenchApp$FileManager
+ *                 JavacBenchApp$SourceFile
+ * @run driver/timeout=480 TestDisableAOTCode
+ */
+
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestDisableAOTCode {
+
+    public static void main(String... args) throws Exception {
+        String appJar = ClassFileInstaller.getJarPath("app.jar");
+        String aotConfigFile = "app.aotconfig";
+        String aotCacheFile = "app.aot";
+        String appClass = "JavacBenchApp";
+        String appArgs = "10";
+
+        ProcessBuilder pb;
+        OutputAnalyzer out;
+
+        // first make sure we have a valid aotConfigFile
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot",
+            "-XX:AOTMode=record",
+            "-XX:AOTConfiguration=" + aotConfigFile,
+            "-cp", appJar, appClass, appArgs);
+
+        out = CDSTestUtils.executeAndLog(pb, "train");
+        out.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot+codecache+exit",
+            "-XX:AOTMode=create",
+            "-XX:AOTConfiguration=" + aotConfigFile,
+            "-XX:AOTCache=" + aotCacheFile,
+            "-cp", appJar);
+
+        out = CDSTestUtils.executeAndLog(pb, "assemble");
+        out.shouldMatch("aot,codecache,exit.*\\s+Tier 1:.*");
+        out.shouldMatch("aot,codecache,exit.*\\s+Tier 2:.*");
+        out.shouldMatch("aot,codecache,exit.*\\s+Tier 3:.*");
+        out.shouldMatch("aot,codecache,exit.*\\s+Tier 4:.*");
+        out.shouldMatch("aot,codecache,exit.*\\s+Tier 5:.*");
+        out.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot+codecache+init",
+            "-XX:AOTCache=" + aotCacheFile,
+            "-XX:+CITime",
+            "-cp", appJar, appClass, appArgs);
+
+        out = CDSTestUtils.executeAndLog(pb, "production_default");
+        out.shouldMatch("  AOT Code T1.*");
+        out.shouldMatch("  AOT Code T2.*");
+        out.shouldMatch("  AOT Code T4.*");
+        out.shouldMatch("  AOT Code T5.*");
+        // Tier 3 AOT code generation is not implemented
+        out.shouldNotMatch("\\s+AOT Code T3.*");
+        out.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot+codecache+init",
+            "-XX:AOTCache=" + aotCacheFile,
+            "-XX:+CITime",
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:DisableAOTCode=1",
+            "-cp", appJar, appClass, appArgs);
+
+        out = CDSTestUtils.executeAndLog(pb, "production_no_AOT_T1");
+        out.shouldNotMatch("  AOT Code T1.*");
+        out.shouldMatch("  AOT Code T2.*");
+        out.shouldMatch("  AOT Code T4.*");
+        out.shouldMatch("  AOT Code T5.*");
+        out.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot+codecache+init",
+            "-XX:AOTCache=" + aotCacheFile,
+            "-XX:+CITime",
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:DisableAOTCode=10000",
+            "-cp", appJar, appClass, appArgs);
+
+        out = CDSTestUtils.executeAndLog(pb, "production_no_AOT_T5");
+        out.shouldMatch("  AOT Code T1.*");
+        out.shouldMatch("  AOT Code T2.*");
+        out.shouldMatch("  AOT Code T4.*");
+        out.shouldNotMatch("  AOT Code T5.*");
+        out.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot+codecache+init",
+            "-XX:AOTCache=" + aotCacheFile,
+            "-XX:+CITime",
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:DisableAOTCode=11111",
+            "-cp", appJar, appClass, appArgs);
+
+        out = CDSTestUtils.executeAndLog(pb, "production_no_AOT_all");
+        out.shouldNotMatch("  AOT Code T1.*");
+        out.shouldNotMatch("  AOT Code T2.*");
+        out.shouldNotMatch("  AOT Code T4.*");
+        out.shouldNotMatch("  AOT Code T5.*");
+        out.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot+codecache+init",
+            "-XX:AOTCache=" + aotCacheFile,
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:DisableAOTCode=15",
+            "-cp", appJar, appClass, appArgs);
+
+        out = CDSTestUtils.executeAndLog(pb, "production_wrong_value");
+        out.shouldContain("Improperly specified VM option 'DisableAOTCode=15'");
+        out.shouldHaveExitValue(1);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot+codecache+init",
+            "-XX:AOTCache=" + aotCacheFile,
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:DisableAOTCode=111111",
+            "-cp", appJar, appClass, appArgs);
+
+        out = CDSTestUtils.executeAndLog(pb, "production_wrong_digits");
+        out.shouldContain("Improperly specified VM option 'DisableAOTCode=111111'");
+        out.shouldHaveExitValue(1);
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/TestVerifyAOTCode.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/TestVerifyAOTCode.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @summary Sanity test of the diagnostic flag -XX:+VerifyAOTCode
+ * @requires vm.cds.supports.aot.class.linking
+ * @requires vm.flagless
+ * @requires vm.compiler1.enabled & vm.compiler2.enabled
+ * @comment Both C1 and C2 JIT compilers are required because the test verifies
+ *          all AOT code tiers generation (except tier 3).
+ * @library /test/lib /test/setup_aot
+ * @build TestVerifyAOTCode JavacBenchApp
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar
+ *                 JavacBenchApp
+ *                 JavacBenchApp$ClassFile
+ *                 JavacBenchApp$FileManager
+ *                 JavacBenchApp$SourceFile
+ * @run driver/timeout=480 TestVerifyAOTCode
+ */
+
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestVerifyAOTCode {
+
+    public static void main(String... args) throws Exception {
+        String appJar = ClassFileInstaller.getJarPath("app.jar");
+        String aotConfigFile = "app.aotconfig";
+        String aotCacheFile = "app.aot";
+        String appClass = "JavacBenchApp";
+        String appArgs = "10";
+
+        ProcessBuilder pb;
+        OutputAnalyzer out;
+
+        // first make sure we have a valid aotConfigFile
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot",
+            "-XX:AOTMode=record",
+            "-XX:AOTConfiguration=" + aotConfigFile,
+            "-cp", appJar, appClass, appArgs);
+
+        out = CDSTestUtils.executeAndLog(pb, "train");
+        out.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot+codecache+exit",
+            "-XX:AOTMode=create",
+            "-XX:AOTConfiguration=" + aotConfigFile,
+            "-XX:AOTCache=" + aotCacheFile,
+            "-cp", appJar);
+
+        out = CDSTestUtils.executeAndLog(pb, "assemble");
+        out.shouldMatch("aot,codecache,exit.*\\s+Tier 1:.*");
+        out.shouldMatch("aot,codecache,exit.*\\s+Tier 2:.*");
+        out.shouldMatch("aot,codecache,exit.*\\s+Tier 3:.*");
+        out.shouldMatch("aot,codecache,exit.*\\s+Tier 4:.*");
+        out.shouldMatch("aot,codecache,exit.*\\s+Tier 5:.*");
+        out.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot+codecache+init",
+            "-Xlog:aot+codecache+nmethod",
+            "-XX:AOTCache=" + aotCacheFile,
+            "-XX:+CITime",
+            "-cp", appJar, appClass, appArgs);
+
+        out = CDSTestUtils.executeAndLog(pb, "production_default");
+        out.shouldMatch("Loaded nmethod from AOT Code Cache");
+        out.shouldMatch("  AOT Code T1.*");
+        out.shouldMatch("  AOT Code T2.*");
+        out.shouldMatch("  AOT Code T4.*");
+        out.shouldMatch("  AOT Code T5.*");
+        // Tier 3 AOT code generation is not implemented
+        out.shouldNotMatch("\\s+AOT Code T3.*");
+        out.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot+codecache+init",
+            "-Xlog:aot+codecache+nmethod",
+            "-XX:AOTCache=" + aotCacheFile,
+            "-XX:+CITime",
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+VerifyAOTCode",
+            "-cp", appJar, appClass, appArgs);
+
+        out = CDSTestUtils.executeAndLog(pb, "production_VerifyAOTCode");
+        out.shouldMatch("Verified nmethod from AOT Code Cache");
+        out.shouldNotMatch("Loaded nmethod from AOT Code Cache");
+        out.shouldMatch("  AOT Code T1.*");
+        out.shouldMatch("  AOT Code T2.*");
+        out.shouldMatch("  AOT Code T4.*");
+        out.shouldMatch("  AOT Code T5.*");
+        out.shouldHaveExitValue(0);
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AOTFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AOTFlags.java
@@ -52,6 +52,12 @@ public class AOTFlags {
     }
 
     static void positiveTests() throws Exception {
+        String hasTrainingDataPattern = "MethodTrainingData *= *[1-9]";
+        String noTrainingDataPattern = "MethodTrainingData *= *0";
+        String hasAOTCodePattern = "Shared file region .ac. .: *[1-9]";
+        String noAOTCodePattern = "Shared file region .ac. .: *0";
+        String hasMappedAOTCodePattern = "Mapped [0-9]+ bytes at address 0x[0-9a-f]+ from AOT Code Cache";
+
         //----------------------------------------------------------------------
         printTestCase("Training Run");
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
@@ -63,6 +69,8 @@ public class AOTFlags {
         OutputAnalyzer out = CDSTestUtils.executeAndLog(pb, "train");
         out.shouldContain("Hello World");
         out.shouldContain("AOTConfiguration recorded: " + aotConfigFile);
+        out.shouldMatch(hasTrainingDataPattern);
+        out.shouldMatch(noAOTCodePattern);
         out.shouldHaveExitValue(0);
 
         //----------------------------------------------------------------------
@@ -76,6 +84,8 @@ public class AOTFlags {
         out = CDSTestUtils.executeAndLog(pb, "asm");
         out.shouldContain("AOTCache creation is complete");
         out.shouldMatch("hello[.]aot");
+        out.shouldMatch(hasTrainingDataPattern);
+        out.shouldMatch(hasAOTCodePattern);
         out.shouldHaveExitValue(0);
 
         //----------------------------------------------------------------------
@@ -83,11 +93,13 @@ public class AOTFlags {
         pb = ProcessTools.createLimitedTestJavaProcessBuilder(
             "-XX:AOTCache=" + aotCacheFile,
             "-Xlog:aot",
+            "-Xlog:aot+codecache*",
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod");
         out.shouldContain("Using AOT-linked classes: true (static archive: has aot-linked classes)");
         out.shouldContain("Opened AOT cache hello.aot.");
         out.shouldContain("Hello World");
+        out.shouldMatch(hasMappedAOTCodePattern);
         out.shouldHaveExitValue(0);
 
         //----------------------------------------------------------------------
@@ -141,11 +153,13 @@ public class AOTFlags {
             "-XX:-AOTClassLinking",
             "-XX:AOTConfiguration=" + aotConfigFile,
             "-XX:AOTCache=" + aotCacheFile,
-            "-Xlog:aot",
+            "-Xlog:aot=debug",
             "-cp", appJar);
         out = CDSTestUtils.executeAndLog(pb, "asm");
         out.shouldContain("AOTCache creation is complete");
         out.shouldMatch("hello[.]aot");
+        out.shouldMatch(noTrainingDataPattern);
+        out.shouldMatch(noAOTCodePattern);
         out.shouldHaveExitValue(0);
 
         //----------------------------------------------------------------------
@@ -153,11 +167,13 @@ public class AOTFlags {
         pb = ProcessTools.createLimitedTestJavaProcessBuilder(
             "-XX:AOTCache=" + aotCacheFile,
             "-Xlog:aot",
+            "-Xlog:aot+codecache*",
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod");
         out.shouldContain("Using AOT-linked classes: false (static archive: no aot-linked classes)");
         out.shouldContain("Opened AOT cache hello.aot.");
         out.shouldContain("Hello World");
+        out.shouldNotMatch(hasMappedAOTCodePattern);
         out.shouldHaveExitValue(0);
 
         //----------------------------------------------------------------------
@@ -181,8 +197,8 @@ public class AOTFlags {
             "-Xlog:aot=debug",
             "-cp", appJar);
         out = CDSTestUtils.executeAndLog(pb, "asm");
-        out.shouldContain("Writing AOTCache file:");
-        out.shouldMatch("aot.*hello[.]aot");
+        out.shouldContain("AOTCache creation is complete");
+        out.shouldMatch("hello[.]aot");
         out.shouldHaveExitValue(0);
 
         //----------------------------------------------------------------------
@@ -213,33 +229,8 @@ public class AOTFlags {
         out.shouldContain("AOTCache creation is complete: hello.aot");
         out.shouldHaveExitValue(0);
 
-        // Set AOTCacheOutput/AOTConfiguration/AOTMode=auto; Ergo changes: AOTMode=record
-        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
-            "-XX:AOTMode=auto",
-            "-XX:AOTCacheOutput=" + aotCacheFile,
-            "-XX:AOTConfiguration=" + aotConfigFile,
-            "-Xlog:aot=debug",
-            "-cp", appJar, helloClass);
-        out = CDSTestUtils.executeAndLog(pb, "ontstep-train");
-        out.shouldContain("Hello World");
-        out.shouldContain("AOTConfiguration recorded: " + aotConfigFile);
-        out.shouldContain("AOTCache creation is complete: hello.aot");
-        out.shouldHaveExitValue(0);
-
         // Set AOTCacheOutput only; Ergo for: AOTMode=record, AOTConfiguration=<temp>
         pb = ProcessTools.createLimitedTestJavaProcessBuilder(
-            "-XX:AOTCacheOutput=" + aotCacheFile,
-            "-Xlog:aot=debug",
-            "-cp", appJar, helloClass);
-        out = CDSTestUtils.executeAndLog(pb, "ontstep-train");
-        out.shouldContain("Hello World");
-        out.shouldContain("Temporary AOTConfiguration recorded: " + aotCacheFile + ".config");
-        out.shouldContain("AOTCache creation is complete: hello.aot");
-        out.shouldHaveExitValue(0);
-
-        // Set AOTCacheOutput/AOTMode=auto only; Ergo for: AOTMode=record, AOTConfiguration=<temp>
-        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
-            "-XX:AOTMode=auto",
             "-XX:AOTCacheOutput=" + aotCacheFile,
             "-Xlog:aot=debug",
             "-cp", appJar, helloClass);

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotProfile/AOTProfileFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotProfile/AOTProfileFlags.java
@@ -74,6 +74,7 @@ public class AOTProfileFlags {
 
         // first make sure we have a valid aotConfigFile with default value of TypeProfileLevel
         pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot",
             "-XX:AOTMode=record",
             "-XX:AOTConfiguration=" + aotConfigFile,
             "-XX:+UnlockExperimentalVMOptions",
@@ -84,6 +85,7 @@ public class AOTProfileFlags {
         out.shouldHaveExitValue(0);
 
         pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot",
             "-XX:AOTMode=create",
             "-XX:AOTConfiguration=" + aotConfigFile,
             "-XX:AOTCache=" + aotCacheFile,
@@ -95,6 +97,7 @@ public class AOTProfileFlags {
         out.shouldHaveExitValue(0);
 
         pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot",
             "-XX:AOTCache=" + aotCacheFile,
             "-XX:+UnlockExperimentalVMOptions",
             trainingFlags,
@@ -105,6 +108,7 @@ public class AOTProfileFlags {
         out.shouldHaveExitValue(0);
 
         pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:aot",
             "-XX:AOTCache=" + aotCacheFile,
             "-XX:+UnlockExperimentalVMOptions",
             productionFlags,


### PR DESCRIPTION
Pushing to new `premain2` branch AOT code caching implementation from mainline PR: https://github.com/openjdk/jdk/pull/30778

Tested: tier1-5

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386108](https://bugs.openjdk.org/browse/JDK-8386108): [leyden] Implement JEP: Ahead-of-Time Code Compilation (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/113/head:pull/113` \
`$ git checkout pull/113`

Update a local copy of the PR: \
`$ git checkout pull/113` \
`$ git pull https://git.openjdk.org/leyden.git pull/113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 113`

View PR using the GUI difftool: \
`$ git pr show -t 113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/113.diff">https://git.openjdk.org/leyden/pull/113.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/113#issuecomment-4639949737)
</details>
