### PR TITLE
8390095: [Leyden] reset CompileThresholdScaling flag to default 1.0 value during AOT assembly phase

### DIFF
--- a/src/hotspot/share/cds/aotMetaspace.cpp
+++ b/src/hotspot/share/cds/aotMetaspace.cpp
@@ -1233,7 +1233,7 @@ void AOTMetaspace::dump_static_archive_impl(StaticArchiveBuilder& builder, TRAPS
     if (AOTCodeCache::is_dumping_code()) {
       // Let's run the AOT compiler.
       CDSConfig::enable_dumping_aot_code();
-      log_info(aot)("Compiling AOT code");
+      log_info(aot)("Compiling AOT code with %d compiler threads", (int)CICompilerCount);
       AOTCompileBroker::compile_aot_code(&builder, CHECK);
       log_info(aot)("Finished compiling AOT code");
       CDSConfig::disable_dumping_aot_code();

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -687,6 +687,11 @@ bool CDSConfig::check_vm_args_consistency(bool patch_mod_javabase, bool mode_fla
         // with AOT and -Xcomp.
         Arguments::set_mode_flags(Arguments::_mixed);
       }
+      if (CompileThresholdScaling < 1.0) {
+        // Set flag to default value to avoid excessive normal JIT
+        // compilations during assembly phase.
+        FLAG_SET_ERGO(CompileThresholdScaling, 1.0);
+      }
     } else if (!mode_flag_cmd_line) {
       // By default, -Xshare:dump runs in interpreter-only mode, which is required for deterministic archive.
       //

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1300,7 +1300,7 @@ void ciEnv::register_method(ciMethod* target,
             nm->set_preloaded(true);
           }
         }
-      } else // No need to make AOT code usable during assembly phase
+      }
 #endif
       make_code_usable(THREAD, target, /* preload */ false, entry_bci, /* aot_code_entry */ nullptr, nm);
     }

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1046,7 +1046,7 @@ void ciEnv::make_code_usable(JavaThread* thread, ciMethod* target, bool preload,
   methodHandle method(thread, target->get_Method());
 
   if (entry_bci == InvocationEntryBci) {
-    if (TieredCompilation) {
+    if (TieredCompilation || is_aot_compile()) {
       // If there is an old version we're done with it
       nmethod* old = method->code();
       if (TraceMethodReplacement && old != nullptr) {

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1144,8 +1144,11 @@ void CompileBroker::compile_method_base(const methodHandle& method,
   if (CIPrintRequests) {
     ResourceMark rm;
     stringStream ss;
-    const char* aotn = (compile_reason == CompileTask::Reason_AOTPreload) ? "AP" :
-                       (aot_code_entry != nullptr ? " A" : "  ");
+    bool comp_aot_preload = (compile_reason == CompileTask::Reason_AOTPreload) ||
+                            (compile_reason == CompileTask::Reason_AOTCompileForPreload);
+    bool comp_aot = (compile_reason == CompileTask::Reason_AOTCompile) ||
+                    (aot_code_entry != nullptr);
+    const char* aotn = comp_aot_preload ? "AP" : (comp_aot ? " A" : "  ");
     ss.print("request %16s: %s%d", CompileTask::reason_name(compile_reason), aotn, comp_level);
     if (osr_bci != InvocationEntryBci) {
       ss.print(" osr_bci: %d", osr_bci);
@@ -1155,13 +1158,16 @@ void CompileBroker::compile_method_base(const methodHandle& method,
     tty->print_cr("%s", ss.freeze());
   }
   LogStreamHandle(Debug, aot, codecache, compilation) log;
-  if (log.is_enabled() && AOTCodeCache::is_using_code()) {
+  if (log.is_enabled() && (AOTCodeCache::is_using_code() || AOTCodeCache::is_dumping_code())) {
     ResourceMark rm;
     MethodTrainingData* mtd = MethodTrainingData::have_data() ? MethodTrainingData::find_fast(method) : nullptr;
     MethodCounters* mc = method->method_counters();
     const char* name = method->name_and_sig_as_C_string(true /* use_double_colon */);
-    const char* aotn = (compile_reason == CompileTask::Reason_AOTPreload) ? "AP" :
-                       (aot_code_entry != nullptr ? " A" : "  ");
+    bool comp_aot_preload = (compile_reason == CompileTask::Reason_AOTPreload) ||
+                            (compile_reason == CompileTask::Reason_AOTCompileForPreload);
+    bool comp_aot = (compile_reason == CompileTask::Reason_AOTCompile) ||
+                    (aot_code_entry != nullptr);
+    const char* aotn = comp_aot_preload ? "AP" : (comp_aot ? " A" : "  ");
     const char* osrn = (osr_bci != InvocationEntryBci) ? "% " : "";
     log.print("request %16s: %s%d %s%s", CompileTask::reason_name(compile_reason), aotn, comp_level, osrn, name);
     if (mtd != nullptr) {


### PR DESCRIPTION
Set `CompileThresholdScaling` flag to default `1.0` value during AOT assembly phase to avoid excessive normal JIT compilation which intervene with AOT compilation and slow it down.  We do similar thing for `-Xcomp` by replacing it with `-Xmixed` during assembly phase.

Our testing showed that several AOT tests timed out when run with `-XX:-TieredCompilation -XX:CompileThresholdScaling=0.01` flags. The output showed that they stack in assembly phase doing AOT compilation which was slow. `CITime` times show that.

Training run (224.685 s in C2):
```
C2 {speed: 11688.665 bytes/s; standard: 224.685 s, 2572919 bytes, 8780 methods; osr: 9.755 s, 167368 bytes, 143 methods; nmethods_size: 27880176 bytes; nmethods_code_size: 13817408 bytes}
```
Current assembly phase (914.266 s in C2 JIT + AOT compilation):
(Note, only half of AOT compilation was done because compilation was disable when CodeCache 48Mb become full)
```
C2 {speed: 3894.559 bytes/s; standard: 1914.266 s, 7481628 bytes, 10783 methods; osr: 8.758 s, 7702 bytes, 12 methods; nmethods_size: 76087256 bytes; nmethods_code_size: 44661208 bytes}
```
Assembly phase with fix (214.494 s in C2 JIT + AOT compilation, CodeCache was only half full):
```
C2 {speed: 10700.744 bytes/s; standard: 214.494 s, 2293321 bytes, 21248 methods; osr:  0.254 s, 4651 bytes, 12 methods; nmethods_size: 38913344 bytes; nmethods_code_size: 22307664 bytes}
```

You may notice that number of compiled AOT methods more than 2x of compiled during training. 2x is expected: Preload AOT + normal AOT.  But it shows that we compile around 2K more of each. I filed [JDK-8390111](https://bugs.openjdk.org/browse/JDK-8390111) to investigate that.

Additional changes.
 - Print `CICompilerCount` in AOT log message when starting AOT compilation.
 - Call `make_code_usable()` for AOT compiled nmethod after they are copied to AOT cache. This will mark them "in_use" and allow GC collect them to free CodeCache.
 - Mark correctly AOT compilation in assembly phase in `CIPrintRequests` output.

Tested: tier1-3

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390095](https://bugs.openjdk.org/browse/JDK-8390095): [Leyden] reset CompileThresholdScaling flag to default 1.0 value during AOT assembly phase (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/126/head:pull/126` \
`$ git checkout pull/126`

Update a local copy of the PR: \
`$ git checkout pull/126` \
`$ git pull https://git.openjdk.org/leyden.git pull/126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 126`

View PR using the GUI difftool: \
`$ git pr show -t 126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/126.diff">https://git.openjdk.org/leyden/pull/126.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/126#issuecomment-5271639508)
</details>
