### PR TITLE
8388411: [leyden] Increase memory limit for C2 AOT compilations

### DIFF
--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include "cds/cdsConfig.hpp"
 #include "ci/ciMethod.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "compiler/abstractCompiler.hpp"
@@ -214,7 +215,14 @@ bool DirectiveSet::should_print_memstat() const {
 }
 
 size_t DirectiveSet::mem_limit() const {
-  return MemLimitOption < 0 ? -MemLimitOption : MemLimitOption;
+  size_t limit = MemLimitOption < 0 ? -MemLimitOption : MemLimitOption;
+#if INCLUDE_CDS
+  if (CDSConfig::is_dumping_aot_code()) {
+    // Double limit for AOT compilation because it generates more code.
+    limit = limit * 2;
+  }
+#endif
+  return limit;
 }
 
 bool DirectiveSet::should_crash_at_mem_limit() const {


### PR DESCRIPTION
Double memory limit used by C2 during AOT compilations.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388411](https://bugs.openjdk.org/browse/JDK-8388411): [leyden] Increase memory limit for C2 AOT compilations (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/122/head:pull/122` \
`$ git checkout pull/122`

Update a local copy of the PR: \
`$ git checkout pull/122` \
`$ git pull https://git.openjdk.org/leyden.git pull/122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 122`

View PR using the GUI difftool: \
`$ git pr show -t 122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/122.diff">https://git.openjdk.org/leyden/pull/122.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/122#issuecomment-5038057682)
</details>
