### PR TITLE
8388410: [Leyden] Improve map file logging to add Embedded Stubs from StubGenBlobs

### DIFF
--- a/src/hotspot/share/cds/aotMapLogger.cpp
+++ b/src/hotspot/share/cds/aotMapLogger.cpp
@@ -144,9 +144,9 @@ void AOTMapLogger::log_embedded_stubs(const AOTCodeCache* cache, const AOTCodeEn
     pos += sizeof(uint);
 
     // Log the embedded stub
-    log_debug(aot, map)(PTR_FORMAT ": @@ %-17s %d %d %d %s",
+    log_debug(aot, map)(PTR_FORMAT ": @@ %-17s %d id=%d blob=%d %s",
       p2i(buf + entry->offset() + entry->code_offset() + offset),
-      "EmbeddedStub", size, entry->id(), (int) stub_id, StubInfo::name(stub_id));
+      "EmbeddedStub", size, (int) stub_id, entry->id(), StubInfo::name(stub_id));
 
     //Get the number of secondary/extra entry offsets
     int n = *(int*) (buf + pos);

--- a/src/hotspot/share/cds/aotMapLogger.cpp
+++ b/src/hotspot/share/cds/aotMapLogger.cpp
@@ -123,31 +123,12 @@ void AOTMapLogger::dumptime_log(ArchiveBuilder* builder, FileMapInfo* mapinfo,
 void AOTMapLogger::log_embedded_stubs(const AOTCodeCache* cache, const AOTCodeEntry* entry) {
 
   //start at the beginning of our AOT cache
-  const char* buf  = cache->store_buffer();
+  const char* buf = cache->store_buffer();
 
-  //pos now points at the beginning of the StubGenBlob
-  uint pos = entry->offset() + entry->code_offset();
+  // jump to the embedded stubs section
+  uint pos = entry->offset() + entry->embedded_stub_offset();
 
-  // The first part is the CodeBlob which we are not going to log
-  const CodeBlob* blob = (const CodeBlob*)(buf + pos);
-  pos += blob->size();
-
-  // Then we have the relocation data records (aligned to HeapWordSize)
-  // we are not interested in logging this either
-  int reloc_count = *(int*)(buf + pos);
-  pos += sizeof(int);
-  pos = align_up(pos, (uint)HeapWordSize);
-  pos += reloc_count * (uint)sizeof(relocInfo);
-
-  // Then we have an optional OopMapSet
-  if (entry->has_oop_maps()) {
-    pos = align_up(pos, (uint)sizeof(int));
-    int oopmaps_size = *(int*)(buf + pos);  pos += sizeof(int);
-    pos += oopmaps_size;
-  }
-  pos = align_up(pos, (uint)sizeof(int));
-
-  // Now we can get the information we wanted to log (embedded stubs)
+  // Now we can get the information we want to log (embedded stubs)
   // get the first embedded stub id
   StubId stub_id = *(StubId*)(buf + pos);
   pos += sizeof(StubId);

--- a/src/hotspot/share/cds/aotMapLogger.cpp
+++ b/src/hotspot/share/cds/aotMapLogger.cpp
@@ -138,6 +138,8 @@ void AOTMapLogger::log_embedded_stubs(const AOTCodeCache* cache, const AOTCodeEn
 
   // loop until we run out of stubs (no stubid)
   while (stub_id != StubId::NO_STUBID) {
+    assert(stub_id > StubId::NO_STUBID && stub_id < StubId::NUM_STUBIDS, "Embedded Stub ID is not valid.");
+    assert(StubInfo::blob(stub_id) == entry->id(), "We found an embedded stub that doesn't belong here.");
     uint offset = *(uint*)(buf + pos);
     pos += sizeof(uint);
     uint size = *(uint*)(buf + pos);
@@ -153,6 +155,8 @@ void AOTMapLogger::log_embedded_stubs(const AOTCodeCache* cache, const AOTCodeEn
     pos += sizeof(int);
     //to skip them and prepare for the following stub (if exists)
     pos += n * sizeof(uint);
+    // the entry+extras count for the stub read from the file should exceed the declared entry count
+    assert(n >= StubInfo::entry_count(stub_id) - 1, "We are missing entries on this stub.");
 
     // position ourselves in the potential following stub
     stub_id = *(StubId*)(buf + pos);

--- a/src/hotspot/share/cds/aotMapLogger.cpp
+++ b/src/hotspot/share/cds/aotMapLogger.cpp
@@ -139,7 +139,7 @@ void AOTMapLogger::log_embedded_stubs(const AOTCodeCache* cache, const AOTCodeEn
   // loop until we run out of stubs (no stubid)
   while (stub_id != StubId::NO_STUBID) {
     assert(stub_id > StubId::NO_STUBID && stub_id < StubId::NUM_STUBIDS, "Embedded Stub ID is not valid.");
-    assert(StubInfo::blob(stub_id) == entry->id(), "We found an embedded stub that doesn't belong here.");
+    assert(StubInfo::blob(stub_id) == (BlobId) entry->id(), "We found an embedded stub that doesn't belong here.");
     uint offset = *(uint*)(buf + pos);
     pos += sizeof(uint);
     uint size = *(uint*)(buf + pos);

--- a/src/hotspot/share/cds/aotMapLogger.cpp
+++ b/src/hotspot/share/cds/aotMapLogger.cpp
@@ -145,7 +145,7 @@ void AOTMapLogger::log_ac_region() {
 
       switch (entry->kind()) {
         case  AOTCodeEntry::Kind::Nmethod:
-          log_debug(aot, map)(PTR_FORMAT ": @@ %-17s %d %d %d %s",
+          log_debug(aot, map)(PTR_FORMAT ": @@ %-17s %d level=%d id=%d %s",
             p2i(entry), AOTCodeCache::get_kind_name(entry->kind()),
             entry->size(), entry->comp_level(), entry->comp_id(), name);
           break;
@@ -154,16 +154,16 @@ void AOTMapLogger::log_ac_region() {
             BlobId blob_id = (BlobId) entry->id();
 
             //First we log the stub blob
-            log_debug(aot, map)(PTR_FORMAT ": @@ %-17s %d %d %s",
+            log_debug(aot, map)(PTR_FORMAT ": @@ %-17s %d id=%d %s",
               p2i(entry), AOTCodeCache::get_kind_name(entry->kind()),
               entry->size(), entry->id(), StubInfo::name(blob_id));
 
             //Now we log each stub embedded inside the blob
-            cache->loop_over_embedded_stubs(entry,  log_embedded_stub);
+            cache->iterate_embedded_stubs(entry,  log_embedded_stub);
           }
             break;
           default:
-          log_debug(aot, map)(PTR_FORMAT ": @@ %-17s %d %d %s",
+          log_debug(aot, map)(PTR_FORMAT ": @@ %-17s %d id=%d %s",
             p2i(entry), AOTCodeCache::get_kind_name(entry->kind()),
             entry->size(), entry->id(), name);
           break;

--- a/src/hotspot/share/cds/aotMapLogger.cpp
+++ b/src/hotspot/share/cds/aotMapLogger.cpp
@@ -120,6 +120,65 @@ void AOTMapLogger::dumptime_log(ArchiveBuilder* builder, FileMapInfo* mapinfo,
   log_info(aot, map)("[End of AOT cache map]");
 }
 
+void AOTMapLogger::log_embedded_stubs(const AOTCodeCache* cache, const AOTCodeEntry* entry) {
+
+  //start at the beginning of our AOT cache
+  const char* buf  = cache->store_buffer();
+
+  //pos now points at the beginning of the StubGenBlob
+  uint pos = entry->offset() + entry->code_offset();
+
+  // The first part is the CodeBlob which we are not going to log
+  const CodeBlob* blob = (const CodeBlob*)(buf + pos);
+  pos += blob->size();
+
+  // Then we have the relocation data records (aligned to HeapWordSize)
+  // we are not interested in logging this either
+  int reloc_count = *(int*)(buf + pos);
+  pos += sizeof(int);
+  pos = align_up(pos, (uint)HeapWordSize);
+  pos += reloc_count * (uint)sizeof(relocInfo);
+
+  // Then we have an optional OopMapSet
+  if (entry->has_oop_maps()) {
+    pos = align_up(pos, (uint)sizeof(int));
+    int oopmaps_size = *(int*)(buf + pos);  pos += sizeof(int);
+    pos += oopmaps_size;
+  }
+  pos = align_up(pos, (uint)sizeof(int));
+
+  // Now we can get the information we wanted to log (embedded stubs)
+  // get the first embedded stub id
+  StubId stub_id = *(StubId*)(buf + pos);
+  pos += sizeof(StubId);
+
+  // Embedded StubGenBlobs are assumed to have the following structure
+  // [ StubId | offset | size | N | offset_1 | offset_2 | ... | offset_N ]
+
+  // loop until we run out of stubs (no stubid)
+  while (stub_id != StubId::NO_STUBID) {
+    uint offset = *(uint*)(buf + pos);
+    pos += sizeof(uint);
+    uint size = *(uint*)(buf + pos);
+    pos += sizeof(uint);
+
+    // Log the embedded stub
+    log_debug(aot, map)(PTR_FORMAT ": @@ %-17s %d %d %d %s",
+      p2i(buf + entry->offset() + entry->code_offset() + offset),
+      "EmbeddedStub", size, entry->id(), (int) stub_id, StubInfo::name(stub_id));
+
+    //Get the number of secondary/extra entry offsets
+    int n = *(int*) (buf + pos);
+    pos += sizeof(int);
+    //to skip them and prepare for the following stub (if exists)
+    pos += n * sizeof(uint);
+
+    // position ourselves in the potential following stub
+    stub_id = *(StubId*)(buf + pos);
+    pos += sizeof(StubId);
+  }
+}
+
 void AOTMapLogger::log_ac_region() {
   ResourceMark rm;
 
@@ -143,7 +202,20 @@ void AOTMapLogger::log_ac_region() {
             p2i(entry), AOTCodeCache::get_kind_name(entry->kind()),
             entry->size(), entry->comp_level(), entry->comp_id(), name);
           break;
-        default:
+        case  AOTCodeEntry::Kind::StubGenBlob:
+          {
+            BlobId blob_id = (BlobId) entry->id();
+
+            //First we log the stub blob
+            log_debug(aot, map)(PTR_FORMAT ": @@ %-17s %d %d %s",
+              p2i(entry), AOTCodeCache::get_kind_name(entry->kind()),
+              entry->size(), entry->id(), StubInfo::name(blob_id));
+
+            //Now we log each stub embedded inside the blob
+            log_embedded_stubs(cache, entry);
+          }
+            break;
+          default:
           log_debug(aot, map)(PTR_FORMAT ": @@ %-17s %d %d %s",
             p2i(entry), AOTCodeCache::get_kind_name(entry->kind()),
             entry->size(), entry->id(), name);

--- a/src/hotspot/share/cds/aotMapLogger.cpp
+++ b/src/hotspot/share/cds/aotMapLogger.cpp
@@ -120,48 +120,10 @@ void AOTMapLogger::dumptime_log(ArchiveBuilder* builder, FileMapInfo* mapinfo,
   log_info(aot, map)("[End of AOT cache map]");
 }
 
-void AOTMapLogger::log_embedded_stubs(const AOTCodeCache* cache, const AOTCodeEntry* entry) {
 
-  //start at the beginning of our AOT cache
-  const char* buf = cache->store_buffer();
-
-  // jump to the embedded stubs section
-  uint pos = entry->offset() + entry->embedded_stub_offset();
-
-  // Now we can get the information we want to log (embedded stubs)
-  // get the first embedded stub id
-  StubId stub_id = *(StubId*)(buf + pos);
-  pos += sizeof(StubId);
-
-  // Embedded StubGenBlobs are assumed to have the following structure
-  // [ StubId | offset | size | N | offset_1 | offset_2 | ... | offset_N ]
-
-  // loop until we run out of stubs (no stubid)
-  while (stub_id != StubId::NO_STUBID) {
-    assert(stub_id > StubId::NO_STUBID && stub_id < StubId::NUM_STUBIDS, "Embedded Stub ID is not valid.");
-    assert(StubInfo::blob(stub_id) == (BlobId) entry->id(), "We found an embedded stub that doesn't belong here.");
-    uint offset = *(uint*)(buf + pos);
-    pos += sizeof(uint);
-    uint size = *(uint*)(buf + pos);
-    pos += sizeof(uint);
-
-    // Log the embedded stub
-    log_debug(aot, map)(PTR_FORMAT ": @@ %-17s %d id=%d blob=%d %s",
-      p2i(buf + entry->offset() + entry->code_offset() + offset),
-      "EmbeddedStub", size, (int) stub_id, entry->id(), StubInfo::name(stub_id));
-
-    //Get the number of secondary/extra entry offsets
-    int n = *(int*) (buf + pos);
-    pos += sizeof(int);
-    //to skip them and prepare for the following stub (if exists)
-    pos += n * sizeof(uint);
-    // the entry+extras count for the stub read from the file should exceed the declared entry count
-    assert(n >= StubInfo::entry_count(stub_id) - 1, "We are missing entries on this stub.");
-
-    // position ourselves in the potential following stub
-    stub_id = *(StubId*)(buf + pos);
-    pos += sizeof(StubId);
-  }
+static void log_embedded_stub(const intptr_t pointer, const uint size, const uint stub_id, const char* stub_name, const uint entry_id) {
+  log_debug(aot, map)(PTR_FORMAT ": @@ %-17s %d id=%d blob=%d %s",
+    pointer, "EmbeddedStub", size, stub_id, entry_id, stub_name);
 }
 
 void AOTMapLogger::log_ac_region() {
@@ -197,7 +159,7 @@ void AOTMapLogger::log_ac_region() {
               entry->size(), entry->id(), StubInfo::name(blob_id));
 
             //Now we log each stub embedded inside the blob
-            log_embedded_stubs(cache, entry);
+            cache->loop_over_embedded_stubs(entry,  log_embedded_stub);
           }
             break;
           default:

--- a/src/hotspot/share/cds/aotMapLogger.hpp
+++ b/src/hotspot/share/cds/aotMapLogger.hpp
@@ -33,6 +33,8 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
 
+class AOTCodeCache;
+class AOTCodeEntry;
 class AOTMappedHeapInfo;
 class AOTStreamedHeapInfo;
 class CompileTrainingData;
@@ -160,6 +162,7 @@ private:
   static void log_method_training_data(MethodTrainingData* mtd, address requested_addr, const char* type_name, int bytes, Thread* current);
   static void log_compile_training_data(CompileTrainingData* ctd, address requested_addr, const char* type_name, int bytes, Thread* current);
   static void log_ac_region();
+  static void log_embedded_stubs(const AOTCodeCache* cache, const AOTCodeEntry* entry);
 
 #if INCLUDE_CDS_JAVA_HEAP
   static void dumptime_log_mapped_heap_region(AOTMappedHeapInfo* mapped_heap_info);

--- a/src/hotspot/share/cds/aotMapLogger.hpp
+++ b/src/hotspot/share/cds/aotMapLogger.hpp
@@ -162,7 +162,6 @@ private:
   static void log_method_training_data(MethodTrainingData* mtd, address requested_addr, const char* type_name, int bytes, Thread* current);
   static void log_compile_training_data(CompileTrainingData* ctd, address requested_addr, const char* type_name, int bytes, Thread* current);
   static void log_ac_region();
-  static void log_embedded_stubs(const AOTCodeCache* cache, const AOTCodeEntry* entry);
 
 #if INCLUDE_CDS_JAVA_HEAP
   static void dumptime_log_mapped_heap_region(AOTMappedHeapInfo* mapped_heap_info);

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -1523,8 +1523,9 @@ bool AOTCodeCache::store_code_blob(CodeBlob& blob, AOTCodeEntry::Kind entry_kind
   // In the case of a multi-stub blob we need to write start, end,
   // secondary entries and extras. For any other blob entry addresses
   // beyond the blob start will be stored in the blob as offsets.
+  uint embedded_stub_offset = 0;
   if (stub_data != nullptr) {
-    if (!cache->write_stub_data(blob, stub_data)) {
+    if (!cache->write_stub_data(blob, stub_data, &embedded_stub_offset)) {
       return false;
     }
   }
@@ -1575,6 +1576,9 @@ bool AOTCodeCache::store_code_blob(CodeBlob& blob, AOTCodeEntry::Kind entry_kind
   AOTCodeEntry* entry = new(cache) AOTCodeEntry(entry_kind, encode_id(entry_kind, id),
                                                 entry_position, entry_size, name_offset, name_size,
                                                 blob_offset, has_oop_maps);
+  if (embedded_stub_offset != 0) {
+    entry->set_embedded_stub_offset(embedded_stub_offset - entry_position);
+  }
   log_debug(aot, codecache, stubs)("Wrote code blob '%s' (id=%u, kind=%s) to AOT Code Cache", name, id, aot_code_entry_kind_name[entry_kind]);
   return true;
 }
@@ -1597,9 +1601,12 @@ bool AOTCodeCache::store_code_blob(CodeBlob& blob, AOTCodeEntry::Kind entry_kind
   return store_code_blob(blob, entry_kind, (uint)id, StubInfo::name(id), stub_data, code_buffer);
 }
 
-bool AOTCodeCache::write_stub_data(CodeBlob &blob, AOTStubData *stub_data) {
+bool AOTCodeCache::write_stub_data(CodeBlob &blob, AOTStubData *stub_data, uint* stubs_offset) {
   if (!align_write_int()) {
     return false;
+  }
+  if (stubs_offset != nullptr) {
+    *stubs_offset = _write_position;
   }
   BlobId blob_id = stub_data->blob_id();
   StubId stub_id = StubInfo::stub_base(blob_id);

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -432,6 +432,48 @@ void AOTCodeCache::dump() {
   }
 }
 
+//This is a helper function that executes a function over each embedded stub available
+void AOTCodeCache::loop_over_embedded_stubs(const AOTCodeEntry* entry, const embedded_stub_func func) {
+  assert(entry->kind() == StubGen, "invalid call");
+  // jump to the embedded stubs section
+  uint pos = entry->offset() + entry->embedded_stub_offset();
+
+  // Now we can get the information we want to log (embedded stubs)
+  // get the first embedded stub id
+  StubId stub_id = *(StubId*)(_store_buffer + pos);
+  pos += sizeof(StubId);
+
+  // Embedded StubGenBlobs are assumed to have the following structure
+  // [ StubId | offset | size | N | offset_1 | offset_2 | ... | offset_N ]
+
+  // loop until we run out of stubs (no stubid)
+  while (stub_id != StubId::NO_STUBID) {
+    assert(stub_id > StubId::NO_STUBID && stub_id < StubId::NUM_STUBIDS, "Embedded Stub ID is not valid.");
+    assert(StubInfo::blob(stub_id) == (BlobId) entry->id(), "We found an embedded stub that doesn't belong here.");
+    uint offset = *(uint*)(_store_buffer + pos);
+    pos += sizeof(uint);
+    uint size = *(uint*)(_store_buffer + pos);
+    pos += sizeof(uint);
+
+    //Call the function on the embedded stub
+    (*func)(p2i(_store_buffer + entry->offset() + entry->code_offset() + offset),
+      size, (uint) stub_id, StubInfo::name(stub_id), (uint) entry->id());
+
+    //Get the number of secondary/extra entry offsets
+    int n = *(int*) (_store_buffer + pos);
+    pos += sizeof(int);
+    //to skip them and prepare for the following stub (if exists)
+    pos += n * sizeof(uint);
+    // the entry+extras count for the stub read from the file should exceed the declared entry count
+    assert(n >= StubInfo::entry_count(stub_id) - 1, "We are missing entries on this stub.");
+
+    // position ourselves in the potential following stub
+    stub_id = *(StubId*)(_store_buffer + pos);
+    pos += sizeof(StubId);
+  }
+}
+
+
 class CachedCodeDirectory {
 public:
   uint _aot_code_size;

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -433,7 +433,7 @@ void AOTCodeCache::dump() {
 }
 
 //This is a helper function that executes a function over each embedded stub available
-void AOTCodeCache::loop_over_embedded_stubs(const AOTCodeEntry* entry, const embedded_stub_func func) {
+void AOTCodeCache::iterate_embedded_stubs(const AOTCodeEntry* entry, const embedded_stub_func func) {
   assert(entry->kind() == AOTCodeEntry::Kind::StubGenBlob, "invalid call");
   // jump to the embedded stubs section
   uint pos = entry->offset() + entry->embedded_stub_offset();

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -434,7 +434,7 @@ void AOTCodeCache::dump() {
 
 //This is a helper function that executes a function over each embedded stub available
 void AOTCodeCache::loop_over_embedded_stubs(const AOTCodeEntry* entry, const embedded_stub_func func) {
-  assert(entry->kind() == StubGen, "invalid call");
+  assert(entry->kind() == AOTCodeEntry::Kind::StubGenBlob, "invalid call");
   // jump to the embedded stubs section
   uint pos = entry->offset() + entry->embedded_stub_offset();
 

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -143,7 +143,7 @@ public:
     if (_kind == StubGenBlob) {
       _embedded_stub_offset = 0;
     } else {
-      _comp_level   = comp_level;
+      _comp_level = comp_level;
     }
 
     _comp_id      = comp_id;
@@ -168,8 +168,14 @@ public:
   uint name_size()    const { return _name_size; }
   uint code_offset()  const { return _code_offset; }
 
-  void set_embedded_stub_offset(const uint off) { _embedded_stub_offset = off; }
-  uint embedded_stub_offset()  const { return _embedded_stub_offset; }
+  void set_embedded_stub_offset(const uint off) {
+    precond(_kind == StubGenBlob);
+    _embedded_stub_offset = off;
+  }
+  uint embedded_stub_offset()  const {
+    precond(_kind == StubGenBlob);
+    return _embedded_stub_offset;
+  }
 
   bool has_oop_maps() const { return _has_oop_maps; }
   uint num_inlined_bytecodes() const { return _num_inlined_bytecodes; }
@@ -178,7 +184,10 @@ public:
   uint inline_instructions_size() const { return _inline_instructions_size; }
   void set_inline_instructions_size(int size) { _inline_instructions_size = size; }
 
-  uint comp_level()   const { return _comp_level; }
+  uint comp_level()   const {
+    precond(_kind != StubGenBlob);
+    return _comp_level;
+  }
   uint comp_id()      const { return _comp_id; }
 
   bool has_clinit_barriers() const { return _has_clinit_barriers; }
@@ -798,7 +807,7 @@ public:
   static void print_timers_on(outputStream* st) NOT_CDS_RETURN;
 
   typedef void (*embedded_stub_func)(intptr_t pointer, uint size, uint stub_id, const char* stub_name, uint entry_id) ;
-  void loop_over_embedded_stubs(const AOTCodeEntry *entry, embedded_stub_func func);
+  void iterate_embedded_stubs(const AOTCodeEntry *entry, embedded_stub_func func);
 };
 
 // Concurent AOT code reader

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -107,9 +107,11 @@ private:
   uint   _name_offset; // Method's or intrinsic name
   uint   _name_size;
   uint   _code_offset; // Start of code in cache
-  uint   _embedded_stub_offset; // Start of embedded stubs in StubGenBlobs
 
-  uint   _comp_level;  // compilation level
+  union {
+    uint   _embedded_stub_offset; // Start of embedded stubs in StubGenBlobs
+    uint   _comp_level;           // compilation level (not needed in StubGenBlobs)
+  };
   uint   _comp_id;     // compilation id
   uint   _num_inlined_bytecodes;
   uint   _inline_instructions_size; // size from training run
@@ -137,9 +139,13 @@ public:
     _name_offset  = name_offset;
     _name_size    = name_size;
     _code_offset  = code_offset;
-    _embedded_stub_offset = 0;
 
-    _comp_level   = comp_level;
+    if (_kind == StubGenBlob) {
+      _embedded_stub_offset = 0;
+    } else {
+      _comp_level   = comp_level;
+    }
+
     _comp_id      = comp_id;
     _num_inlined_bytecodes = 0;
     _inline_instructions_size = 0;

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -603,7 +603,7 @@ public:
   AOTCodeCache(bool is_dumping, bool is_using);
 
   const char* cache_buffer() const { return _load_buffer; }
-  const char* store_buffer()      const { return _store_buffer; }
+  const char* store_buffer() const { return _store_buffer; }
   bool failed() const { return _failed; }
   void set_failed()   { _failed = true; }
 

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -603,6 +603,7 @@ public:
   AOTCodeCache(bool is_dumping, bool is_using);
 
   const char* cache_buffer() const { return _load_buffer; }
+  const char* store_buffer()      const { return _store_buffer; }
   bool failed() const { return _failed; }
   void set_failed()   { _failed = true; }
 

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -107,6 +107,7 @@ private:
   uint   _name_offset; // Method's or intrinsic name
   uint   _name_size;
   uint   _code_offset; // Start of code in cache
+  uint   _embedded_stub_offset; // Start of embedded stubs in StubGenBlobs
 
   uint   _comp_level;  // compilation level
   uint   _comp_id;     // compilation id
@@ -136,6 +137,7 @@ public:
     _name_offset  = name_offset;
     _name_size    = name_size;
     _code_offset  = code_offset;
+    _embedded_stub_offset = 0;
 
     _comp_level   = comp_level;
     _comp_id      = comp_id;
@@ -159,6 +161,9 @@ public:
   uint name_offset()  const { return _name_offset; }
   uint name_size()    const { return _name_size; }
   uint code_offset()  const { return _code_offset; }
+
+  void set_embedded_stub_offset(const uint off) { _embedded_stub_offset = off; }
+  uint embedded_stub_offset()  const { return _embedded_stub_offset; }
 
   bool has_oop_maps() const { return _has_oop_maps; }
   uint num_inlined_bytecodes() const { return _num_inlined_bytecodes; }
@@ -663,7 +668,7 @@ public:
   bool write_metadata(Metadata* m);
   bool write_oops(nmethod* nm);
   bool write_metadata(nmethod* nm);
-  bool write_stub_data(CodeBlob& blob, AOTStubData *stub_data);
+  bool write_stub_data(CodeBlob& blob, AOTStubData *stub_data, uint* stubs_offset = nullptr);
 
 #ifndef PRODUCT
   bool write_asm_remarks(AsmRemarks& asm_remarks, bool use_string_table);

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -790,6 +790,9 @@ public:
   static void print_on(outputStream* st) NOT_CDS_RETURN;
   static void print_statistics_on(outputStream* st) NOT_CDS_RETURN;
   static void print_timers_on(outputStream* st) NOT_CDS_RETURN;
+
+  typedef void (*embedded_stub_func)(intptr_t pointer, uint size, uint stub_id, const char* stub_name, uint entry_id) ;
+  void loop_over_embedded_stubs(const AOTCodeEntry *entry, embedded_stub_func func);
 };
 
 // Concurent AOT code reader


### PR DESCRIPTION
Continuation of https://github.com/openjdk/leyden/pull/115

Right now, we log StubGenBlobs in premain2: https://github.com/openjdk/leyden/pull/115

Current output example:
```
0x00007f1b37ffefe4: @@ StubGenBlob 24452 73 initial_blob (stub gen)
```

But we are skipping logging of the embedded stubs inside those blobs. This PR improves the logging to add the embedded stubs too.

The log line for `EmbeddedStub` contains the following data:
 - Pointer
 - Size of the Embedded Stub
 - Id of the StubGenBlob (BlobId) to link back to which StubGenBlob it belongs (although it should be ordered)
 - Id of the Embedded Stub
 - Name of the Embedded stub
 
Example of output:
```
0x00007fd2fbffefe4: @@ StubGenBlob       24452 73 initial_blob (stub gen)
0x00007fd2dbfff05b: @@ EmbeddedStub      276 73 77 call_stub_stub (stub gen)
0x00007fd2dbfff010: @@ EmbeddedStub      75 73 78 forward_exception_stub (stub gen)
0x00007fd2dbfff16f: @@ EmbeddedStub      31 73 79 catch_exception_stub (stub gen)
0x00007fd2dbfff350: @@ EmbeddedStub      612 73 80 updateBytesCRC32_stub (stub gen)
0x00007fd2dbfff5d0: @@ EmbeddedStub      612 73 81 updateBytesCRC32C_stub (stub gen)
0x00007fd2dbfff83e: @@ EmbeddedStub      14 73 82 f2hf_stub (stub gen)
0x00007fd2dbfff834: @@ EmbeddedStub      10 73 83 hf2f_stub (stub gen)
0x00007fd2dc00196f: @@ EmbeddedStub      909 73 84 dexp_stub (stub gen)
0x00007fd2dc002ed7: @@ EmbeddedStub      660 73 85 dlog_stub (stub gen)
0x00007fd2dc00316b: @@ EmbeddedStub      744 73 86 dlog10_stub (stub gen)
0x00007fd2dc001cfc: @@ EmbeddedStub      4571 73 87 dpow_stub (stub gen)
0x00007fd2dbfff84c: @@ EmbeddedStub      1861 73 88 dsin_stub (stub gen)
0x00007fd2dbffff91: @@ EmbeddedStub      1793 73 89 dcos_stub (stub gen)
0x00007fd2dc000692: @@ EmbeddedStub      2312 73 90 dtan_stub (stub gen)
0x00007fd2dc000f9a: @@ EmbeddedStub      1029 73 91 dsinh_stub (stub gen)
0x00007fd2dc00139f: @@ EmbeddedStub      859 73 92 dtanh_stub (stub gen)
0x00007fd2dc0016fa: @@ EmbeddedStub      629 73 93 dcbrt_stub (stub gen)
0x00007fd2dc003470: @@ EmbeddedStub      489 73 94 fmod_stub (stub gen)
0x00007fd2dbfff18e: @@ EmbeddedStub      1 73 95 verify_mxcsr_stub (stub gen)
0x00007fd2dbfff18f: @@ EmbeddedStub      56 73 96 f2i_fixup_stub (stub gen)
0x00007fd2dbfff1c7: @@ EmbeddedStub      67 73 97 f2l_fixup_stub (stub gen)
0x00007fd2dbfff20a: @@ EmbeddedStub      80 73 98 d2i_fixup_stub (stub gen)
0x00007fd2dbfff25a: @@ EmbeddedStub      90 73 99 d2l_fixup_stub (stub gen)
0x00007fd2dbfff2d0: @@ EmbeddedStub      16 73 100 float_sign_mask_stub (stub gen)
0x00007fd2dbfff2f0: @@ EmbeddedStub      16 73 101 float_sign_flip_stub (stub gen)
0x00007fd2dbfff310: @@ EmbeddedStub      16 73 102 double_sign_mask_stub (stub gen)
0x00007fd2dbfff330: @@ EmbeddedStub      16 73 103 double_sign_flip_stub (stub gen)
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388410](https://bugs.openjdk.org/browse/JDK-8388410): [Leyden] Improve map file logging to add Embedded Stubs from StubGenBlobs (**Sub-task** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/118/head:pull/118` \
`$ git checkout pull/118`

Update a local copy of the PR: \
`$ git checkout pull/118` \
`$ git pull https://git.openjdk.org/leyden.git pull/118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 118`

View PR using the GUI difftool: \
`$ git pr show -t 118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/118.diff">https://git.openjdk.org/leyden/pull/118.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/118#issuecomment-4995658087)
</details>
