### PR TITLE
8390443: [leyden] AOTCodeEntry::_not_entrant should be synchronized

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -603,19 +603,8 @@ AOTCodeCache::AOTCodeCache(bool is_dumping, bool is_using) :
 
 void AOTCodeCache::invalidate(AOTCodeEntry* entry) {
   // Invalidate AOT code during production run.
-  // This should be called only from nmethod::make_not_entrant().
-  assert_lock_strong(NMethodState_lock);
+  // This could be concurrent execution.
   if (entry != nullptr && is_on_for_use()) {
-    _cache->invalidate_entry(entry);
-  }
-}
-
-void AOTCodeCache::invalidate_with_lock(AOTCodeEntry* entry) {
-  // Invalidate AOT code during production run.
-  // This could be concurrently executed - use lock.
-  if (entry != nullptr && is_on_for_use()) {
-    ConditionalMutexLocker ml(NMethodState_lock, !NMethodState_lock->owned_by_self(),
-                              Mutex::_no_safepoint_check_flag);
     _cache->invalidate_entry(entry);
   }
 }
@@ -1098,6 +1087,19 @@ void* AOTCodeEntry::operator new(size_t x, AOTCodeCache* cache) {
   return (void*)(cache->add_entry());
 }
 
+bool AOTCodeEntry::not_entrant() const {
+  return AtomicAccess::load(&_not_entrant);
+}
+
+void AOTCodeEntry::set_not_entrant() {
+  return AtomicAccess::store(&_not_entrant, true);
+}
+
+bool AOTCodeEntry::try_set_not_entrant() {
+  // If old value is 'true' - other thread set it already.
+  return AtomicAccess::xchg(&_not_entrant, true);
+}
+
 static bool check_entry(AOTCodeEntry::Kind kind, uint id, uint comp_level, AOTCodeEntry* entry) {
   if (entry->kind() == kind) {
     assert(entry->id() == id, "sanity");
@@ -1169,7 +1171,7 @@ AOTCodeEntry* AOTCodeCache::find_entry(AOTCodeEntry::Kind kind, uint id, uint co
 
 void AOTCodeCache::invalidate_entry(AOTCodeEntry* entry) {
   assert(entry!= nullptr, "all entries should be read already");
-  if (entry->not_entrant()) {
+  if (entry->try_set_not_entrant()) {
     return; // Someone invalidated it already
   }
 #ifdef ASSERT
@@ -1197,7 +1199,6 @@ void AOTCodeCache::invalidate_entry(AOTCodeEntry* entry) {
   found = (i < count);
   assert(found, "entry should exist");
 #endif
-  entry->set_not_entrant();
   uint name_offset = entry->offset() + entry->name_offset();
   const char* name = _load_buffer + name_offset;;
   uint level       = entry->comp_level();
@@ -1340,21 +1341,12 @@ bool AOTCodeCache::finish_write() {
     AOTCodeEntry* preload_entries = (AOTCodeEntry*)current;
     for (int i = code_count - 1; i >= 0; i--) {
       AOTCodeEntry* entry = &entries_address[i];
-      if (entry->load_fail()) {
-        continue;
-      }
       if (entry->for_preload()) {
-        if (entry->not_entrant()) {
-          // Skip not entrant preload code:
-          // we can't pre-load code which may have failing dependencies.
-          log_info(aot, codecache, exit)("Skip not entrant preload code comp_id: %d, comp_level: %d, hash: " UINT32_FORMAT_X_0 "%s",
-                                         entry->comp_id(), entry->comp_level(), entry->id(), (entry->has_clinit_barriers() ? ", has clinit barriers" : ""));
-        } else {
-          copy_bytes((const char*)entry, (address)current, sizeof(AOTCodeEntry));
-          stats.collect_entry_stats(entry);
-          current += sizeof(AOTCodeEntry);
-          preload_entries_cnt++;
-        }
+        assert(!entry->not_entrant(), "AOT code should not be not_entrant during assembly phase");
+        copy_bytes((const char*)entry, (address)current, sizeof(AOTCodeEntry));
+        stats.collect_entry_stats(entry);
+        current += sizeof(AOTCodeEntry);
+        preload_entries_cnt++;
       }
     }
 
@@ -1377,14 +1369,10 @@ bool AOTCodeCache::finish_write() {
     AOTCodeEntry* code_entries = (AOTCodeEntry*)current;
     for (int i = code_count - 1; i >= 0; i--) {
       AOTCodeEntry* entry = &entries_address[i];
-      if (entry->load_fail() || entry->for_preload()) {
+      if (entry->for_preload()) {
         continue;
       }
-      if (entry->not_entrant()) {
-        log_info(aot, codecache, exit)("Not entrant new entry comp_id: %d, comp_level: %d, hash: " UINT32_FORMAT_X_0 "%s",
-                                       entry->comp_id(), entry->comp_level(), entry->id(), (entry->has_clinit_barriers() ? ", has clinit barriers" : ""));
-        entry->set_entrant(); // Reset
-      }
+      assert(!entry->not_entrant(), "AOT code should not be not_entrant during assembly phase");
       copy_bytes((const char*)entry, (address)current, sizeof(AOTCodeEntry));
       stats.collect_entry_stats(entry);
       current += sizeof(AOTCodeEntry);

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -603,8 +603,19 @@ AOTCodeCache::AOTCodeCache(bool is_dumping, bool is_using) :
 
 void AOTCodeCache::invalidate(AOTCodeEntry* entry) {
   // Invalidate AOT code during production run.
-  // This could be concurrent execution.
+  // This should be called only from nmethod::make_not_entrant().
+  assert_lock_strong(NMethodState_lock);
   if (entry != nullptr && is_on_for_use()) {
+    _cache->invalidate_entry(entry);
+  }
+}
+
+void AOTCodeCache::invalidate_with_lock(AOTCodeEntry* entry) {
+  // Invalidate AOT code during production run.
+  // This could be concurrently executed - use lock.
+  if (entry != nullptr && is_on_for_use()) {
+    ConditionalMutexLocker ml(NMethodState_lock, !NMethodState_lock->owned_by_self(),
+                              Mutex::_no_safepoint_check_flag);
     _cache->invalidate_entry(entry);
   }
 }

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -195,9 +195,10 @@ public:
   bool is_loaded()    const { return _loaded; }
   void set_loaded()         { _loaded = true; }
 
-  bool not_entrant()  const { return _not_entrant; }
-  void set_not_entrant()    { _not_entrant = true; }
-  void set_entrant()        { _not_entrant = false; }
+  // Use atomic access to _not_entrant field.
+  bool not_entrant() const;
+  void set_not_entrant();
+  bool try_set_not_entrant();
 
   bool load_fail()  const { return _load_fail; }
   void set_load_fail()    { _load_fail = true; }
@@ -798,7 +799,6 @@ public:
   static bool maybe_dumping_code() NOT_CDS_RETURN_(false);
 
   static void invalidate(AOTCodeEntry* entry) NOT_CDS_RETURN;
-  static void invalidate_with_lock(AOTCodeEntry* entry) NOT_CDS_RETURN;
   static AOTCodeEntry* find_code_entry(const methodHandle& method, uint comp_level) NOT_CDS_RETURN_(nullptr);
   static void preload_code(JavaThread* thread) NOT_CDS_RETURN;
 

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -798,6 +798,7 @@ public:
   static bool maybe_dumping_code() NOT_CDS_RETURN_(false);
 
   static void invalidate(AOTCodeEntry* entry) NOT_CDS_RETURN;
+  static void invalidate_with_lock(AOTCodeEntry* entry) NOT_CDS_RETURN;
   static AOTCodeEntry* find_code_entry(const methodHandle& method, uint comp_level) NOT_CDS_RETURN_(nullptr);
   static void preload_code(JavaThread* thread) NOT_CDS_RETURN;
 

--- a/src/hotspot/share/oops/methodCounters.cpp
+++ b/src/hotspot/share/oops/methodCounters.cpp
@@ -79,7 +79,7 @@ void MethodCounters::clear_counters() {
   backedge_counter()->reset();
 #if INCLUDE_CDS
   if (aot_preload_code_entry() != nullptr) {
-    AOTCodeCache::invalidate_with_lock(aot_preload_code_entry());
+    AOTCodeCache::invalidate(aot_preload_code_entry());
     set_aot_preload_code_entry(nullptr);
   }
 #endif
@@ -94,7 +94,7 @@ void MethodCounters::clear_counters() {
 #if INCLUDE_CDS
 void MethodCounters::deallocate_contents(ClassLoaderData* loader_data) {
   if (aot_preload_code_entry() != nullptr) {
-    AOTCodeCache::invalidate_with_lock(aot_preload_code_entry());
+    AOTCodeCache::invalidate(aot_preload_code_entry());
     set_aot_preload_code_entry(nullptr);
   }
 }

--- a/src/hotspot/share/oops/methodCounters.cpp
+++ b/src/hotspot/share/oops/methodCounters.cpp
@@ -79,7 +79,7 @@ void MethodCounters::clear_counters() {
   backedge_counter()->reset();
 #if INCLUDE_CDS
   if (aot_preload_code_entry() != nullptr) {
-    AOTCodeCache::invalidate(aot_preload_code_entry());
+    AOTCodeCache::invalidate_with_lock(aot_preload_code_entry());
     set_aot_preload_code_entry(nullptr);
   }
 #endif
@@ -94,7 +94,7 @@ void MethodCounters::clear_counters() {
 #if INCLUDE_CDS
 void MethodCounters::deallocate_contents(ClassLoaderData* loader_data) {
   if (aot_preload_code_entry() != nullptr) {
-    AOTCodeCache::invalidate(aot_preload_code_entry());
+    AOTCodeCache::invalidate_with_lock(aot_preload_code_entry());
     set_aot_preload_code_entry(nullptr);
   }
 }


### PR DESCRIPTION
I am not sure about these changes. @iklam, @veresov, @adinn and @ashu-mehra please help.

At first `AOTCodeCache::invalidate(AOTCodeEntry)` was only called from `nmethod::make_not_entrant()` under NMethodState_lock. So changing `_not_entrant field` was synchronized.

Later two additional places were added: `MethodCounters::deallocate_contents()` which was called during class unloading and `MethodCounters::clear_counters()` called from WhiteBox API `clearMethodState()`.

These changes added new `AOTCodeCache::invalidate_with_lock()` method which takes `NMethodState_lock`. It will be used in those two methods.

On other hand these 2 methods may never be called for methods with AOT code. `deallocate_contents()` is not called for methods from built-in loaders but it may not be true for future when we add support for custom class loaders (do we plan to generate AOT **preload** code for them). `clear_counters()` -  we don't support WhiteBox API for AOT code currently but it may change in a future.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390443](https://bugs.openjdk.org/browse/JDK-8390443): [leyden] AOTCodeEntry::_not_entrant should be synchronized (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.org/leyden.git pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/128.diff">https://git.openjdk.org/leyden/pull/128.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/128#issuecomment-5309069881)
</details>
