### PR TITLE
8389577: [leyden] BufferedInlineTypeBlob entries are not recorded in AOT address table

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -473,7 +473,7 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
           // saved to the archive. So, a direct call to the handler
           // address cannot be injected into a caller that is saved
           // and restored.
-          __ movptr(rscratch1, vk->get_instanceKlass());
+          __ mov_metadata(rscratch1, vk->constant_encoding());
           __ ldr(rscratch1, Address(rscratch1, InlineKlass::adr_members_offset()));
           __ ldr(rscratch1, Address(rscratch1, InlineKlass::unpack_handler_offset()));
         } else

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -466,6 +466,18 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
       if (vk->can_be_returned_as_fields()) {
         address unpack_handler = vk->unpack_handler();
         assert(unpack_handler != nullptr, "must be");
+#if INCLUDE_CDS
+        if (AOTCodeCache::is_on_for_dump()) {
+          // in AOT compiled code call the unpack handler indirectly
+          // via the klass. The handler's blob does not currently get
+          // saved to the archive. So, a direct call to the handler
+          // address cannot be injected into a caller that is saved
+          // and restored.
+          __ movptr(rscratch1, vk->get_instanceKlass());
+          __ ldr(rscratch1, Address(rscratch1, InlineKlass::adr_members_offset()));
+          __ ldr(rscratch1, Address(rscratch1, InlineKlass::unpack_handler_offset()));
+        } else
+#endif
         __ far_call(RuntimeAddress(unpack_handler));
       }
     } else if (return_type->is_instance_klass() && (!return_type->is_loaded() || StressCallingConvention)) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -7130,6 +7130,19 @@ int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from
     }
     // 3. Initialize its fields with an inline class specific handler
     if (vk != nullptr) {
+#if INCLUDE_CDS
+      if (AOTCodeCache::is_on_for_dump()) {
+        // in AOT compiled code call the pack handler indirectly via
+        // the klass. The handler's blob does not currently get saved
+        // to the archive. So, a direct call to the handler address
+        // cannot be injected into a caller that is saved and
+        // restored.
+        __ movptr(tmp1, vk->get_instanceKlass());
+        __ ldr(tmp1, Address(rscratch1, InlineKlass::adr_members_offset()));
+        __ ldr(tmp1, Address(rscratch1, InlineKlass::pack_handler_offset()));
+        __ blr(tmp1);
+      } else
+#endif
       far_call(RuntimeAddress(vk->pack_handler())); // no need for call info as this will not safepoint.
     } else {
       ldr(tmp1, Address(klass, InlineKlass::adr_members_offset()));

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -7137,10 +7137,10 @@ int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from
         // to the archive. So, a direct call to the handler address
         // cannot be injected into a caller that is saved and
         // restored.
-        __ movptr(tmp1, vk->get_instanceKlass());
-        __ ldr(tmp1, Address(rscratch1, InlineKlass::adr_members_offset()));
-        __ ldr(tmp1, Address(rscratch1, InlineKlass::pack_handler_offset()));
-        __ blr(tmp1);
+        mov_metadata(tmp1, vk->constant_encoding());
+        ldr(tmp1, Address(rscratch1, InlineKlass::adr_members_offset()));
+        ldr(tmp1, Address(rscratch1, InlineKlass::pack_handler_offset()));
+        blr(tmp1);
       } else
 #endif
       far_call(RuntimeAddress(vk->pack_handler())); // no need for call info as this will not safepoint.

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -483,6 +483,19 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
       if (vk->can_be_returned_as_fields()) {
         address unpack_handler = vk->unpack_handler();
         assert(unpack_handler != nullptr, "must be");
+#if INCLUDE_CDS
+        if (AOTCodeCache::is_on_for_dump()) {
+          // in AOT compiled code call the unpack handler indirectly
+          // via the klass. The handler's blob does not currently get
+          // saved to the archive. So, a direct call to the handler
+          // address cannot be injected into a caller that is saved
+          // and restored.
+          __ mov_metadata(rdi, vk->constant_encoding());
+          __ movptr(rdi, Address(rdi, InlineKlass::adr_members_offset()));
+          __ movptr(rdi, Address(rdi, InlineKlass::unpack_handler_offset()));
+          __ call(rdi);
+        } else
+#endif
         __ call(RuntimeAddress(unpack_handler));
       }
     } else if (return_type->is_instance_klass() && (!return_type->is_loaded() || StressCallingConvention)) {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -6087,6 +6087,19 @@ int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from
     }
     // 3. Initialize its fields with an inline class specific handler
     if (vk != nullptr) {
+#if INCLUDE_CDS
+      if (AOTCodeCache::is_on_for_dump()) {
+        // in AOT compiled code call the pack handler indirectly via
+        // the klass. The handler's blob does not currently get saved
+        // to the archive. So, a direct call to the handler address
+        // cannot be injected into a caller that is saved and
+        // restored.
+        mov_metadata(rbx, vk->constant_encoding());
+        movptr(rbx, Address(rdi, InlineKlass::adr_members_offset()));
+        movptr(rbx, Address(rdi, InlineKlass::unpack_handler_offset()));
+        call(rbx);
+      } else
+#endif
       call(RuntimeAddress(vk->pack_handler())); // no need for call info as this will not safepoint.
     } else {
       movptr(rbx, Address(klass, InlineKlass::adr_members_offset()));

--- a/test/hotspot/jtreg/ProblemList-enable-preview.txt
+++ b/test/hotspot/jtreg/ProblemList-enable-preview.txt
@@ -43,13 +43,13 @@ runtime/cds/appcds/aotCode/AOTCodeFlags.java#parallel   8382398 generic-all
 runtime/cds/appcds/aotCode/AOTCodeFlags.java#Z          8382398 generic-all
 runtime/cds/appcds/aotCode/AOTCodeFlags.java#shenandoah 8382398 generic-all
 
-runtime/cds/appcds/aotCode/AOTCodeTest.java#G1          8389577 generic-all
-runtime/cds/appcds/aotCode/AOTCodeTest.java#parallel    8389577 generic-all
-runtime/cds/appcds/aotCode/AOTCodeTest.java#serial      8389577 generic-all
-runtime/cds/appcds/aotCode/AOTCodeTest.java#Z           8389577 generic-all
-runtime/cds/appcds/aotCode/AOTCodeTest.java#shenandoah  8389577 generic-all
+runtime/cds/appcds/aotCode/AOTCodeTest.java#G1          8390238 generic-all
+runtime/cds/appcds/aotCode/AOTCodeTest.java#parallel    8390238 generic-all
+runtime/cds/appcds/aotCode/AOTCodeTest.java#serial      8390238 generic-all
+runtime/cds/appcds/aotCode/AOTCodeTest.java#Z           8390238 generic-all
+runtime/cds/appcds/aotCode/AOTCodeTest.java#shenandoah  8390238 generic-all
 
-runtime/cds/appcds/aotCode/AOTCodeCompressedOopsTest.java 8389577 generic-all
-runtime/cds/appcds/aotCode/AOTCodeCPUFeatureIncompatibilityTest.java 8389577 generic-all
-runtime/cds/appcds/aotCode/TestDisableAOTCode.java 8389577 generic-all
-runtime/cds/appcds/aotCode/TestVerifyAOTCode.java 8389577 generic-all
+runtime/cds/appcds/aotCode/AOTCodeCompressedOopsTest.java 8390238 generic-all
+runtime/cds/appcds/aotCode/AOTCodeCPUFeatureIncompatibilityTest.java 8390238 generic-all
+runtime/cds/appcds/aotCode/TestDisableAOTCode.java 8390238 generic-all
+runtime/cds/appcds/aotCode/TestVerifyAOTCode.java 8390238 generic-all


### PR DESCRIPTION
This PR resolves the problem of calls that target BufferedInlineTypeBlob entries not being valid across AOT save and restore by modifying the C1 compiler to load the entry address via the associated InlineKlass rather than inserting it into the code as a constant.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389577](https://bugs.openjdk.org/browse/JDK-8389577): [leyden] BufferedInlineTypeBlob entries are not recorded in AOT address table (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [f3542fdc](https://git.openjdk.org/leyden/pull/131/files/f3542fdc8fd8c6c90b85ba56bc9d48aa437b464d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/131/head:pull/131` \
`$ git checkout pull/131`

Update a local copy of the PR: \
`$ git checkout pull/131` \
`$ git pull https://git.openjdk.org/leyden.git pull/131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 131`

View PR using the GUI difftool: \
`$ git pr show -t 131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/131.diff">https://git.openjdk.org/leyden/pull/131.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/131#issuecomment-5439274514)
</details>
