### PR TITLE
8391565: [leyden] AOT C1 compilation should load null reset value from class

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1827,6 +1827,16 @@ void GraphBuilder::copy_inline_content(ciInlineKlass* vk, Value src, int src_off
   }
 }
 
+Value GraphBuilder::load_null_reset_value(ciInlineKlass* vk) {
+  if (AOTCodeCache::is_dumping_code()) {
+    Value clazz = append(new Constant(new ClassConstant(vk)));
+    Value offset = append(new Constant(new IntConstant(vk->get_null_reset_value_offset())));
+    return append(new UnsafeGet(T_OBJECT, clazz, offset, /*is_volatile*/false,/*is_raw*/true));
+  } else {
+    return append(new Constant(new ObjectConstant(vk->get_null_reset_value().as_object())));
+  }
+}
+
 void GraphBuilder::access_field(Bytecodes::Code code) {
   bool will_link;
   ciField* field = stream()->get_field(will_link);
@@ -2142,7 +2152,8 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
 
           // Store the subfields when field is a nullable non-atomic field
           Value object_null = append(new Constant(objectNull));
-          Value null_reset_value = append(new Constant(new ObjectConstant(inline_klass->get_null_reset_value().as_object())));
+          // Value null_reset_value = append(new Constant(new ObjectConstant(inline_klass->get_null_reset_value().as_object())));
+          Value null_reset_value = load_null_reset_value(inline_klass);
           Value src = append(new IfOp(val, Instruction::neq, object_null, val, null_reset_value, state_before, false));
           copy_inline_content(inline_klass, src, inline_klass->payload_offset(), obj, offset, state_before);
 

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1828,7 +1828,7 @@ void GraphBuilder::copy_inline_content(ciInlineKlass* vk, Value src, int src_off
 }
 
 Value GraphBuilder::load_null_reset_value(ciInlineKlass* vk) {
-  if (AOTCodeCache::is_dumping_code()) {
+  if (compilation()->env()->is_aot_compile()) {
     Value clazz = append(new Constant(new ClassConstant(vk)));
     Value offset = append(new Constant(new IntConstant(vk->get_null_reset_value_offset())));
     return append(new UnsafeGet(T_OBJECT, clazz, offset, /*is_volatile*/false,/*is_raw*/true));
@@ -2152,7 +2152,6 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
 
           // Store the subfields when field is a nullable non-atomic field
           Value object_null = append(new Constant(objectNull));
-          // Value null_reset_value = append(new Constant(new ObjectConstant(inline_klass->get_null_reset_value().as_object())));
           Value null_reset_value = load_null_reset_value(inline_klass);
           Value src = append(new IfOp(val, Instruction::neq, object_null, val, null_reset_value, state_before, false));
           copy_inline_content(inline_klass, src, inline_klass->payload_offset(), obj, offset, state_before);

--- a/src/hotspot/share/c1/c1_GraphBuilder.hpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.hpp
@@ -300,6 +300,7 @@ class GraphBuilder {
 
   // inline types
   void copy_inline_content(ciInlineKlass* vk, Value src, int src_off, Value dest, int dest_off, ValueStack* state_before, ciField* enclosing_field = nullptr);
+  Value load_null_reset_value(ciInlineKlass* vk);
 
   // stack/code manipulation helpers
   Instruction* append_with_bci(Instruction* instr, int bci);

--- a/src/hotspot/share/ci/ciInlineKlass.cpp
+++ b/src/hotspot/share/ci/ciInlineKlass.cpp
@@ -166,6 +166,12 @@ ciConstant ciInlineKlass::get_null_reset_value() {
   return ciConstant(T_OBJECT, CURRENT_ENV->get_object(null_reset_value));
 }
 
+int ciInlineKlass::get_null_reset_value_offset() {
+  VM_ENTRY_MARK
+  InlineKlass* vk = get_InlineKlass();
+  return vk->null_reset_value_offset();
+}
+
 ArrayDescription ciInlineKlass::array_description_of_array_properties(const ArrayProperties& requested_properties) {
   GUARDED_VM_ENTRY(return ObjArrayKlass::array_layout_selection(get_InlineKlass(), requested_properties);)
 }

--- a/src/hotspot/share/ci/ciInlineKlass.hpp
+++ b/src/hotspot/share/ci/ciInlineKlass.hpp
@@ -83,6 +83,7 @@ public:
   int field_map_offset() const;
   ciConstant get_field_map() const;
   ciConstant get_null_reset_value();
+  int get_null_reset_value_offset();
   ArrayDescription array_description_of_array_properties(const ArrayProperties&);
 };
 


### PR DESCRIPTION
This fixes AOT C1 compilation of a `putfield` to a flat inline field by calling `null_reset_value` at runtime to retrieve the prototype null value rather than calling it at assembly time and hard-wiring the oop it into the compiled method's constant table and code.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391565](https://bugs.openjdk.org/browse/JDK-8391565): [leyden] AOT C1 compilation should load null reset value from class (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden.git pull/134/head:pull/134` \
`$ git checkout pull/134`

Update a local copy of the PR: \
`$ git checkout pull/134` \
`$ git pull https://git.openjdk.org/leyden.git pull/134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 134`

View PR using the GUI difftool: \
`$ git pr show -t 134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden/pull/134.diff">https://git.openjdk.org/leyden/pull/134.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/leyden/pull/134#issuecomment-5585754739)
</details>
